### PR TITLE
Allow nodejs programs to shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,12 @@ export * from './signature'
 export * from './circuit_value'
 export * from './merkle_proof'
 
-import { Bool, Group, Field } from './snarky'
+import { Bool, Group, Field, shutdown } from './snarky'
 // Hangs
-// const x0 = new Field('37')
-// const x1 = new Field(37)
-// console.assert(x0.equals(x1).toBoolean())
+const x0 = new Field('37')
+const x1 = new Field(37)
+console.log(x0.toString());
+console.assert(x0.equals(x1).toBoolean())
 
 // Does not hang
 const b0 = new Bool(false)
@@ -21,3 +22,5 @@ let g1 = new Group({ x: -2, y: 2 })
 let g2 = Group.generator
 let g3 = g0.add(g1).neg().sub(g2)
 console.log(g3.toJSON())
+
+shutdown().then(() => { console.log("Shutdown"); });

--- a/src/node_bindings/snarky_js_node.bc.runtime.js
+++ b/src/node_bindings/snarky_js_node.bc.runtime.js
@@ -110,12 +110,12 @@ a=c%10,b=c%100;if(b>=11&&b<=13||a===0||a>=4)return"th";switch(a){case
 1:return"st";case
 2:return"nd";case
 3:return"rd"}}function
-m(a){return(a.getTimezoneOffset()||0)*60000}}())}(function(){return this}()));(function(d){"use strict";var
+m(a){return(a.getTimezoneOffset()||0)*60000}}())}(function(){return this}()));(function(c){"use strict";var
 eE=" : flags Open_text and Open_binary are not compatible",d1=0x100,ew=0x0000FFFF,eL="_nat",eM=1e14,eu="Invalid_argument",ev=" is too large for shifting.",eK=0.001,eT=180,eb="caml_bigstring_blit_ba_to_ba: kind mismatch",eD=0.5,ea="2d",co=1255,el=0x7F,et="\\",eJ="<",aO=255,eI=0x800,D=0xffff,e4="l and r lengths don't match",eS=0x04,d$="jsError",cn="caml_bigstring_blit_string_to_ba: kind mismatch",ad=0x8000,ek=12520,cs=0x0A,Y=256,a6="ml_z_overflow",eH=0.012,d_="End_of_file",eC=0x01,d0="lexing: empty token",bH="_z",d9="Failure",m=0xff,eB=0x07,V=1000,dZ=0x02,g="",eA="Stack_overflow",cp="^",d8="Bigarray.blit: dimension mismatch",dY=0x3F,ej=86400000,z="0",cz=200,a5=0x3f,ez="Not_found",cv=65599,cy=0xf,e3=0x8495A6BE,ei=0x12,bk=128,d7=0xdc00,er="Sys_blocked_io",es="p",e2="fd ",eh="Match_failure",W=248,ey="px ",dX="static/",eG="Division_by_zero",e1=">",eq=0x06,cA=252,eZ=0x05,e0=1027,G=0x00,eY=0x18,dW=0xFE,d6="Sys_error",p=0xFF,aQ=".",as="+",eR=0x08,dV="__is_deallocated",eQ=0xf0,d5="wasm_bindgen_worker_ready",cu=0x3FFFFFFF,ep="integers:uint32",ex=1026,eP=4294967296,cx=1900,bJ="Invalid integer: ",eX=0x03,ac="int_of_string",a4=65536,cr=127,bj=1024,eF="Illegal seek",dU=251,eW=0x33333333,U=" ",L=0x80,af=1023,bL="e",dT="Undefined_recursive_module",eo=" : flags Open_rdonly and Open_wronly are not compatible",dS=1074,eV="([^/]*)",d4=512,B="-",eg="nan",d2="canvas",d3=0x7ff0,en=0x19,ef=0xe0,em=" : file already exists",cw=0x09,ee=0xFF00,ed=0xdfff,v=0xffffff,O="/",ct="compare: functional value",eN="Assert_failure",eO="Str.replace: reference to unmatched group",cm="0x",cq=0x40,ec="#",a7=0x20,eU="Out_of_memory",aP=1e7,ae=254,cB="index out of bounds",bI=250,bK="_bigarr02";function
 i9(a){var
 c=Math.exp(a),b=c-1;return Math.abs(a)>1?b:b==0?a:a*b/Math.log(c)}function
-k(a){return a.toUtf16()}if(d.process&&d.process.cwd)var
-aE=d.process.cwd().replace(/\\/g,O);else
+k(a){return a.toUtf16()}if(c.process&&c.process.cwd)var
+aE=c.process.cwd().replace(/\\/g,O);else
 var
 aE="/static";if(aE.slice(-1)!==O)aE+=O;function
 b4(a){a=k(a);if(a.charCodeAt(0)!=47)a=aE+a;var
@@ -170,21 +170,21 @@ l=[0];function
 o(a){cf(l.Sys_error,a)}function
 x(a){if((a.t&6)!=0)Q(a);return a.c}function
 bA(a){a=x(a);o(a+": No such file or directory")}function
-c(a){cf(l.Invalid_argument,a)}function
-aD(){c(cB)}function
+d(a){cf(l.Invalid_argument,a)}function
+aD(){d(cB)}function
 I(a,b){switch(a.t&6){default:if(b>=a.c.length)return 0;case
 0:return a.c.charCodeAt(b);case
 4:return a.c[b]}}function
 cO(b,a){if(a>>>0>=b.l)aD();return I(b,a)}function
-M(a){if(a<0)c("Bytes.create");return new
+M(a){if(a<0)d("Bytes.create");return new
 ag(a?2:9,g,a)}function
 av(a){return a.l}function
-bo(b){if(d.Uint8Array)var
-c=new(d.Uint8Array)(b.l);else
+bo(b){if(c.Uint8Array)var
+d=new(c.Uint8Array)(b.l);else
 var
-c=new
+d=new
 Array(b.l);var
-f=b.c,e=f.length,a=0;for(;a<e;a++)c[a]=f.charCodeAt(a);for(e=b.l;a<e;a++)c[a]=0;b.c=c;b.t=4;return c}function
+f=b.c,e=f.length,a=0;for(;a<e;a++)d[a]=f.charCodeAt(a);for(e=b.l;a<e;a++)d[a]=0;b.c=d;b.t=4;return d}function
 aI(d,e,b,f,c){if(c==0)return 0;if(f==0&&(c>=b.l||b.t==2&&c>=b.c.length)){b.c=d.t==4?bC(d.c,e,c):e==0&&d.c.length==c?d.c:d.c.substr(e,c);b.t=b.c.length==b.l?0:2}else
 if(b.t==2&&f==b.c.length){b.c+=d.t==4?bC(d.c,e,c):e==0&&d.c.length==c?d.c:d.c.substr(e,c);b.t=b.c.length==b.l?0:2}else{if(b.t!=4)bo(b);var
 g=d.c,h=b.c;if(d.t==4)if(f<=e)for(var
@@ -249,17 +249,17 @@ bm(a){if(a.t!=4)bo(a);return a.c}function
 ak(a,c,b){b&=m;if(a.t!=4){if(c==a.c.length){a.c+=String.fromCharCode(b);if(c+1==a.l)a.t=0;return 0}bo(a)}a.c[c]=b;return 0}function
 cS(b,a,c){if(a>>>0>=b.l)aD();return ak(b,a,c)}function
 ai(a){this.fs=require("fs");this.fd=a}ai.prototype=new
-cD();ai.prototype.truncate=function(a){try{this.fs.ftruncateSync(this.fd,a|0)}catch(a){o(a.toString())}};ai.prototype.length=function(){try{return this.fs.fstatSync(this.fd).size}catch(a){o(a.toString())}};ai.prototype.write=function(g,b,c,f){var
+cD();ai.prototype.truncate=function(a){try{this.fs.ftruncateSync(this.fd,a|0)}catch(a){o(a.toString())}};ai.prototype.length=function(){try{return this.fs.fstatSync(this.fd).size}catch(a){o(a.toString())}};ai.prototype.write=function(g,b,d,f){var
 a=bn(b);if(!(a
 instanceof
-d.Uint8Array))a=new(d.Uint8Array)(a);var
-e=d.Buffer.from(a);try{this.fs.writeSync(this.fd,e,c,f,g)}catch(a){o(a.toString())}return 0};ai.prototype.read=function(h,e,c,g){var
+c.Uint8Array))a=new(c.Uint8Array)(a);var
+e=c.Buffer.from(a);try{this.fs.writeSync(this.fd,e,d,f,g)}catch(a){o(a.toString())}return 0};ai.prototype.read=function(h,e,d,g){var
 a=bm(e);if(!(a
 instanceof
-d.Uint8Array))a=new(d.Uint8Array)(a);var
-f=d.Buffer.from(a);try{this.fs.readSync(this.fd,f,c,g,h)}catch(a){o(a.toString())}for(var
-b=0;b<g;b++)cS(e,c+b,f[c+b]);return 0};ai.prototype.read_one=function(c){var
-b=new(d.Uint8Array)(1),a=d.Buffer.from(b);try{this.fs.readSync(this.fd,a,0,1,c)}catch(a){o(a.toString())}return a[0]};ai.prototype.close=function(){try{this.fs.closeSync(this.fd)}catch(a){o(a.toString())}};ai.prototype.constructor=ai;function
+c.Uint8Array))a=new(c.Uint8Array)(a);var
+f=c.Buffer.from(a);try{this.fs.readSync(this.fd,f,d,g,h)}catch(a){o(a.toString())}for(var
+b=0;b<g;b++)cS(e,d+b,f[d+b]);return 0};ai.prototype.read_one=function(d){var
+b=new(c.Uint8Array)(1),a=c.Buffer.from(b);try{this.fs.readSync(this.fd,a,0,1,d)}catch(a){o(a.toString())}return a[0]};ai.prototype.close=function(){try{this.fs.closeSync(this.fd)}catch(a){o(a.toString())}};ai.prototype.constructor=ai;function
 ah(a){this.fs=require("fs");this.root=a}ah.prototype.nm=function(a){return this.root+a};ah.prototype.exists=function(a){try{return this.fs.existsSync(this.nm(a))?1:0}catch(a){o(a.toString())}};ah.prototype.readdir=function(a){try{return this.fs.readdirSync(this.nm(a))}catch(a){o(a.toString())}};ah.prototype.is_dir=function(a){try{return this.fs.statSync(this.nm(a)).isDirectory()?1:0}catch(a){o(a.toString())}};ah.prototype.unlink=function(a){try{var
 b=this.fs.existsSync(this.nm(a))?1:0;this.fs.unlinkSync(this.nm(a))}catch(a){o(a.toString())}return b};ah.prototype.open=function(f,c){var
 a=require("constants"),b=0;for(var
@@ -270,9 +270,9 @@ d=this.fs.openSync(this.nm(f),b);return new
 ai(d)}catch(a){o(a.toString())}};ah.prototype.rename=function(b,a){try{this.fs.renameSync(this.nm(b),this.nm(a))}catch(a){o(a.toString())}};ah.prototype.constructor=ah;var
 aZ=aE.match(/[^\/]*\//)[0];function
 dE(){return typeof
-d.process!=="undefined"&&typeof
-d.process.versions!=="undefined"&&typeof
-d.process.versions.node!=="undefined"&&d.process.platform!=="browser"}var
+c.process!=="undefined"&&typeof
+c.process.versions!=="undefined"&&typeof
+c.process.versions.node!=="undefined"&&c.process.platform!=="browser"}var
 ab=[];if(dE())ab.push({path:aZ,device:new
 ah(aZ)});else
 ab.push({path:aZ,device:new
@@ -284,7 +284,7 @@ d=0;d<ab.length;d++){var
 a=ab[d];if(e.search(a.path)==0&&(!c||c.path.length<a.path.length))c={path:a.path,device:a.device,rest:b.substring(a.path.length,b.length)}}return c}function
 o8(c){var
 a=ar(c),b=a.device.is_dir(a.rest);return b?1:0}var
-dD=new(d.FinalizationRegistry)(function(a){a.free()});function
+dD=new(c.FinalizationRegistry)(function(a){a.free()});function
 r(a){var
 b=a.constructor.__wrap(a.ptr);dD.register(a,b,a);return a}function
 gd(a,b){return new
@@ -293,8 +293,8 @@ F(b,c){var
 a=new
 c();if(b===0)a.infinity=true;else{a.x=b[1][1];a.y=b[1][2]}return a}function
 ck(e){var
-b=e.length,c=new(d.Uint32Array)(b);for(var
-a=0;a<b;a++)c[a]=e[a].ptr;return c}function
+b=e.length,d=new(c.Uint32Array)(b);for(var
+a=0;a<b;a++)d[a]=e[a].ptr;return d}function
 C(a,d,f){var
 a=a.slice(1);for(var
 b=0,e=a.length;b<e;b++){var
@@ -314,18 +314,18 @@ b=gd(a[1],c),f=a[2],g=a[3],k=a[4],d=gf(a[5],l,i,h),j=gg(a[6],m);return new
 e(b,f,g,k,d,j)}function
 aB(a){throw a}function
 gi(){aB(l.Not_found)}function
-go(c){var
-a=d,b=k(c);if(a.process&&a.process.env&&a.process.env[b]!=undefined)return T(a.process.env[b]);if(d.jsoo_static_env&&d.jsoo_static_env[b])return T(d.jsoo_static_env[b]);gi()}function
+go(d){var
+a=c,b=k(d);if(a.process&&a.process.env&&a.process.env[b]!=undefined)return T(a.process.env[b]);if(c.jsoo_static_env&&c.jsoo_static_env[b])return T(c.jsoo_static_env[b]);gi()}function
 dP(e,g,i,f,h,b){if(b==0){f.data[h]=0;return 0}var
 c=0;for(var
 a=i-1;a>=0;a--){var
 d=e.data[g+a]>>>0;e.data[g+a]=d>>>b|c;c=d<<32-b}f.data[h]=c;return 0}var
 a8;if(typeof
-d.WeakMap==="undefined")a8=function(){function
+c.WeakMap==="undefined")a8=function(){function
 a(a){this.objs=a}a.prototype.get=function(b){for(var
 a=0;a<this.objs.length;a++)if(this.objs[a]===b)return a};a.prototype.set=function(){};return function(){this.objs=[];this.lookup=new
 a(this.objs)}}();else
-a8=function(){this.objs=[];this.lookup=new(d.WeakMap)()};a8.prototype.store=function(a){this.lookup.set(a,this.objs.length);this.objs.push(a)};a8.prototype.recall=function(b){var
+a8=function(){this.objs=[];this.lookup=new(c.WeakMap)()};a8.prototype.store=function(a){this.lookup.set(a,this.objs.length);this.objs.push(a)};a8.prototype.recall=function(b){var
 a=this.lookup.get(b);return a===undefined?undefined:this.objs.length-a};function
 e(a){cf(l.Failure,a)}var
 a$=Math.pow(2,-24);function
@@ -390,12 +390,13 @@ k3(a){return Math.LOG10E*Math.log(a)}function
 bx(b,d){for(var
 a=0,c=b.length;a<c;a++)b[a]=d[a]}var
 a3=require("worker_threads"),e6;function
-dQ(g,b,a){return d.Promise.all(Array.from({length:a.numThreads()},function(){var
-c=new(a3.Worker)(g,{workerData:{memory:b,receiver:a.receiver()}}),e=c,f=d5;return new(d.Promise)(function(d){var
-b=false;e.on("message",function(a){if(a==null||a.type!==f||b)return;b=true;d(c)})})})).then(function(b){e6=b;a.build()})}function
+dQ(g,d,a){c.wasm_workers=[];c.wasm_rayon_poolbuilder=a;return c.Promise.all(Array.from({length:a.numThreads()},function(){var
+b=new(a3.Worker)(g,{workerData:{memory:d,receiver:a.receiver()}});c.wasm_workers.push(b);var
+e=b,f=d5;return new(c.Promise)(function(d){var
+c=false;e.on("message",function(a){if(a==null||a.type!==f||c)return;c=true;d(b)})})})).then(function(b){e6=b;try{a.build()}catch(a){}})}function
 g4(a){a3.parentPort.postMessage({type:d5});a.wbg_rayon_start_worker(a3.workerData.receiver)}var
-a=function(){d.startWorkers=dQ;var
-b=require("env");if(a3.isMainThread){b.memory=new(d.WebAssembly.Memory)({initial:20,maximum:16384,shared:true});d.startWorkers=dQ}else
+a=function(){c.startWorkers=dQ;var
+b=require("env");if(a3.isMainThread){b.memory=new(c.WebAssembly.Memory)({initial:20,maximum:16384,shared:true});c.startWorkers=dQ}else
 b.memory=a3.workerData.memory;var
 a=require("./plonk_wasm.js");if(a3.isMainThread)a.initThreadPool(3,__filename);else
 g4(a);return a}(),gb=a.caml_pasta_fq_sub;function
@@ -432,7 +433,7 @@ by(b){return dm(b,a.WasmPallasGAffine)}function
 bf(b){return dn(b,a.WasmPastaFqPlonkVerifierIndex,a.WasmPastaFqPlonkDomain,a.WasmPastaFqPlonkVerificationEvals,a.WasmPastaPallasPolyComm,a.caml_pasta_pallas_affine_one,a.WasmPastaFqPlonkVerificationShifts)}function
 np(b){return by(a.caml_pasta_fq_plonk_verifier_index_deep_copy(bf(b)))}var
 nu=a.caml_pasta_fq_print;function
-u(){c(cB)}function
+u(){d(cB)}function
 $(a){return new
 f(a[7]<<0|a[6]<<8|a[5]<<16,a[4]<<0|a[3]<<8|a[2]<<16,a[1]<<0|a[0]<<8)}function
 h$(a,k){var
@@ -474,10 +475,10 @@ Array(c);for(var
 a=0;a<c;a++)b[a]=arguments[a];return al(d,[b])}}function
 jk(){return[ae,0,0,0]}function
 b9(e){e=x(e);var
-f=e.length;if(f>31)c("format_int: format too long");var
+f=e.length;if(f>31)d("format_int: format too long");var
 a={justify:as,signstyle:B,filler:U,alternate:false,base:0,signedconv:false,width:0,uppercase:false,sign:1,prec:-1,conv:"f"};for(var
-d=0;d<f;d++){var
-b=e.charAt(d);switch(b){case"-":a.justify=B;break;case"+":case" ":a.signstyle=b;break;case"0":a.filler=z;break;case"#":a.alternate=true;break;case"1":case"2":case"3":case"4":case"5":case"6":case"7":case"8":case"9":a.width=0;while(b=e.charCodeAt(d)-48,b>=0&&b<=9){a.width=a.width*10+b;d++}d--;break;case".":a.prec=0;d++;while(b=e.charCodeAt(d)-48,b>=0&&b<=9){a.prec=a.prec*10+b;d++}d--;case"d":case"i":a.signedconv=true;case"u":a.base=10;break;case"x":a.base=16;break;case"X":a.base=16;a.uppercase=true;break;case"o":a.base=8;break;case"e":case"f":case"g":a.signedconv=true;a.conv=b;break;case"E":case"F":case"G":a.signedconv=true;a.uppercase=true;a.conv=b.toLowerCase();break}}return a}function
+c=0;c<f;c++){var
+b=e.charAt(c);switch(b){case"-":a.justify=B;break;case"+":case" ":a.signstyle=b;break;case"0":a.filler=z;break;case"#":a.alternate=true;break;case"1":case"2":case"3":case"4":case"5":case"6":case"7":case"8":case"9":a.width=0;while(b=e.charCodeAt(c)-48,b>=0&&b<=9){a.width=a.width*10+b;c++}c--;break;case".":a.prec=0;c++;while(b=e.charCodeAt(c)-48,b>=0&&b<=9){a.prec=a.prec*10+b;c++}c--;case"d":case"i":a.signedconv=true;case"u":a.base=10;break;case"x":a.base=16;break;case"X":a.base=16;a.uppercase=true;break;case"o":a.base=8;break;case"e":case"f":case"g":a.signedconv=true;a.conv=b;break;case"E":case"F":case"G":a.signedconv=true;a.uppercase=true;a.conv=b.toLowerCase();break}}return a}function
 j2(){e("caml_gr_synchronize not Implemented")}function
 l7(){return r(a.caml_pasta_fp_plonk_gate_vector_create())}function
 no(b){return by(a.caml_pasta_fq_plonk_verifier_index_create(b))}var
@@ -485,9 +486,9 @@ qx=Math.log2&&Math.log2(1.1235582092889474E+307)==1020;function
 dI(a){if(qx)return Math.floor(Math.log2(a));var
 b=0;if(a==0)return-Infinity;if(a>=1)while(a>=2){a/=2;b++}else
 while(a<1){a*=2;b--}return b}function
-bX(c){var
-a=new(d.Float32Array)(1);a[0]=c;var
-b=new(d.Int32Array)(a.buffer);return b[0]|0}function
+bX(d){var
+a=new(c.Float32Array)(1);a[0]=d;var
+b=new(c.Int32Array)(a.buffer);return b[0]|0}function
 aK(a){if(!isFinite(a)){if(isNaN(a))return am(1,0,d3);return a>0?am(0,0,d3):am(0,0,0xfff0)}var
 f=a==0&&1/a==-Infinity?ad:a>=0?0:ad;if(f)a=-a;var
 b=dI(a)+af;if(b<=0){b=0;a/=Math.pow(2,-ex)}else{a/=Math.pow(2,b-e0);if(a<16){a*=2;b-=1}if(b==0)a/=2}var
@@ -536,7 +537,7 @@ a_(a){switch(a){case
 10:case
 11:return 2;default:return 1}}function
 cH(e,g){var
-b=d,a;switch(e){case
+b=c,a;switch(e){case
 0:a=b.Float32Array;break;case
 1:a=b.Float64Array;break;case
 2:a=b.Int8Array;break;case
@@ -549,32 +550,32 @@ b=d,a;switch(e){case
 9:a=b.Int32Array;break;case
 10:a=b.Float32Array;break;case
 11:a=b.Float64Array;break;case
-12:a=b.Uint8Array;break}if(!a)c("Bigarray.create: unsupported kind");var
+12:a=b.Uint8Array;break}if(!a)d("Bigarray.create: unsupported kind");var
 f=new
 a(g*a_(e));return f}function
-bY(c){var
-a=new(d.Int32Array)(1);a[0]=c;var
-b=new(d.Float32Array)(a.buffer);return b[0]}function
+bY(d){var
+a=new(c.Int32Array)(1);a[0]=d;var
+b=new(c.Float32Array)(a.buffer);return b[0]}function
 aV(d){var
 f=d.lo,g=d.mi,b=d.hi,c=(b&0x7fff)>>4;if(c==2047)return(f|g|b&cy)==0?b&ad?-Infinity:Infinity:NaN;var
 e=Math.pow(2,-24),a=(f*e+g)*e+(b&cy);if(c>0){a+=16;a*=Math.pow(2,c-e0)}else
 a*=Math.pow(2,-ex);if(b&ad)a=-a;return a}function
 aS(b){var
-e=b.length,d=1;for(var
-a=0;a<e;a++){if(b[a]<0)c("Bigarray.create: negative dimension");d=d*b[a]}return d}function
+e=b.length,c=1;for(var
+a=0;a<e;a++){if(b[a]<0)d("Bigarray.create: negative dimension");c=c*b[a]}return c}function
 fG(b,a){return new
 f(b&v,b>>>24&m|(a&D)<<8,a>>>16&D)}function
 bZ(a){return a.hi32()}function
 b0(a){return a.lo32()}var
 fa=bK;function
 aC(c,d,b,a){this.kind=c;this.layout=d;this.dims=b;this.data=a}aC.prototype.caml_custom=fa;aC.prototype.offset=function(b){var
-d=0;if(typeof
+c=0;if(typeof
 b==="number")b=[b];if(!(b
 instanceof
-Array))c("bigarray.js: invalid offset");if(this.dims.length!=b.length)c("Bigarray.get/set: bad number of dimensions");if(this.layout==0)for(var
-a=0;a<this.dims.length;a++){if(b[a]<0||b[a]>=this.dims[a])u();d=d*this.dims[a]+b[a]}else
+Array))d("bigarray.js: invalid offset");if(this.dims.length!=b.length)d("Bigarray.get/set: bad number of dimensions");if(this.layout==0)for(var
+a=0;a<this.dims.length;a++){if(b[a]<0||b[a]>=this.dims[a])u();c=c*this.dims[a]+b[a]}else
 for(var
-a=this.dims.length-1;a>=0;a--){if(b[a]<1||b[a]>this.dims[a])u();d=d*this.dims[a]+(b[a]-1)}return d};aC.prototype.get=function(a){switch(this.kind){case
+a=this.dims.length-1;a>=0;a--){if(b[a]<1||b[a]>this.dims[a])u();c=c*this.dims[a]+(b[a]-1)}return c};aC.prototype.get=function(a){switch(this.kind){case
 7:var
 d=this.data[a*2+0],b=this.data[a*2+1];return fG(d,b);case
 10:case
@@ -616,11 +617,11 @@ aC();aR.prototype.offset=function(a){if(typeof
 a!=="number")if(a
 instanceof
 Array&&a.length==1)a=a[0];else
-c("Ml_Bigarray_c_1_1.offset");if(a<0||a>=this.dims[0])u();return a};aR.prototype.get=function(a){return this.data[a]};aR.prototype.set=function(a,b){this.data[a]=b;return 0};aR.prototype.fill=function(a){this.data.fill(a);return 0};function
-Z(d,e,a,b){var
-f=a_(d);if(aS(a)*f!=b.length)c("length doesn't match dims");if(e==0&&a.length==1&&f==1)return new
-aR(d,e,a,b);return new
-aC(d,e,a,b)}function
+d("Ml_Bigarray_c_1_1.offset");if(a<0||a>=this.dims[0])u();return a};aR.prototype.get=function(a){return this.data[a]};aR.prototype.set=function(a,b){this.data[a]=b;return 0};aR.prototype.fill=function(a){this.data.fill(a);return 0};function
+Z(c,e,a,b){var
+f=a_(c);if(aS(a)*f!=b.length)d("length doesn't match dims");if(e==0&&a.length==1&&f==1)return new
+aR(c,e,a,b);return new
+aC(c,e,a,b)}function
 cJ(b,x,t){var
 j=b.read32s();if(j<0||j>16)e("input_value: wrong number of bigarray dimensions");var
 r=b.read32s(),k=r&m,q=r>>8&1,i=[];if(t==bK)for(var
@@ -746,23 +747,23 @@ aJ(a,b,e){var
 f=[];for(;;){if(!(e&&a===b)){var
 g=cU(a);if(g==bI){a=a[1];continue}var
 h=cU(b);if(h==bI){b=b[1];continue}if(g!==h){if(g==V){if(h==co)return cT(a,b,-1,e);return-1}if(h==V){if(g==co)return cT(b,a,1,e);return 1}return g<h?-1:1}switch(g){case
-247:c(ct);break;case
+247:d(ct);break;case
 248:var
-d=b1(a[2],b[2]);if(d!=0)return d|0;break;case
-249:c(ct);break;case
-250:c("equal: got Forward_tag, should not happen");break;case
-251:c("equal: abstract value");break;case
+c=b1(a[2],b[2]);if(c!=0)return c|0;break;case
+249:d(ct);break;case
+250:d("equal: got Forward_tag, should not happen");break;case
+251:d("equal: abstract value");break;case
 252:if(a!==b){var
-d=cN(a,b);if(d!=0)return d|0}break;case
-253:c("equal: got Double_tag, should not happen");break;case
-254:c("equal: got Double_array_tag, should not happen");break;case
-255:c("equal: got Custom_tag, should not happen");break;case
-1247:c(ct);break;case
+c=cN(a,b);if(c!=0)return c|0}break;case
+253:d("equal: got Double_tag, should not happen");break;case
+254:d("equal: got Double_array_tag, should not happen");break;case
+255:d("equal: got Custom_tag, should not happen");break;case
+1247:d(ct);break;case
 1255:var
-j=bU(a);if(j!=bU(b))return a.caml_custom<b.caml_custom?-1:1;if(!j)c("compare: abstract value");var
-d=j(a,b,e);if(d!=d)return e?-1:d;if(d!==(d|0))return-1;if(d!=0)return d|0;break;case
+j=bU(a);if(j!=bU(b))return a.caml_custom<b.caml_custom?-1:1;if(!j)d("compare: abstract value");var
+c=j(a,b,e);if(c!=c)return e?-1:c;if(c!==(c|0))return-1;if(c!=0)return c|0;break;case
 1256:var
-d=a.compare(b,e);if(d!=d)return e?-1:d;if(d!==(d|0))return-1;if(d!=0)return d|0;break;case
+c=a.compare(b,e);if(c!=c)return e?-1:c;if(c!==(c|0))return-1;if(c!=0)return c|0;break;case
 1000:a=+a;b=+b;if(a<b)return-1;if(a>b)return 1;if(a!=b){if(!e)return NaN;if(a==a)return 1;if(b==b)return-1}break;case
 1001:if(a<b)return-1;if(a>b)return 1;if(a!=b){if(!e)return NaN;if(a==a)return 1;if(b==b)return-1}break;case
 1251:if(a!==b){if(!e)return NaN;return 1}break;case
@@ -791,7 +792,7 @@ b=0;b<a;b++)e.write(32,c.data[b]);d[0]=a*4;d[1]=a*8}function
 os(a){return 0}function
 k8(a){return 0}function
 o3(b){var
-a=d;if(a.quit)a.quit(b);if(a.process&&a.process.exit)a.process.exit(b);c("Function 'exit' not implemented")}var
+a=c;if(a.quit)a.quit(b);if(a.process&&a.process.exit)a.process.exit(b);d("Function 'exit' not implemented")}var
 h=new
 Array();function
 iE(b){var
@@ -804,15 +805,15 @@ bi(i,b){var
 j=i.length,g=j/b,e=new
 Array(g+1);e[0]=0;for(var
 a=1,h=0;a<=g;a++){var
-f=new(d.Uint8Array)(b);for(var
-c=0;c<b;c++,h++)f[c]=i[h];e[a]=f}return e}function
+f=new(c.Uint8Array)(b);for(var
+d=0;d<b;d++,h++)f[d]=i[h];e[a]=f}return e}function
 dl(a){var
 b=[0,a.typ,gh(a.wires),bi(a.c,32)];a.free();return b}function
 m8(c,b){return dl(a.caml_pasta_fq_plonk_gate_vector_get(c,b))}function
 a1(e){var
-a=1,c=e.length-a;if(c===0)return new(d.Uint8Array)(0);var
-f=e[a].length,h=new(d.Uint8Array)(c*f);for(var
-g=0;a<=c;a++)for(var
+a=1,d=e.length-a;if(d===0)return new(c.Uint8Array)(0);var
+f=e[a].length,h=new(c.Uint8Array)(d*f);for(var
+g=0;a<=d;a++)for(var
 b=0;b<f;b++,g++)h[g]=e[a][b];return h}function
 gk(a){var
 b=[0,a[1],a[2],a[3][1],a[4],a[5],a[6],a[7],a[8][1],a[9][1],a[10][1]];return a1(b)}function
@@ -826,9 +827,9 @@ R;function
 q(){if(R)return R;throw[0,aw("Graphics.Graphic_failure"),i("Not initialized")]}function
 jQ(d,e,c,b){var
 a=q();a.context.fillRect(d,a.height-e,c,-b);return 0}function
-ff(f,d,a,g,b){if(12!=a.kind)c(cn);if(b==0)return 0;var
-e=a.offset(g);if(d+b>y(f))u();if(e+b>a.data.length)u();var
-h=bn(f).slice(d,d+b);a.data.set(h,e);return 0}function
+ff(f,c,a,g,b){if(12!=a.kind)d(cn);if(b==0)return 0;var
+e=a.offset(g);if(c+b>y(f))u();if(e+b>a.data.length)u();var
+h=bn(f).slice(c,c+b);a.data.set(h,e);return 0}function
 bd(b){return dm(b,a.WasmVestaGAffine)}function
 mo(b){return bd(a.caml_pasta_fp_plonk_verifier_index_create(b))}function
 jw(){return l}function
@@ -896,13 +897,13 @@ h_(a,g){var
 b=a.offset(g);if(b+3>=a.data.length)u();var
 c=a.get(b+0),d=a.get(b+1),e=a.get(b+2),f=a.get(b+3);return c<<0|d<<8|e<<16|f<<24}var
 b=function(C){"use strict";var
-i=aP,ad=7,u=9007199254740992,K=r(u),P="0123456789abcdefghijklmnopqrstuvwxyz",j=d.BigInt,I=typeof
+i=aP,ad=7,u=9007199254740992,K=r(u),P="0123456789abcdefghijklmnopqrstuvwxyz",j=c.BigInt,I=typeof
 j==="function";function
 f(a,b,c,d){if(typeof
 a==="undefined")return f[0];if(typeof
 b!=="undefined")return+b===10&&!c?h(a):ah(a,b,c,d);return h(a)}function
 a(b,a){this.value=b;this.sign=a;this.isSmall=false;this.caml_custom=bH}a.prototype=Object.create(f.prototype);function
-c(a){this.value=a;this.sign=a<0;this.isSmall=true;this.caml_custom=bH}c.prototype=Object.create(f.prototype);function
+d(a){this.value=a;this.sign=a<0;this.isSmall=true;this.caml_custom=bH}d.prototype=Object.create(f.prototype);function
 e(a){this.value=a;this.caml_custom=bH}e.prototype=Object.create(f.prototype);function
 q(a){return-u<a&&a<u}function
 r(a){if(a<aP)return[a];if(a<eM)return[a%aP,Math.floor(a/aP)];return[a%aP,Math.floor(a/aP)%aP,Math.floor(a/eM)]}function
@@ -927,39 +928,39 @@ Array(g),c=i,e,b;for(b=0;b<g;b++){e=f[b]-c+a;a=Math.floor(e/c);d[b]=e-a*c;a+=1}w
 b=h(e);if(this.sign!==b.sign)return this.subtract(b.negate());var
 c=this.value,d=b.value;if(b.isSmall)return new
 a(D(c,Math.abs(d)),this.sign);return new
-a(v(c,d),this.sign)};a.prototype.plus=a.prototype.add;c.prototype.add=function(f){var
+a(v(c,d),this.sign)};a.prototype.plus=a.prototype.add;d.prototype.add=function(f){var
 e=h(f),b=this.value;if(b<0!==e.sign)return this.subtract(e.negate());var
-d=e.value;if(e.isSmall){if(q(b+d))return new
-c(b+d);d=r(Math.abs(d))}return new
-a(D(d,Math.abs(b)),b<0)};c.prototype.plus=c.prototype.add;e.prototype.add=function(a){return new
+c=e.value;if(e.isSmall){if(q(b+c))return new
+d(b+c);c=r(Math.abs(c))}return new
+a(D(c,Math.abs(b)),b<0)};d.prototype.plus=d.prototype.add;e.prototype.add=function(a){return new
 e(this.value+h(a).value)};e.prototype.plus=e.prototype.add;function
 y(d,g){var
 f=d.length,h=g.length,c=new
 Array(f),e=0,j=i,a,b;for(a=0;a<h;a++){b=d[a]-e-g[a];if(b<0){b+=j;e=1}else
 e=0;c[a]=b}for(a=h;a<f;a++){b=d[a]-e;if(b<0)b+=j;else{c[a++]=b;break}c[a]=b}for(;a<f;a++)c[a]=d[a];s(c);return c}function
-al(e,f,d){var
-b;if(o(e,f)>=0)b=y(e,f);else{b=y(f,e);d=!d}b=n(b);if(typeof
-b==="number"){if(d)b=-b;return new
-c(b)}return new
-a(b,d)}function
+al(e,f,c){var
+b;if(o(e,f)>=0)b=y(e,f);else{b=y(f,e);c=!c}b=n(b);if(typeof
+b==="number"){if(c)b=-b;return new
+d(b)}return new
+a(b,c)}function
 H(g,l,k){var
 j=g.length,b=new
-Array(j),h=-l,f=i,e,d;for(e=0;e<j;e++){d=g[e]+h;h=Math.floor(d/f);d%=f;b[e]=d<0?d+f:d}b=n(b);if(typeof
+Array(j),h=-l,f=i,e,c;for(e=0;e<j;e++){c=g[e]+h;h=Math.floor(c/f);c%=f;b[e]=c<0?c+f:c}b=n(b);if(typeof
 b==="number"){if(k)b=-b;return new
-c(b)}return new
+d(b)}return new
 a(b,k)}a.prototype.subtract=function(d){var
 a=h(d);if(this.sign!==a.sign)return this.add(a.negate());var
-b=this.value,c=a.value;if(a.isSmall)return H(b,Math.abs(c),this.sign);return al(b,c,this.sign)};a.prototype.minus=a.prototype.subtract;c.prototype.subtract=function(e){var
+b=this.value,c=a.value;if(a.isSmall)return H(b,Math.abs(c),this.sign);return al(b,c,this.sign)};a.prototype.minus=a.prototype.subtract;d.prototype.subtract=function(e){var
 b=h(e),a=this.value;if(a<0!==b.sign)return this.add(b.negate());var
-d=b.value;if(b.isSmall)return new
-c(a-d);return H(d,Math.abs(a),a>=0)};c.prototype.minus=c.prototype.subtract;e.prototype.subtract=function(a){return new
+c=b.value;if(b.isSmall)return new
+d(a-c);return H(c,Math.abs(a),a>=0)};d.prototype.minus=d.prototype.subtract;e.prototype.subtract=function(a){return new
 e(this.value-h(a).value)};e.prototype.minus=e.prototype.subtract;a.prototype.negate=function(){return new
-a(this.value,!this.sign)};c.prototype.negate=function(){var
+a(this.value,!this.sign)};d.prototype.negate=function(){var
 b=this.sign,a=new
-c(-this.value);a.sign=!b;return a};e.prototype.negate=function(){return new
+d(-this.value);a.sign=!b;return a};e.prototype.negate=function(){return new
 e(-this.value)};a.prototype.abs=function(){return new
-a(this.value,false)};c.prototype.abs=function(){return new
-c(Math.abs(this.value))};e.prototype.abs=function(){return new
+a(this.value,false)};d.prototype.abs=function(){return new
+d(Math.abs(this.value))};e.prototype.abs=function(){return new
 e(this.value>=0?this.value:-this.value)};function
 O(f,j){var
 h=f.length,l=j.length,n=h+l,c=E(n),m=i,e,d,a,g,k;for(a=0;a<h;++a){g=f[a];for(var
@@ -979,15 +980,15 @@ a(F(c,b),g);return new
 a(O(c,b),g)};a.prototype.times=a.prototype.multiply;function
 X(b,c,d){if(b<i)return new
 a(w(c,b),d);return new
-a(O(c,r(b)),d)}c.prototype._multiplyBySmall=function(a){if(q(a.value*this.value))return new
-c(a.value*this.value);return X(Math.abs(a.value),r(Math.abs(this.value)),this.sign!==a.sign)};a.prototype._multiplyBySmall=function(a){if(a.value===0)return f[0];if(a.value===1)return this;if(a.value===-1)return this.negate();return X(Math.abs(a.value),this.value,this.sign!==a.sign)};c.prototype.multiply=function(a){return h(a)._multiplyBySmall(this)};c.prototype.times=c.prototype.multiply;e.prototype.multiply=function(a){return new
+a(O(c,r(b)),d)}d.prototype._multiplyBySmall=function(a){if(q(a.value*this.value))return new
+d(a.value*this.value);return X(Math.abs(a.value),r(Math.abs(this.value)),this.sign!==a.sign)};a.prototype._multiplyBySmall=function(a){if(a.value===0)return f[0];if(a.value===1)return this;if(a.value===-1)return this.negate();return X(Math.abs(a.value),this.value,this.sign!==a.sign)};d.prototype.multiply=function(a){return h(a)._multiplyBySmall(this)};d.prototype.times=d.prototype.multiply;e.prototype.multiply=function(a){return new
 e(this.value*h(a).value)};e.prototype.times=e.prototype.multiply;function
 aa(g){var
 d=g.length,e=E(d+d),k=i,h,b,a,f,j;for(a=0;a<d;a++){f=g[a];b=0-f*f;for(var
 c=a;c<d;c++){j=g[c];h=2*(f*j)+e[a+c]+b;b=Math.floor(h/k);e[a+c]=h-b*k}e[a+d]=b}s(e);return e}a.prototype.square=function(){return new
-a(aa(this.value),false)};c.prototype.square=function(){var
+a(aa(this.value),false)};d.prototype.square=function(){var
 b=this.value*this.value;if(q(b))return new
-c(b);return new
+d(b);return new
 a(aa(r(Math.abs(this.value))),false)};e.prototype.square=function(a){return new
 e(this.value*this.value)};function
 ae(q,k){var
@@ -996,52 +997,52 @@ af(k,b){var
 l=k.length,g=b.length,e=[],a=[],h=i,c,f,d,m,j;while(l){a.unshift(k[--l]);s(a);if(o(a,b)<0){e.push(0);continue}f=a.length;d=a[f-1]*h+a[f-2];m=b[g-1]*h+b[g-2];if(f>g)d=(d+1)*h;c=Math.ceil(d/m);do{j=w(b,c);if(o(j,a)<=0)break;c--}while(c);e.push(c);a=y(a,j)}e.reverse();return[n(e),n(a)]}function
 R(h,e){var
 f=h.length,g=E(f),j=i,a,d,b,c;b=0;for(a=f-1;a>=0;--a){c=b*j+h[a];d=t(c/e);b=c-d*e;g[a]=d|0}return[g,b|0]}function
-l(d,w){var
+l(c,w){var
 m,j=h(w);if(I)return[new
-e(d.value/j.value),new
-e(d.value%j.value)];var
-l=d.value,g=j.value,b;if(g===0)throw new
-Error("Cannot divide by zero");if(d.isSmall){if(j.isSmall)return[new
-c(t(l/g)),new
-c(l%g)];return[f[0],d]}if(j.isSmall){if(g===1)return[d,f[0]];if(g==-1)return[d.negate(),f[0]];var
+e(c.value/j.value),new
+e(c.value%j.value)];var
+l=c.value,g=j.value,b;if(g===0)throw new
+Error("Cannot divide by zero");if(c.isSmall){if(j.isSmall)return[new
+d(t(l/g)),new
+d(l%g)];return[f[0],c]}if(j.isSmall){if(g===1)return[c,f[0]];if(g==-1)return[c.negate(),f[0]];var
 q=Math.abs(g);if(q<i){m=R(l,q);b=n(m[0]);var
-p=m[1];if(d.sign)p=-p;if(typeof
-b==="number"){if(d.sign!==j.sign)b=-b;return[new
-c(b),new
-c(p)]}return[new
-a(b,d.sign!==j.sign),new
-c(p)]}g=r(q)}var
-s=o(l,g);if(s===-1)return[f[0],d];if(s===0)return[f[d.sign===j.sign?1:-1],f[0]];if(l.length+g.length<=cz)m=ae(l,g);else
+p=m[1];if(c.sign)p=-p;if(typeof
+b==="number"){if(c.sign!==j.sign)b=-b;return[new
+d(b),new
+d(p)]}return[new
+a(b,c.sign!==j.sign),new
+d(p)]}g=r(q)}var
+s=o(l,g);if(s===-1)return[f[0],c];if(s===0)return[f[c.sign===j.sign?1:-1],f[0]];if(l.length+g.length<=cz)m=ae(l,g);else
 m=af(l,g);b=m[0];var
-v=d.sign!==j.sign,k=m[1],u=d.sign;if(typeof
+v=c.sign!==j.sign,k=m[1],u=c.sign;if(typeof
 b==="number"){if(v)b=-b;b=new
-c(b)}else
+d(b)}else
 b=new
 a(b,v);if(typeof
 k==="number"){if(u)k=-k;k=new
-c(k)}else
+d(k)}else
 k=new
 a(k,u);return[b,k]}a.prototype.divmod=function(b){var
-a=l(this,b);return{quotient:a[0],remainder:a[1]}};e.prototype.divmod=c.prototype.divmod=a.prototype.divmod;a.prototype.divide=function(a){return l(this,a)[0]};e.prototype.over=e.prototype.divide=function(a){return new
-e(this.value/h(a).value)};c.prototype.over=c.prototype.divide=a.prototype.over=a.prototype.divide;a.prototype.mod=function(a){return l(this,a)[1]};e.prototype.mod=e.prototype.remainder=function(a){return new
-e(this.value%h(a).value)};c.prototype.remainder=c.prototype.mod=a.prototype.remainder=a.prototype.mod;a.prototype.pow=function(j){var
-b=h(j),d=this.value,a=b.value,i,e,g;if(a===0)return f[1];if(d===0)return f[0];if(d===1)return f[1];if(d===-1)return b.isEven()?f[1]:f[-1];if(b.sign)return f[0];if(!b.isSmall)throw new
-Error("The exponent "+b.toString()+" is too large.");if(this.isSmall)if(q(i=Math.pow(d,a)))return new
-c(t(i));e=this;g=f[1];while(true){if(a&1===1){g=g.times(e);--a}if(a===0)break;a/=2;e=e.square()}return g};c.prototype.pow=a.prototype.pow;e.prototype.pow=function(m){var
+a=l(this,b);return{quotient:a[0],remainder:a[1]}};e.prototype.divmod=d.prototype.divmod=a.prototype.divmod;a.prototype.divide=function(a){return l(this,a)[0]};e.prototype.over=e.prototype.divide=function(a){return new
+e(this.value/h(a).value)};d.prototype.over=d.prototype.divide=a.prototype.over=a.prototype.divide;a.prototype.mod=function(a){return l(this,a)[1]};e.prototype.mod=e.prototype.remainder=function(a){return new
+e(this.value%h(a).value)};d.prototype.remainder=d.prototype.mod=a.prototype.remainder=a.prototype.mod;a.prototype.pow=function(j){var
+b=h(j),c=this.value,a=b.value,i,e,g;if(a===0)return f[1];if(c===0)return f[0];if(c===1)return f[1];if(c===-1)return b.isEven()?f[1]:f[-1];if(b.sign)return f[0];if(!b.isSmall)throw new
+Error("The exponent "+b.toString()+" is too large.");if(this.isSmall)if(q(i=Math.pow(c,a)))return new
+d(t(i));e=this;g=f[1];while(true){if(a&1===1){g=g.times(e);--a}if(a===0)break;a/=2;e=e.square()}return g};d.prototype.pow=a.prototype.pow;e.prototype.pow=function(m){var
 g=h(m),d=this.value,a=g.value,b=j(0),c=j(1),l=j(2);if(a===b)return f[1];if(d===b)return f[0];if(d===c)return f[1];if(d===j(-1))return g.isEven()?f[1]:f[-1];if(g.isNegative())return new
 e(b);var
 i=this,k=f[1];while(true){if((a&c)===c){k=k.times(i);--a}if(a===b)break;a/=l;i=i.square()}return k};a.prototype.modPow=function(a,b){a=h(a);b=h(b);if(b.isZero())throw new
 Error("Cannot take modPow with modulus 0");var
-d=f[1],c=this.mod(b);if(a.isNegative()){a=a.multiply(f[-1]);c=c.modInv(b)}while(a.isPositive()){if(c.isZero())return f[0];if(a.isOdd())d=d.multiply(c).mod(b);a=a.divide(2);c=c.square().mod(b)}return d};e.prototype.modPow=c.prototype.modPow=a.prototype.modPow;function
+d=f[1],c=this.mod(b);if(a.isNegative()){a=a.multiply(f[-1]);c=c.modInv(b)}while(a.isPositive()){if(c.isZero())return f[0];if(a.isOdd())d=d.multiply(c).mod(b);a=a.divide(2);c=c.square().mod(b)}return d};e.prototype.modPow=d.prototype.modPow=a.prototype.modPow;function
 o(b,c){if(b.length!==c.length)return b.length>c.length?1:-1;for(var
 a=b.length-1;a>=0;a--)if(b[a]!==c[a])return b[a]>c[a]?1:-1;return 0}a.prototype.compareAbs=function(d){var
-a=h(d),b=this.value,c=a.value;if(a.isSmall)return 1;return o(b,c)};c.prototype.compareAbs=function(d){var
+a=h(d),b=this.value,c=a.value;if(a.isSmall)return 1;return o(b,c)};d.prototype.compareAbs=function(d){var
 c=h(d),b=Math.abs(this.value),a=c.value;if(c.isSmall){a=Math.abs(a);return b===a?0:b>a?1:-1}return-1};e.prototype.compareAbs=function(c){var
 a=this.value,b=h(c).value;a=a>=0?a:-a;b=b>=0?b:-b;return a===b?0:a>b?1:-1};a.prototype.compare=function(b){if(b===Infinity)return-1;if(b===-Infinity)return 1;var
-a=h(b),c=this.value,d=a.value;if(this.sign!==a.sign)return a.sign?1:-1;if(a.isSmall)return this.sign?-1:1;return o(c,d)*(this.sign?-1:1)};a.prototype.compareTo=a.prototype.compare;c.prototype.compare=function(c){if(c===Infinity)return-1;if(c===-Infinity)return 1;var
-b=h(c),a=this.value,d=b.value;if(b.isSmall)return a==d?0:a>d?1:-1;if(a<0!==b.sign)return a<0?-1:1;return a<0?1:-1};c.prototype.compareTo=c.prototype.compare;e.prototype.compare=function(a){if(a===Infinity)return-1;if(a===-Infinity)return 1;var
-b=this.value,c=h(a).value;return b===c?0:b>c?1:-1};e.prototype.compareTo=e.prototype.compare;a.prototype.equals=function(a){return this.compare(a)===0};e.prototype.eq=e.prototype.equals=c.prototype.eq=c.prototype.equals=a.prototype.eq=a.prototype.equals;a.prototype.notEquals=function(a){return this.compare(a)!==0};e.prototype.neq=e.prototype.notEquals=c.prototype.neq=c.prototype.notEquals=a.prototype.neq=a.prototype.notEquals;a.prototype.greater=function(a){return this.compare(a)>0};e.prototype.gt=e.prototype.greater=c.prototype.gt=c.prototype.greater=a.prototype.gt=a.prototype.greater;a.prototype.lesser=function(a){return this.compare(a)<0};e.prototype.lt=e.prototype.lesser=c.prototype.lt=c.prototype.lesser=a.prototype.lt=a.prototype.lesser;a.prototype.greaterOrEquals=function(a){return this.compare(a)>=0};e.prototype.geq=e.prototype.greaterOrEquals=c.prototype.geq=c.prototype.greaterOrEquals=a.prototype.geq=a.prototype.greaterOrEquals;a.prototype.lesserOrEquals=function(a){return this.compare(a)<=0};e.prototype.leq=e.prototype.lesserOrEquals=c.prototype.leq=c.prototype.lesserOrEquals=a.prototype.leq=a.prototype.lesserOrEquals;a.prototype.isEven=function(){return(this.value[0]&1)===0};c.prototype.isEven=function(){return(this.value&1)===0};e.prototype.isEven=function(){return(this.value&j(1))===j(0)};a.prototype.isOdd=function(){return(this.value[0]&1)===1};c.prototype.isOdd=function(){return(this.value&1)===1};e.prototype.isOdd=function(){return(this.value&j(1))===j(1)};a.prototype.isPositive=function(){return!this.sign};c.prototype.isPositive=function(){return this.value>0};e.prototype.isPositive=c.prototype.isPositive;a.prototype.isNegative=function(){return this.sign};c.prototype.isNegative=function(){return this.value<0};e.prototype.isNegative=c.prototype.isNegative;a.prototype.isUnit=function(){return false};c.prototype.isUnit=function(){return Math.abs(this.value)===1};e.prototype.isUnit=function(){return this.abs().value===j(1)};a.prototype.isZero=function(){return false};c.prototype.isZero=function(){return this.value===0};e.prototype.isZero=function(){return this.value===j(0)};a.prototype.isDivisibleBy=function(b){var
-a=h(b);if(a.isZero())return false;if(a.isUnit())return true;if(a.compareAbs(2)===0)return this.isEven();return this.mod(a).isZero()};e.prototype.isDivisibleBy=c.prototype.isDivisibleBy=a.prototype.isDivisibleBy;function
+a=h(b),c=this.value,d=a.value;if(this.sign!==a.sign)return a.sign?1:-1;if(a.isSmall)return this.sign?-1:1;return o(c,d)*(this.sign?-1:1)};a.prototype.compareTo=a.prototype.compare;d.prototype.compare=function(c){if(c===Infinity)return-1;if(c===-Infinity)return 1;var
+b=h(c),a=this.value,d=b.value;if(b.isSmall)return a==d?0:a>d?1:-1;if(a<0!==b.sign)return a<0?-1:1;return a<0?1:-1};d.prototype.compareTo=d.prototype.compare;e.prototype.compare=function(a){if(a===Infinity)return-1;if(a===-Infinity)return 1;var
+b=this.value,c=h(a).value;return b===c?0:b>c?1:-1};e.prototype.compareTo=e.prototype.compare;a.prototype.equals=function(a){return this.compare(a)===0};e.prototype.eq=e.prototype.equals=d.prototype.eq=d.prototype.equals=a.prototype.eq=a.prototype.equals;a.prototype.notEquals=function(a){return this.compare(a)!==0};e.prototype.neq=e.prototype.notEquals=d.prototype.neq=d.prototype.notEquals=a.prototype.neq=a.prototype.notEquals;a.prototype.greater=function(a){return this.compare(a)>0};e.prototype.gt=e.prototype.greater=d.prototype.gt=d.prototype.greater=a.prototype.gt=a.prototype.greater;a.prototype.lesser=function(a){return this.compare(a)<0};e.prototype.lt=e.prototype.lesser=d.prototype.lt=d.prototype.lesser=a.prototype.lt=a.prototype.lesser;a.prototype.greaterOrEquals=function(a){return this.compare(a)>=0};e.prototype.geq=e.prototype.greaterOrEquals=d.prototype.geq=d.prototype.greaterOrEquals=a.prototype.geq=a.prototype.greaterOrEquals;a.prototype.lesserOrEquals=function(a){return this.compare(a)<=0};e.prototype.leq=e.prototype.lesserOrEquals=d.prototype.leq=d.prototype.lesserOrEquals=a.prototype.leq=a.prototype.lesserOrEquals;a.prototype.isEven=function(){return(this.value[0]&1)===0};d.prototype.isEven=function(){return(this.value&1)===0};e.prototype.isEven=function(){return(this.value&j(1))===j(0)};a.prototype.isOdd=function(){return(this.value[0]&1)===1};d.prototype.isOdd=function(){return(this.value&1)===1};e.prototype.isOdd=function(){return(this.value&j(1))===j(1)};a.prototype.isPositive=function(){return!this.sign};d.prototype.isPositive=function(){return this.value>0};e.prototype.isPositive=d.prototype.isPositive;a.prototype.isNegative=function(){return this.sign};d.prototype.isNegative=function(){return this.value<0};e.prototype.isNegative=d.prototype.isNegative;a.prototype.isUnit=function(){return false};d.prototype.isUnit=function(){return Math.abs(this.value)===1};e.prototype.isUnit=function(){return this.abs().value===j(1)};a.prototype.isZero=function(){return false};d.prototype.isZero=function(){return this.value===0};e.prototype.isZero=function(){return this.value===j(0)};a.prototype.isDivisibleBy=function(b){var
+a=h(b);if(a.isZero())return false;if(a.isUnit())return true;if(a.compareAbs(2)===0)return this.isEven();return this.mod(a).isZero()};e.prototype.isDivisibleBy=d.prototype.isDivisibleBy=a.prototype.isDivisibleBy;function
 U(b){var
 a=b.abs();if(a.isUnit())return false;if(a.equals(2)||a.equals(3)||a.equals(5))return true;if(a.isEven()||a.isDivisibleBy(3)||a.isDivisibleBy(5))return false;if(a.lesser(49))return true}function
 M(e,f){var
@@ -1049,22 +1050,22 @@ h=e.prev(),d=h,i=0,g,j,c,a;while(d.isEven())d=d.divide(2),i++;next:for(c=0;c<f.l
 f=U(this);if(f!==C)return f;var
 c=this.abs(),e=c.bitLength();if(e<=64)return M(c,[2,3,5,7,11,13,17,19,23,29,31,37]);var
 g=Math.log(2)*e.toJSNumber(),i=Math.ceil(h===true?2*Math.pow(g,2):g);for(var
-d=[],a=0;a<i;a++)d.push(b(a+2));return M(c,d)};e.prototype.isPrime=c.prototype.isPrime=a.prototype.isPrime;a.prototype.isProbablePrime=function(e){var
+d=[],a=0;a<i;a++)d.push(b(a+2));return M(c,d)};e.prototype.isPrime=d.prototype.isPrime=a.prototype.isPrime;a.prototype.isProbablePrime=function(e){var
 d=U(this);if(d!==C)return d;var
 f=this.abs(),g=e===C?5:e;for(var
-a=[],c=0;c<g;c++)a.push(b.randBetween(2,f.minus(2)));return M(f,a)};e.prototype.isProbablePrime=c.prototype.isProbablePrime=a.prototype.isProbablePrime;a.prototype.modInv=function(e){var
+a=[],c=0;c<g;c++)a.push(b.randBetween(2,f.minus(2)));return M(f,a)};e.prototype.isProbablePrime=d.prototype.isProbablePrime=a.prototype.isProbablePrime;a.prototype.modInv=function(e){var
 a=b.zero,f=b.one,d=h(e),c=this.abs(),g,j,i;while(!c.isZero()){g=d.divide(c);j=a;i=d;a=f;d=c;f=j.subtract(g.multiply(f));c=i.subtract(g.multiply(c))}if(!d.isUnit())throw new
-Error(this.toString()+" and "+e.toString()+" are not co-prime");if(a.compare(0)===-1)a=a.add(e);if(this.isNegative())return a.negate();return a};e.prototype.modInv=c.prototype.modInv=a.prototype.modInv;a.prototype.next=function(){var
+Error(this.toString()+" and "+e.toString()+" are not co-prime");if(a.compare(0)===-1)a=a.add(e);if(this.isNegative())return a.negate();return a};e.prototype.modInv=d.prototype.modInv=a.prototype.modInv;a.prototype.next=function(){var
 b=this.value;if(this.sign)return H(b,1,this.sign);return new
-a(D(b,1),this.sign)};c.prototype.next=function(){var
+a(D(b,1),this.sign)};d.prototype.next=function(){var
 b=this.value;if(b+1<u)return new
-c(b+1);return new
+d(b+1);return new
 a(K,false)};e.prototype.next=function(){return new
 e(this.value+j(1))};a.prototype.prev=function(){var
 b=this.value;if(this.sign)return new
-a(D(b,1),true);return H(b,1,this.sign)};c.prototype.prev=function(){var
+a(D(b,1),true);return H(b,1,this.sign)};d.prototype.prev=function(){var
 b=this.value;if(b-1>-u)return new
-c(b-1);return new
+d(b-1);return new
 a(K,true)};e.prototype.prev=function(){return new
 e(this.value-j(1))};var
 k=[1];while(2*k[k.length-1]<=i)k.push(2*k[k.length-1]);var
@@ -1072,14 +1073,14 @@ x=k.length,m=k[x-1];function
 $(a){return Math.abs(a)<=i}a.prototype.shiftLeft=function(c){var
 a=h(c).toJSNumber();if(!$(a))throw new
 Error(String(a)+ev);if(a<0)return this.shiftRight(-a);var
-b=this;if(b.isZero())return b;while(a>=x){b=b.multiply(m);a-=x-1}return b.multiply(k[a])};e.prototype.shiftLeft=c.prototype.shiftLeft=a.prototype.shiftLeft;a.prototype.shiftRight=function(d){var
+b=this;if(b.isZero())return b;while(a>=x){b=b.multiply(m);a-=x-1}return b.multiply(k[a])};e.prototype.shiftLeft=d.prototype.shiftLeft=a.prototype.shiftLeft;a.prototype.shiftRight=function(d){var
 a,b=h(d).toJSNumber();if(!$(b))throw new
 Error(String(b)+ev);if(b<0)return this.shiftLeft(-b);var
-c=this;while(b>=x){if(c.isZero()||c.isNegative()&&c.isUnit())return c;a=l(c,m);c=a[1].isNegative()?a[0].prev():a[0];b-=x-1}a=l(c,k[b]);return a[1].isNegative()?a[0].prev():a[0]};e.prototype.shiftRight=c.prototype.shiftRight=a.prototype.shiftRight;function
+c=this;while(b>=x){if(c.isZero()||c.isNegative()&&c.isUnit())return c;a=l(c,m);c=a[1].isNegative()?a[0].prev():a[0];b-=x-1}a=l(c,k[b]);return a[1].isNegative()?a[0].prev():a[0]};e.prototype.shiftRight=d.prototype.shiftRight=a.prototype.shiftRight;function
 L(i,a,r){a=h(a);var
 n=i.isNegative(),q=a.isNegative(),k=n?i.not():i,p=q?a.not():a,c=0,d=0,j=null,o=null,f=[];while(!k.isZero()||!p.isZero()){j=l(k,m);c=j[1].toJSNumber();if(n)c=m-1-c;o=l(p,m);d=o[1].toJSNumber();if(q)d=m-1-d;k=j[0];p=o[0];f.push(r(c,d))}var
 g=r(n?1:0,q?1:0)!==0?b(-1):b(0);for(var
-e=f.length-1;e>=0;e-=1)g=g.multiply(m).add(b(f[e]));return g}a.prototype.not=function(){return this.negate().prev()};e.prototype.not=c.prototype.not=a.prototype.not;a.prototype.and=function(a){return L(this,a,function(a,b){return a&b})};e.prototype.and=c.prototype.and=a.prototype.and;a.prototype.or=function(a){return L(this,a,function(a,b){return a|b})};e.prototype.or=c.prototype.or=a.prototype.or;a.prototype.xor=function(a){return L(this,a,function(a,b){return a^b})};e.prototype.xor=c.prototype.xor=a.prototype.xor;var
+e=f.length-1;e>=0;e-=1)g=g.multiply(m).add(b(f[e]));return g}a.prototype.not=function(){return this.negate().prev()};e.prototype.not=d.prototype.not=a.prototype.not;a.prototype.and=function(a){return L(this,a,function(a,b){return a&b})};e.prototype.and=d.prototype.and=a.prototype.and;a.prototype.or=function(a){return L(this,a,function(a,b){return a|b})};e.prototype.or=d.prototype.or=a.prototype.or;a.prototype.xor=function(a){return L(this,a,function(a,b){return a^b})};e.prototype.xor=d.prototype.xor=a.prototype.xor;var
 J=1<<30,ac=(i&-i)*(i&-i)|J;function
 G(c){var
 a=c.value,b=typeof
@@ -1087,7 +1088,7 @@ a==="number"?a|J:typeof
 a==="bigint"?a|j(J):a[0]+a[1]*i|ac;return b&-b}function
 T(c,a){if(a.compareTo(c)<=0){var
 g=T(c,a.square(a)),e=g.p,d=g.e,f=e.multiply(a);return f.compareTo(c)<=0?{p:f,e:d*2+1}:{p:e,e:d*2}}return{p:b(1),e:0}}a.prototype.bitLength=function(){var
-a=this;if(a.compareTo(b(0))<0)a=a.negate().subtract(b(1));if(a.compareTo(b(0))===0)return b(0);return b(T(a,b(2)).e).add(b(1))};e.prototype.bitLength=c.prototype.bitLength=a.prototype.bitLength;function
+a=this;if(a.compareTo(b(0))<0)a=a.negate().subtract(b(1));if(a.compareTo(b(0))===0)return b(0);return b(T(a,b(2)).e).add(b(1))};e.prototype.bitLength=d.prototype.bitLength=a.prototype.bitLength;function
 W(a,b){a=h(a);b=h(b);return a.greater(b)?a:b}function
 N(a,b){a=h(a);b=h(b);return a.lesser(b)?a:b}function
 S(a,b){a=h(a).abs();b=h(b).abs();if(a.equals(b))return a;if(a.isZero())return b;if(b.isZero())return a;var
@@ -1123,22 +1124,22 @@ g=false;if(a.isNegative()&&c.isPositive()){g=true;a=a.abs()}if(c.isUnit()){if(a.
 h=[],d=a,f;while(d.isNegative()||d.compareAbs(c)>=0){f=d.divmod(c);d=f.quotient;var
 e=f.remainder;if(e.isNegative()){e=c.minus(e).abs();d=d.next()}h.push(e.toJSNumber())}h.push(d.toJSNumber());return{value:h.reverse(),isNegative:g}}function
 ab(d,c,b){var
-a=A(d,c);return(a.isNegative?B:g)+a.value.map(function(a){return ak(a,b)}).join(g)}a.prototype.toArray=function(a){return A(this,a)};c.prototype.toArray=function(a){return A(this,a)};e.prototype.toArray=function(a){return A(this,a)};a.prototype.toString=function(a,f){if(a===C)a=10;if(a!==10)return ab(this,a,f);var
+a=A(d,c);return(a.isNegative?B:g)+a.value.map(function(a){return ak(a,b)}).join(g)}a.prototype.toArray=function(a){return A(this,a)};d.prototype.toArray=function(a){return A(this,a)};e.prototype.toArray=function(a){return A(this,a)};a.prototype.toString=function(a,f){if(a===C)a=10;if(a!==10)return ab(this,a,f);var
 d=this.value,c=d.length,e=String(d[--c]),i="0000000",b;while(--c>=0){b=String(d[c]);e+=i.slice(b.length)+b}var
-h=this.sign?B:g;return h+e};c.prototype.toString=function(a,b){if(a===C)a=10;if(a!=10)return ab(this,a,b);return String(this.value)};e.prototype.toString=c.prototype.toString;e.prototype.toJSON=a.prototype.toJSON=c.prototype.toJSON=function(){return this.toString()};a.prototype.valueOf=function(){return parseInt(this.toString(),10)};a.prototype.toJSNumber=a.prototype.valueOf;c.prototype.valueOf=function(){return this.value};c.prototype.toJSNumber=c.prototype.valueOf;e.prototype.valueOf=e.prototype.toJSNumber=function(){return parseInt(this.toString(),10)};function
+h=this.sign?B:g;return h+e};d.prototype.toString=function(a,b){if(a===C)a=10;if(a!=10)return ab(this,a,b);return String(this.value)};e.prototype.toString=d.prototype.toString;e.prototype.toJSON=a.prototype.toJSON=d.prototype.toJSON=function(){return this.toString()};a.prototype.valueOf=function(){return parseInt(this.toString(),10)};a.prototype.toJSNumber=a.prototype.valueOf;d.prototype.valueOf=function(){return this.value};d.prototype.toJSNumber=d.prototype.valueOf;e.prototype.valueOf=e.prototype.toJSNumber=function(){return parseInt(this.toString(),10)};function
 Z(b){if(q(+b)){var
 l=+b;if(l===t(l))return I?new
 e(j(l)):new
-c(l);throw new
+d(l);throw new
 Error(bJ+b)}var
 o=b[0]===B;if(o)b=b.slice(1);var
 g=b.split(/e/i);if(g.length>2)throw new
 Error(bJ+g.join(bL));if(g.length===2){var
-d=g[1];if(d[0]===as)d=d.slice(1);d=+d;if(d!==t(d)||!q(d))throw new
-Error(bJ+d+" is not a valid exponent.");var
-f=g[0],h=f.indexOf(aQ);if(h>=0){d-=f.length-h-1;f=f.slice(0,h)+f.slice(h+1)}if(d<0)throw new
+c=g[1];if(c[0]===as)c=c.slice(1);c=+c;if(c!==t(c)||!q(c))throw new
+Error(bJ+c+" is not a valid exponent.");var
+f=g[0],h=f.indexOf(aQ);if(h>=0){c-=f.length-h-1;f=f.slice(0,h)+f.slice(h+1)}if(c<0)throw new
 Error("Cannot include negative exponent part for integers");f+=new
-Array(d+1).join(z);b=f}var
+Array(c+1).join(z);b=f}var
 p=/^([0-9][0-9]*)$/.test(b);if(!p)throw new
 Error(bJ+b);if(I)return new
 e(j(o?B+b:b));var
@@ -1147,7 +1148,7 @@ a(n,o)}function
 ai(a){if(I)return new
 e(j(a));if(q(a)){if(a!==t(a))throw new
 Error(a+" is not an integer.");return new
-c(a)}return Z(a.toString())}function
+d(a)}return Z(a.toString())}function
 h(a){if(typeof
 a==="number")return ai(a);if(typeof
 a==="string")return Z(a);if(typeof
@@ -1157,7 +1158,7 @@ p=0;p<V;p++){f[p]=h(p);if(p>0)f[-p]=h(-p)}f.one=f[1];f.zero=f[0];f.minusOne=f[-1
 instanceof
 a||b
 instanceof
-c||b
+d||b
 instanceof
 e};f.randBetween=aj;f.fromArray=function(b,a,c){return Y(b.map(h),h(a||10),c)};return f}();function
 j(a){var
@@ -1224,10 +1225,10 @@ l6(b,c){return a.caml_pasta_fp_plonk_gate_vector_add(b,fn(c))}function
 pF(){return 0}function
 pj(){return 0}var
 a9=function(){var
-a=d,g="a.out",b=[];if(a.process&&a.process.argv&&a.process.argv.length>1){var
+a=c,g="a.out",b=[];if(a.process&&a.process.argv&&a.process.argv.length>1){var
 f=a.process.argv;g=f[1];b=f.slice(2)}var
 h=T(g),e=[0,h];for(var
-c=0;c<b.length;c++)e.push(T(b[c]));return e}(),fl=a9[1];function
+d=0;d<b.length;d++)e.push(T(b[d]));return e}(),fl=a9[1];function
 o2(a){return fl}function
 kX(a,b){return+(aJ(a,b,false)<=0)}function
 p5(a){return a.value|0}function
@@ -1261,20 +1262,20 @@ a==="string"){b=bW(b,a);c--}else
 if(a===(a|0)){b=w(b,a+a+1);c--}else
 if(a===+a){b=bp(b,a);c--}}b=c0(b);return b&cu}function
 g8(a){return cY(1,1,0,a)}var
-aM=[0,d];function
-iS(a,c){var
-b=k(c);d.console.log("Dynlink: look for symbol ",b);if(aM[a]&&aM[a][b])return aM[a][b];return 0}function
+aM=[0,c];function
+iS(a,d){var
+b=k(d);c.console.log("Dynlink: look for symbol ",b);if(aM[a]&&aM[a][b])return aM[a][b];return 0}function
 ax(b){return cc(b,a.WasmPallasGAffine,false)}function
 nJ(e,b,c){var
 d=a.caml_pasta_fq_urs_lagrange_commitment(e,b,c);return ax(d)}function
 dt(d,e){var
 a=h[d],c=i(e),b=y(c);a.file.write(a.offset,c,0,b);a.offset+=b;return 0}function
 bD(a){var
-a=ci(a),b=d;if(b.process&&b.process.stdout&&b.process.stdout.write)b.process.stderr.write(a);else{if(a.charCodeAt(a.length-1)==10)a=a.substr(0,a.length-1);var
-c=b.console;c&&c.error&&c.error(a)}}function
+a=ci(a),b=c;if(b.process&&b.process.stdout&&b.process.stdout.write)b.process.stderr.write(a);else{if(a.charCodeAt(a.length-1)==10)a=a.substr(0,a.length-1);var
+d=b.console;d&&d.error&&d.error(a)}}function
 gL(a){var
-a=ci(a),b=d;if(b.process&&b.process.stdout&&b.process.stdout.write)b.process.stdout.write(a);else{if(a.charCodeAt(a.length-1)==10)a=a.substr(0,a.length-1);var
-c=b.console;c&&c.log&&c.log(a)}}function
+a=ci(a),b=c;if(b.process&&b.process.stdout&&b.process.stdout.write)b.process.stdout.write(a);else{if(a.charCodeAt(a.length-1)==10)a=a.substr(0,a.length-1);var
+d=b.console;d&&d.log&&d.log(a)}}function
 ch(c,e,d,a){if(l.fds===undefined)l.fds=new
 Array();a=a?a:{};var
 b={};b.file=d;b.offset=a.append?d.length():0;b.flags=a;b.output=e;l.fds[c]=b;if(!l.fd_last_idx||c>l.fd_last_idx)l.fd_last_idx=c;return c}function
@@ -1338,26 +1339,26 @@ a=h[b];aX(b);a.opened=false;a.file.close();gn(a.fd);return 0}function
 pK(b){var
 a=fU(b);try{return fS(a,-1)}finally{fT(a)}}var
 _=3;function
-dx(b,a){if(a<0||_+a>=b.length)c("Weak.get_key");return b[_+a]===undefined?0:b[_+a]}var
+dx(b,a){if(a<0||_+a>=b.length)d("Weak.get_key");return b[_+a]===undefined?0:b[_+a]}var
 i1=dx;function
 dw(a){return k(a)}function
 gM(e,a){if(e==0){e=10;var
-d=0,k=1;if(a[d]==B){k=-1;d++}else
-if(a[d]==as)d++;if(a[d]==z){d++;if(a.length==d)return 0;else{var
-f=a[d];if(f=="o"||f=="O")e=8;else
+c=0,k=1;if(a[c]==B){k=-1;c++}else
+if(a[c]==as)c++;if(a[c]==z){c++;if(a.length==c)return 0;else{var
+f=a[c];if(f=="o"||f=="O")e=8;else
 if(f=="x"||f=="X")e=16;else
-if(f=="b"||f=="B")e=2;if(e!=10){a=a.substring(d+1);if(k==-1)a=B+a}}}}if(a[0]==as)a=a.substring(1);a=a.replace(/^0+/,g);if(a==B||a==g)a=z;function
+if(f=="b"||f=="B")e=2;if(e!=10){a=a.substring(c+1);if(k==-1)a=B+a}}}}if(a[0]==as)a=a.substring(1);a=a.replace(/^0+/,g);if(a==B||a==g)a=z;function
 l(a){if(a>=48&&a<=57)return a-48;if(a>=97&&a<=102)return a-97+10;if(a>=65&&a<=70)return a-65+10}var
 h=0;if(a[h]==B)h++;for(;h<a.length;h++){var
-i=l(a.charCodeAt(h));if(i==undefined||i>=e)c("Z.of_substring_base: invalid digit")}return j(b(a,e))}function
-q1(e,a,b,d){if(b!=0||d!=y(a)){a=bn(a);if(a.length-b<d)c("Z.of_substring_base: invalid offset or length");a=bh(a.slice(b,b+d))}return gM(e,dw(a))}var
+i=l(a.charCodeAt(h));if(i==undefined||i>=e)d("Z.of_substring_base: invalid digit")}return j(b(a,e))}function
+q1(e,a,b,c){if(b!=0||c!=y(a)){a=bn(a);if(a.length-b<c)d("Z.of_substring_base: invalid offset or length");a=bh(a.slice(b,b+c))}return gM(e,dw(a))}var
 mb=a.caml_pasta_fp_plonk_index_domain_d8_size;function
 bT(e){var
-c=av(e),b=new(d.Uint8Array)(c);for(var
-a=0;a<c;a++)b[a]=I(e,a);return b}function
+d=av(e),b=new(c.Uint8Array)(d);for(var
+a=0;a<d;a++)b[a]=I(e,a);return b}function
 m3(b){return a.caml_pasta_fq_of_bytes(bT(b))}function
 rz(){}function
-i8(a,b){if(!a.js_error||b||a[0]==W)a.js_error=new(d.Error)("Js exception containing backtrace");return a}function
+i8(a,b){if(!a.js_error||b||a[0]==W)a.js_error=new(c.Error)("Js exception containing backtrace");return a}function
 o9(a){return 0}function
 rv(){return 0}var
 m$=a.caml_pasta_fq_plonk_index_domain_d1_size;function
@@ -1394,24 +1395,24 @@ kD(a,c,b){return a[k(c)].apply(a,aa(b))}function
 K(a){return a1(a)}function
 nG(e,b,c){var
 d=a.caml_pasta_fq_urs_commit_evaluations(e,b,K(c));return ax(d)}function
-gu(a){if(a<0)c("Weak.create");var
+gu(a){if(a<0)d("Weak.create");var
 b=[dU,"caml_ephe_list_head"];b.length=_+a;return b}var
 iY=gu;function
 fJ(a,b){return a.or(b)}function
 p_(a,b){return fJ(a,b)}function
-cI(b,d,g,a,f,e){if(d||a_(a)==2)c("caml_ba_create_from: use return caml_ba_create_unsafe");return Z(a,f,e,b)}function
-e8(a){if(a.data2!=null)c("bigstring_destroy: unsupported kind");if(a.hasOwnProperty(dV))c("bigstring_destroy: bigstring is already deallocated");var
-d=new(a.data.__proto__.constructor)(0),b=cI(d,null,a.data_type,a.kind,a.layout,[0]);b.__is_deallocated=true;Object.assign(a,b);return 0}function
-hs(a,b){if(a.data2!=null)c("Bigstring.unsafe_destroy_and_resize: unsupported kind");if(a.hasOwnProperty(dV))c("bigstring_realloc: bigstring is already deallocated");var
-d=new(a.data.__proto__.constructor)(b);d.set(a.data.slice(0,b));var
-e=cI(d,null,a.data_type,a.kind,a.layout,[b]);e8(a);return e}function
+cI(b,c,g,a,f,e){if(c||a_(a)==2)d("caml_ba_create_from: use return caml_ba_create_unsafe");return Z(a,f,e,b)}function
+e8(a){if(a.data2!=null)d("bigstring_destroy: unsupported kind");if(a.hasOwnProperty(dV))d("bigstring_destroy: bigstring is already deallocated");var
+c=new(a.data.__proto__.constructor)(0),b=cI(c,null,a.data_type,a.kind,a.layout,[0]);b.__is_deallocated=true;Object.assign(a,b);return 0}function
+hs(a,b){if(a.data2!=null)d("Bigstring.unsafe_destroy_and_resize: unsupported kind");if(a.hasOwnProperty(dV))d("bigstring_realloc: bigstring is already deallocated");var
+c=new(a.data.__proto__.constructor)(b);c.set(a.data.slice(0,b));var
+e=cI(c,null,a.data_type,a.kind,a.layout,[b]);e8(a);return e}function
 pn(a){var
 b=1;while(a&&a.joo_tramp){a=a.joo_tramp.apply(null,a.joo_args);b++}return a}function
 p0(a){return new
 H(a)}function
 gW(c,a){a=b(a);if(a.equals(b(0)))S();return j(b(c).mod(a))}function
-dy(b,a,d){if(a<0||_+a>=b.length)c("Weak.set");b[_+a]=d;return 0}function
-bg(){c(cB)}function
+dy(b,a,c){if(a<0||_+a>=b.length)d("Weak.set");b[_+a]=c;return 0}function
+bg(){d(cB)}function
 oJ(b,a){if(a>>>0>=y(b)-3)bg();var
 c=t(b,a),d=t(b,a+1),e=t(b,a+2),f=t(b,a+3);return f<<24|e<<16|d<<8|c}function
 p8(b,a){if(a.isZero())S();b.hi=b.hi>>>0;a.hi=a.hi>>>0;return b.udivmod(a).quotient}function
@@ -1461,20 +1462,20 @@ a=c-8;a>=0;a-=8)this.chunk[b++]=d>>a&p},write_code:function(c,b,d){this.chunk[th
 a=c-8;a>=0;a-=8)this.chunk[this.chunk_idx++]=d>>a&p},write_shared:function(a){if(a<1<<8)this.write_code(8,eS,a);else
 if(a<1<<16)this.write_code(16,eZ,a);else
 this.write_code(32,eq,a)},pos:function(){return this.chunk_idx},finalize:function(){this.block_len=this.chunk_idx-20;this.chunk_idx=0;this.write(32,e3);this.write(32,this.block_len);this.write(32,this.obj_counter);this.write(32,this.size_32);this.write(32,this.size_64);return this.chunk}};return function(b,f){f=fP(f);var
-m=f.indexOf(0)!==-1,p=f.indexOf(1)!==-1;if(p)d.console.warn("in caml_output_val: flag Marshal.Closures is not supported.");var
+m=f.indexOf(0)!==-1,p=f.indexOf(1)!==-1;if(p)c.console.warn("in caml_output_val: flag Marshal.Closures is not supported.");var
 a=new
 o(),l=[],h=m?null:new
 a8();function
 n(c){if(m)return false;var
 b=h.recall(c);if(b){a.write_shared(b);return true}else{h.store(c);return false}}function
 k(b){if(b.caml_custom){if(n(b))return;var
-h=b.caml_custom,k=E[h],j=[0,0];if(!k.serialize)c("output_value: abstract value (Custom)");if(fN){a.write(8,ei);for(var
-d=0;d<h.length;d++)a.write(8,h.charCodeAt(d));a.write(8,0);k.serialize(a,b,j)}else
+h=b.caml_custom,k=E[h],j=[0,0];if(!k.serialize)d("output_value: abstract value (Custom)");if(fN){a.write(8,ei);for(var
+c=0;c<h.length;c++)a.write(8,h.charCodeAt(c));a.write(8,0);k.serialize(a,b,j)}else
 if(k.fixed_length==undefined){a.write(8,eY);for(var
-d=0;d<h.length;d++)a.write(8,h.charCodeAt(d));a.write(8,0);var
+c=0;c<h.length;c++)a.write(8,h.charCodeAt(c));a.write(8,0);var
 m=a.pos();for(var
-d=0;d<12;d++)a.write(8,0);k.serialize(a,b,j);a.write_at(m,32,j[0]);a.write_at(m+4,32,0);a.write_at(m+8,32,j[1])}else{a.write(8,en);for(var
-d=0;d<h.length;d++)a.write(8,h.charCodeAt(d));a.write(8,0);var
+c=0;c<12;c++)a.write(8,0);k.serialize(a,b,j);a.write_at(m,32,j[0]);a.write_at(m+4,32,0);a.write_at(m+8,32,j[1])}else{a.write(8,en);for(var
+c=0;c<h.length;c++)a.write(8,h.charCodeAt(c));a.write(8,0);var
 o=a.pos();k.serialize(a,b,j);if(k.fixed_length!=a.pos()-o)e("output_value: incorrect fixed sizes specified by "+h)}a.size_32+=2+(j[0]+3>>2);a.size_64+=2+(j[1]+7>>3)}else
 if(b
 instanceof
@@ -1484,12 +1485,12 @@ if(aH(b)){if(!aH(i(g)))e("output_value: [Bytes.t] cannot safely be marshaled wit
 f=av(b);if(f<a7)a.write(8,a7+f);else
 if(f<d1)a.write_code(8,cw,f);else
 a.write_code(32,cs,f);for(var
-d=0;d<f;d++)a.write(8,I(b,d));a.size_32+=1+((f+4)/4|0);a.size_64+=1+((f+8)/8|0)}else
+c=0;c<f;c++)a.write(8,I(b,c));a.size_32+=1+((f+4)/4|0);a.size_64+=1+((f+8)/8|0)}else
 if(aW(b)){var
 f=y(b);if(f<a7)a.write(8,a7+f);else
 if(f<d1)a.write_code(8,cw,f);else
 a.write_code(32,cs,f);for(var
-d=0;d<f;d++)a.write(8,t(b,d));a.size_32+=1+((f+4)/4|0);a.size_64+=1+((f+8)/8|0)}else
+c=0;c<f;c++)a.write(8,t(b,c));a.size_32+=1+((f+4)/4|0);a.size_64+=1+((f+8)/8|0)}else
 if(b!=(b|0)){var
 p=typeof
 b;e("output_value: abstract value ("+p+")")}else
@@ -1503,7 +1504,7 @@ oh(a){a=x(a);o(a+": Not a directory")}function
 rw(a){if(dE()){var
 b=require("tty");return b.isatty(a)}else
 return false}function
-bl(a){this.data=new(d.Int32Array)(a);this.length=this.data.length+2}bl.prototype.caml_custom=eL;function
+bl(a){this.data=new(c.Int32Array)(a);this.length=this.data.length+2}bl.prototype.caml_custom=eL;function
 gA(d,e){var
 b=d.read32s(),c=new
 bl(b);for(var
@@ -1562,9 +1563,9 @@ qk(a){return am(a.lo,a.mi,a.hi|0)}function
 gT(a){a=b(a);var
 d=b(0),e=b(1);if(a.lt(d))aB(aw(a6));var
 c;for(c=0;!a.equals(d);c++)a=a.and(a.prev());if(c!=(c|0))aB(aw(a6));return c|0}function
-qM(a,d){if(b(a).isNegative()!=b(d).isNegative())aB(aw(a6));if((a!=(a|0)||d!=(d|0))&&(b(a).isNegative()||b(d).isNegative()))c("Z.hamdist: negative arguments");return gT(b(a).xor(b(d)))}function
+qM(a,c){if(b(a).isNegative()!=b(c).isNegative())aB(aw(a6));if((a!=(a|0)||c!=(c|0))&&(b(a).isNegative()||b(c).isNegative()))d("Z.hamdist: negative arguments");return gT(b(a).xor(b(c)))}function
 qT(a,c){return j(b(a).multiply(b(c)))}function
-gU(d,a){a=b(a);if(a.lt(b(0)))c("Z.pow: exponent must be nonnegative");return j(b(d).pow(a))}function
+gU(c,a){a=b(a);if(a.lt(b(0)))d("Z.pow: exponent must be nonnegative");return j(b(c).pow(a))}function
 nI(b){return N(a.caml_pasta_fq_urs_h(b))}function
 e$(b,e,d){var
 a=aa(d),c=cH(b,aS(a));return Z(b,e,a,c)}function
@@ -1620,8 +1621,8 @@ c.PUSHBACK:p({pos:{pc:l+t,txt:a}});break;case
 c.SETMARK:p({undo:{obj:r,prop:d,value:r[d]}});r[d]=a;break;case
 c.CHECKPROGRESS:if(r[d]===a)e();break;default:throw new
 Error("Invalid bytecode")}}return 0}return a}();function
-rn(e,d,a){if(a<0||a>y(d))c("Str.search_backward");while(a>=0){var
-b=bG(e,d,a,0);if(b)return b;a--}return[0]}function
+rn(e,c,a){if(a<0||a>y(c))d("Str.search_backward");while(a>=0){var
+b=bG(e,c,a,0);if(b)return b;a--}return[0]}function
 qP(a,c){return j(b(a).and(b(c)))}function
 mK(b,d){if(b===0)b=undefined;else
 b=b[1];var
@@ -1651,7 +1652,7 @@ fr(c,b){var
 a=q();a.width=c;a.height=b;a.canvas.width=c;a.canvas.height=b;return 0}function
 fy(){fq(R.x,R.y);fr(R.width,R.height);fu(R.line_width);fv(R.text_size);ft(R.font);fs(R.color);fw(R.title);R.context.textBaseline="bottom"}function
 fb(e){var
-b=d,a;if(e
+b=c,a;if(e
 instanceof
 b.Float32Array)a=0;else
 if(e
@@ -1675,7 +1676,7 @@ b.Int32Array)a=6;else
 if(e
 instanceof
 b.Uint32Array)a=6;else
-c("caml_ba_kind_of_typed_array: unsupported kind");return a}function
+d("caml_ba_kind_of_typed_array: unsupported kind");return a}function
 hT(a){var
 b=fb(a);return Z(b,0,[a.length],a)}function
 lr(a,b){aX(a);h[a].offset=b;return 0}function
@@ -1698,7 +1699,7 @@ ku(a){return!!a}function
 jB(){var
 a=q();a.canvas.width=0;a.canvas.height=0;return 0}var
 he=w;function
-iN(a){if(a<0)c("String.create");return new
+iN(a){if(a<0)d("String.create");return new
 ag(a?2:9,g,a)}function
 il(b){return a.caml_bigint_256_of_decimal_string(k(b))}function
 cC(c){var
@@ -1708,13 +1709,13 @@ fY=a.caml_pasta_fp_add;function
 fM(a){return T(a)}function
 pI(f,b){var
 a=new
-Date(f*V),c=dw(b),e=d.strftime(c,a);return fM(e)}function
+Date(f*V),d=dw(b),e=c.strftime(d,a);return fM(e)}function
 db(d){var
 c=d.length,b=new
 Array(c);for(var
 a=0;a<c;a++)b[a]=d[a];return b}function
-gv(d,b){if(b<0||_+b>=d.length)c("Weak.get_copy");var
-a=dx(d,b);if(a===0)return a;var
+gv(c,b){if(b<0||_+b>=c.length)d("Weak.get_copy");var
+a=dx(c,b);if(a===0)return a;var
 e=a[1];if(e
 instanceof
 Array)return[0,db(e)];return a}function
@@ -1792,7 +1793,7 @@ lE(a){return+(a
 instanceof
 Array)}function
 aU(a){return aV($(a))}function
-nO(b,a){return new(d.Uint8Array)(b[a+1])}function
+nO(b,a){return new(c.Uint8Array)(b[a+1])}function
 bV(a,e){if(a.uppercase)e=e.toUpperCase();var
 d=e.length;if(a.signedconv&&(a.sign<0||a.signstyle!=B))d++;if(a.alternate){if(a.base==8)d+=1;if(a.base==16)d+=2}var
 b=g;if(a.justify==as&&a.filler==U)for(var
@@ -1984,8 +1985,8 @@ gQ(e){var
 c=b(e).toArray(Math.pow(2,32)),a=0;for(var
 d=0;d<c.value.length;d++)a=w(a,c.value[d]);if(c.value.length%2!=0)a=w(a,0);if(c.isNegative)a=a+1;return a|0}function
 p9(a,b){return fF(a,b)}function
-rp(e,d,a){if(a<0||a>y(d))c("Str.string_match");var
-b=bG(e,d,a,0);return b?b:[0]}function
+rp(e,c,a){if(a<0||a>y(c))d("Str.string_match");var
+b=bG(e,c,a,0);return b?b:[0]}function
 e5(a,b){this.s=a;this.i=b}e5.prototype={read8u:function(){return n(this.s,this.i++)},read8s:function(){return n(this.s,this.i++)<<24>>24},read16u:function(){var
 b=this.s,a=this.i;this.i=a+2;return n(b,a)<<8|n(b,a+1)},read16s:function(){var
 b=this.s,a=this.i;this.i=a+2;return n(b,a)<<24>>16|n(b,a+1)},read32u:function(){var
@@ -2000,19 +2001,19 @@ od(c,d){var
 b=a.caml_pasta_vesta_scale(c,d);r(b);return b}function
 g$(a){return cC(a)}var
 l2=a.caml_pasta_fp_of_bigint;function
-fd(a,h,b,f,d){if(12!=a.kind)c(eb);if(12!=b.kind)c(eb);if(d==0)return 0;var
-e=a.offset(h),g=b.offset(f);if(e+d>a.data.length)u();if(g+d>b.data.length)u();var
-i=a.data.subarray(e,e+d);b.data.set(i,f);return 0}var
+fd(a,h,b,f,c){if(12!=a.kind)d(eb);if(12!=b.kind)d(eb);if(c==0)return 0;var
+e=a.offset(h),g=b.offset(f);if(e+c>a.data.length)u();if(g+c>b.data.length)u();var
+i=a.data.subarray(e,e+c);b.data.set(i,f);return 0}var
 iu=fd;function
 bE(a,i){var
-g=b(0),l=b(1);a=b(a);if(i%2===0&&a.lt(g))c("Z.root: even root of a negative number");if(a.equals(g)||a.equals(l))return j(a);var
+g=b(0),l=b(1);a=b(a);if(i%2===0&&a.lt(g))d("Z.root: even root of a negative number");if(a.equals(g)||a.equals(l))return j(a);var
 f=g,e=a,h=null,m=b(2);while(f.leq(e)){var
-d=f.add(e).divide(m),k=d.pow(i);if(k.equals(a))return j(d);else
-if(k.lt(a)){f=d.next();h=d}else
-e=d.prev()}return j(h)}function
+c=f.add(e).divide(m),k=c.pow(i);if(k.equals(a))return j(c);else
+if(k.lt(a)){f=c.next();h=c}else
+e=c.prev()}return j(h)}function
 ra(a){a=b(a);var
-g=b(0);if(a.lt(g))c("Z.sqrt_rem: square root of a negative number");var
-d=b(bE(a,2)),f=d.multiply(d),e=a.subtract(f);return[0,j(d),j(e)]}var
+g=b(0);if(a.lt(g))d("Z.sqrt_rem: square root of a negative number");var
+c=b(bE(a,2)),f=c.multiply(c),e=a.subtract(f);return[0,j(c),j(e)]}var
 at=2;function
 i0(a){return a[at]===undefined?0:[0,db(a[at])]}function
 k9(a,b,c){return 0}function
@@ -2054,12 +2055,12 @@ hA(f,c,d,g,e){var
 b;for(var
 a=0;a<e;a++){b=n(c,f+a);cg(g,d+a,b)}return 0}function
 kz(){var
-b=d.console?d.console:{},c=["log","debug","info","warn","error","assert","dir","dirxml","trace","group","groupCollapsed","groupEnd","time","timeEnd"];function
+b=c.console?c.console:{},d=["log","debug","info","warn","error","assert","dir","dirxml","trace","group","groupCollapsed","groupEnd","time","timeEnd"];function
 e(){}for(var
-a=0;a<c.length;a++)if(!b[c[a]])b[c[a]]=e;return b}function
+a=0;a<d.length;a++)if(!b[d[a]])b[d[a]]=e;return b}function
 pg(a){return go(a)}function
 hr(a){var
-b=new(d.Uint8Array)(a.buffer,a.byteOffset,a.length*a.BYTES_PER_ELEMENT);return Z(12,0,[b.length],b)}function
+b=new(c.Uint8Array)(a.buffer,a.byteOffset,a.length*a.BYTES_PER_ELEMENT);return Z(12,0,[b.length],b)}function
 ou(a){return Math.round(a)}function
 qW(e){var
 d=b.zero,f=b(Y),a=b.one;for(var
@@ -2094,9 +2095,9 @@ bs(a){if(a<0)a=Math.ceil(a);return new
 f(a&v,Math.floor(a*a$)&v,Math.floor(a*a$*a$)&D)}function
 p4(a,b){return new
 H(a.value-b.value)}function
-fe(b,g,e,f,a){if(12!=b.kind)c(cn);if(a==0)return 0;var
-d=b.offset(g);if(d+a>b.data.length)u();if(f+a>av(e))u();var
-h=b.data.slice(d,d+a);aI(bR(h),0,e,f,a);return 0}var
+fe(b,g,e,f,a){if(12!=b.kind)d(cn);if(a==0)return 0;var
+c=b.offset(g);if(c+a>b.data.length)u();if(f+a>av(e))u();var
+h=b.data.slice(c,c+a);aI(bR(h),0,e,f,a);return 0}var
 iv=fe;function
 m7(){return r(a.caml_pasta_fq_plonk_gate_vector_create())}function
 rk(a,b){return a.data[b]}function
@@ -2118,8 +2119,8 @@ kb(c,a){var
 b=new
 bM(c,typeof
 a=="number"?a:a[0]);return c3(b,a)}function
-iT(c,a){var
-b=k(a);d.console.log("Dynlink: try to open ",b);aM.push({});return aM.length}function
+iT(d,a){var
+b=k(a);c.console.log("Dynlink: try to open ",b);aM.push({});return aM.length}function
 oo(a){return 0}function
 lm(a){aX(a);return h[a].offset}var
 pw=bN;function
@@ -2148,7 +2149,7 @@ gp(){var
 a=new
 Date().getTime();return a*eK-j$}function
 pf(a){return gp()}function
-mO(b,a){return new(d.Uint8Array)(b[a+1])}function
+mO(b,a){return new(c.Uint8Array)(b[a+1])}function
 g6(a){return 0}function
 iF(a,b){if(b>>>0>=a.length-1)u();return a}var
 ig=a.caml_bigint_256_compare;function
@@ -2168,7 +2169,7 @@ qG(a,d,c){a=b(a);return j(a.shiftRight(d).and(b(2).pow(c).subtract(1)))}function
 qQ(a){return j(b(a).not())}var
 nw=a.caml_pasta_fq_rng;function
 lW(b){return b3(a.caml_pasta_fp_is_square(b))}function
-oz(a,b){if(!d.jsoo_static_env)d.jsoo_static_env={};d.jsoo_static_env[a]=b;return 0}function
+oz(a,b){if(!c.jsoo_static_env)c.jsoo_static_env={};c.jsoo_static_env[a]=b;return 0}function
 hO(a,c){if(a.layout==c)return a;var
 d=[];for(var
 b=0;b<a.dims.length;b++)d[b]=a.dims[a.dims.length-b-1];return Z(a.kind,c,d,a.data)}function
@@ -2180,7 +2181,7 @@ a=b9(d);if(b<0)if(a.signedconv){a.sign=-1;b=-b}else
 b>>>=0;var
 c=b.toString(a.base);if(a.prec>=0){a.filler=U;var
 e=a.prec-c.length;if(e>0)c=a0(e,z)+c}return bV(a,c)}function
-lI(b,a){if(a<=0||a+1>b.length)c("Obj.truncate");if(b.length!=a+1)b.length=a+1;return 0}function
+lI(b,a){if(a<=0||a+1>b.length)d("Obj.truncate");if(b.length!=a+1)b.length=a+1;return 0}function
 ow(a){return i(g)}function
 hK(a){var
 c=[0];while(a!==0){var
@@ -2189,11 +2190,11 @@ b=1;b<d.length;b++)c.push(d[b]);a=a[2]}return c}function
 fz(a){R=a;fy();return 0}function
 fx(a,d,c){var
 b=a.getContext(ea);return{context:b,canvas:a,x:0,y:0,width:d,height:c,line_width:1,font:i("fixed"),text_size:26,color:0x000000,title:i(g)}}function
-jT(c){var
-p=d,c=k(c);function
+jT(d){var
+p=c,d=k(d);function
 i(b){var
-a=c.match("(^|,) *"+b+" *= *([a-zA-Z0-9_]+) *(,|$)");if(a)return a[2]}var
-f=[];if(!(c==g))f.push(c);var
+a=d.match("(^|,) *"+b+" *= *([a-zA-Z0-9_]+) *(,|$)");if(a)return a[2]}var
+f=[];if(!(d==g))f.push(d);var
 l=i("target");if(!l)l=g;var
 q=i("status");if(!q)f.push("status=1");var
 b=i("width");b=b?parseInt(b):cz;f.push("width="+b);var
@@ -2248,7 +2249,7 @@ b=b[1];return a.caml_pasta_fp_urs_write(b,d,k(c))}function
 hF(f,g,d,c,e){var
 b;for(var
 a=0;a<e;a++){b=t(g,f+a);aj(c,d+a,b)}return 0}function
-ok(){c("Printexc.get_raw_backtrace_slot: index out of bounds")}var
+ok(){d("Printexc.get_raw_backtrace_slot: index out of bounds")}var
 f5=a.caml_pasta_fp_sub;function
 l0(a,b){bv(a,f5(a,b))}function
 dr(a){return a}function
@@ -2328,20 +2329,20 @@ a=0;a<g;a++){var
 b=b1(n(c,d+a),n(e,f+a));if(b!=0)return b}return 0}function
 pr(a){if(a
 instanceof
-Array)return a;if(d.RangeError&&a
+Array)return a;if(c.RangeError&&a
 instanceof
-d.RangeError&&a.message&&a.message.match(/maximum call stack/i))return dr(l.Stack_overflow);if(d.InternalError&&a
+c.RangeError&&a.message&&a.message.match(/maximum call stack/i))return dr(l.Stack_overflow);if(c.InternalError&&a
 instanceof
-d.InternalError&&a.message&&a.message.match(/too much recursion/i))return dr(l.Stack_overflow);if(a
+c.InternalError&&a.message&&a.message.match(/too much recursion/i))return dr(l.Stack_overflow);if(a
 instanceof
-d.Error&&aw(d$))return[0,aw(d$),a];return[0,l.Failure,T(String(a))]}function
+c.Error&&aw(d$))return[0,aw(d$),a];return[0,l.Failure,T(String(a))]}function
 cV(b,a){var
 b=typeof
 b=="string"?i(b):b,a=typeof
 a=="string"?i(a):a,c=ar(b);if(!c.device.register)e("cannot register file");c.device.register(c.rest,a);return 0}function
 fp(){var
-b=d.caml_fs_tmp;if(b)for(var
-a=0;a<b.length;a++)cV(b[a].name,b[a].content);d.caml_create_file=cV;d.caml_fs_tmp=[];return 0}var
+b=c.caml_fs_tmp;if(b)for(var
+a=0;a<b.length;a++)cV(b[a].name,b[a].content);c.caml_create_file=cV;c.caml_fs_tmp=[];return 0}var
 hg=c2;function
 oT(b){var
 a=ar(b);if(a.device.exists(a.rest)){if(a.rest)aE=a.path+a.rest+O;else
@@ -2378,8 +2379,8 @@ h=gZ(e,f+a-1);dO(e,f,a,a2([0]),0,h);dO(b,c,j,a2([0]),0,h);var
 k=(e.data[f+a-1]>>>0)+1,i=gy(a+1);for(var
 d=j-1;d>=a;d--){var
 g=k==eP?b.data[c+d]>>>0:dA(b.data[c+d]>>>0,b.data[c+d-1]>>>0,k)[0];g1(i,0,a+1);dN(i,0,a+1,e,f,a,a2([g]),0);dR(b,c+d-a,a+1,i,0,a+1,1);while(b.data[c+d]!=0||dz(b,c+d-a,a,e,f,a)>=0){g=g+1;dR(b,c+d-a,a+1,e,f,a,1)}b.data[c+d]=g}dP(b,c,a,a2([0]),0,h);dP(e,f,a,a2([0]),0,h);return 0}function
-hN(d,a){if(a.dims.length!=d.dims.length)c(d8);for(var
-b=0;b<a.dims.length;b++)if(a.dims[b]!=d.dims[b])c(d8);a.data.set(d.data);return 0}function
+hN(c,a){if(a.dims.length!=c.dims.length)d(d8);for(var
+b=0;b<a.dims.length;b++)if(a.dims[b]!=c.dims[b])d(d8);a.data.set(c.data);return 0}function
 qt(a,b){if(a.data[b]>=0)return 1;return 0}function
 gG(a){return a.value}function
 hn(c,d,a,b){while(b>0){if(n(c,a)==d)return a;a++;b--}return-1}function
@@ -2399,17 +2400,17 @@ switch(b[0]){case
 0:c[a]=[0];for(var
 d=1;d<b[1].length;d++)e(b[1][d],c[a],d);break;default:c[a]=b[1]}}var
 a=[];e(c,a,0);return a[0]}function
-kk(){c("Meta.invoke_traced_function")}function
+kk(){d("Meta.invoke_traced_function")}function
 qc(a){return an(a)}function
 nK(b,d){if(b===0)b=undefined;else
 b=b[1];var
 c=a.caml_pasta_fq_urs_read(b,k(d));return c?[0,c]:0}function
 qU(a){return j(b(a).negate())}function
 h2(b,e){e=aa(e);var
-d=[],f=e.length;if(f<0||f>16)c("Bigarray.reshape: bad number of dimensions");var
+c=[],f=e.length;if(f<0||f>16)d("Bigarray.reshape: bad number of dimensions");var
 g=1;for(var
-a=0;a<f;a++){d[a]=e[a];if(d[a]<0)c("Bigarray.reshape: negative dimension");g=g*d[a]}var
-h=aS(b.dims);if(g!=h)c("Bigarray.reshape: size mismatch");return Z(b.kind,b.layout,d,b.data)}function
+a=0;a<f;a++){c[a]=e[a];if(c[a]<0)d("Bigarray.reshape: negative dimension");g=g*c[a]}var
+h=aS(b.dims);if(g!=h)d("Bigarray.reshape: size mismatch");return Z(b.kind,b.layout,c,b.data)}function
 pN(d,c,b){dB=h[b];dC=h[c];var
 a=h[d];h[c]=a;h[b]=a;return 0}function
 ox(a){a[2]=dc++;return a}function
@@ -2504,9 +2505,9 @@ d=bO(e,i+a),c=ao(aK(d));for(var
 b=0;b<8;b++)aj(f,g+b+a*8,c[7-b])}return 0}function
 nF(f,b,c){var
 d=C(b,F,a.caml_pasta_pallas_affine_one),e=K(c);return a.caml_pasta_fq_urs_batch_accumulator_check(f,d,e)}function
-is(f,d,a,g,b){if(12!=a.kind)c(cn);if(b==0)return 0;var
-e=a.offset(g);if(d+b>av(f))u();if(e+b>a.data.length)u();var
-h=bm(f).slice(d,d+b);a.data.set(h,e);return 0}function
+is(f,c,a,g,b){if(12!=a.kind)d(cn);if(b==0)return 0;var
+e=a.offset(g);if(c+b>av(f))u();if(e+b>a.data.length)u();var
+h=bm(f).slice(c,c+b);a.data.set(h,e);return 0}function
 hb(e,b){var
 c=1,a=[c,e,c,c],d=c;while(!b==0){a[1]=a[1]*a[3]|0;a[2]=a[1]*a[1]|0;a[3]=a[2]*a[1]|0;d=d*a[b&3]|0;b=b>>2}return d}function
 qv(a,b){if(a.data[b]==0)return 1;return 0}function
@@ -2520,16 +2521,16 @@ b;for(var
 a=0;a<e;a++){b=t(g,f+a);aj(c,d+a,b)}return 0}function
 c7(a,b){return a.sub(b)}function
 cF(b){var
-a=new(d.Uint8Array)(b);return Z(12,0,[a.length],a)}function
+a=new(c.Uint8Array)(b);return Z(12,0,[a.length],a)}function
 hC(i,g,e,c,f){var
 h=cF(g.data.buffer),d=cF(c.data.buffer),b;for(var
 a=0;a<f;a++){b=n(h,i+a);aj(d,e+a,b)}return 0}function
 fK(b,a){return b.shift_left(a)}function
 oW(){return 32}function
-bQ(b,a){if(a<0||a>=b.dims.length)c("Bigarray.dim");return b.dims[a]}function
+bQ(b,a){if(a<0||a>=b.dims.length)d("Bigarray.dim");return b.dims[a]}function
 hP(a){return bQ(a,0)}function
-q$(d){var
-a=b(d),e=b(0);if(a.lt(e))c("Z.sqrt: square root of a negative number");return bE(a,2)}function
+q$(c){var
+a=b(c),e=b(0);if(a.lt(e))d("Z.sqrt: square root of a negative number");return bE(a,2)}function
 kK(a){return i(a)}function
 q6(c,a){return b(c).isProbablePrime(a)?1:0}function
 rx(a){var
@@ -2589,12 +2590,12 @@ c=a.caml_pasta_fp_to_bytes(b);return bS(a.caml_pasta_fp_to_bytes(b))}function
 pQ(a){return 4}function
 kw(a){return k(a)}function
 h7(a,e,g){var
-f,d=1;if(a.layout==0){for(var
-b=1;b<a.dims.length;b++)d=d*a.dims[b];f=0}else{for(var
-b=0;b<a.dims.length-1;b++)d=d*a.dims[b];f=a.dims.length-1;e=e-1}if(e<0||g<0||e+g>a.dims[f])c("Bigarray.sub: bad sub-array");var
+f,c=1;if(a.layout==0){for(var
+b=1;b<a.dims.length;b++)c=c*a.dims[b];f=0}else{for(var
+b=0;b<a.dims.length-1;b++)c=c*a.dims[b];f=a.dims.length-1;e=e-1}if(e<0||g<0||e+g>a.dims[f])d("Bigarray.sub: bad sub-array");var
 h=[];for(var
-b=0;b<a.dims.length;b++)h[b]=a.dims[b];h[f]=g;d*=a_(a.kind);var
-i=a.data.subarray(e*d,(e+g)*d);return Z(a.kind,a.layout,h,i)}var
+b=0;b<a.dims.length;b++)h[b]=a.dims[b];h[f]=g;c*=a_(a.kind);var
+i=a.data.subarray(e*c,(e+g)*c);return Z(a.kind,a.layout,h,i)}var
 ma=a.caml_pasta_fp_plonk_index_domain_d4_size;function
 jl(){return 0}function
 fj(b,a,c){if(a>>>0>=b.l-3)aD();var
@@ -2623,7 +2624,7 @@ a=0;a<d;a++)aj(b,e+a,c)}var
 nb=a.caml_pasta_fq_plonk_index_domain_d8_size,my=a.caml_pasta_fp_size_in_bits;function
 iZ(a){return a[at]===undefined?0:[0,a[at]]}function
 ps(b){var
-a=d;if(typeof
+a=c;if(typeof
 a.XMLHttpRequest!=="undefined")try{return new(a.XMLHttpRequest)()}catch(a){}if(typeof
 a.activeXObject!=="undefined"){try{return new(a.activeXObject)("Msxml2.XMLHTTP")}catch(a){}try{return new(a.activeXObject)("Msxml3.XMLHTTP")}catch(a){}try{return new(a.activeXObject)("Microsoft.XMLHTTP")}catch(a){}}e("Cannot create a XMLHttpRequest")}function
 fo(b){return new(a.WasmPastaFqPlonkGate)(b[1],dp(b[2]),a1(b[3]))}function
@@ -2652,8 +2653,8 @@ i=de(h),g=i[0],k=i[1],c=i[2],j=an(c),l=new
 f(v,0xfffffff,D).udivmod(j).quotient,d=t(h,g),a=bc(d);if(a<0||a>=c)e(ac);var
 b=an(a);for(;;){g++;d=t(h,g);if(d==95)continue;a=bc(d);if(a<0||a>=c)break;if(bb(l,b))e(ac);a=an(a);b=bq(au(j,b),a);if(bb(b,a))e(ac)}if(g!=y(h))e(ac);if(c==10&&bb(new
 f(0,0,ad),b))e(ac);if(k<0)b=br(b);return b}function
-ro(e,b,a){if(a<0||a>y(b))c("Str.search_forward");while(a<=y(b)){var
-d=bG(e,b,a,0);if(d)return d;a++}return[0]}function
+ro(e,b,a){if(a<0||a>y(b))d("Str.search_forward");while(a<=y(b)){var
+c=bG(e,b,a,0);if(c)return c;a++}return[0]}function
 lp(b,c){var
 a=h[b];if(a.refill!=null)o(eF);a.offset=c;return 0}function
 pb(e){var
@@ -2671,8 +2672,8 @@ m9(b,c,d){return a.caml_pasta_fq_plonk_gate_vector_wrap(b,aL(c),aL(d))}function
 iU(b,a){a[at]=b[at];return 0}function
 pG(){return 0}function
 km(a){return+(a>31&&a<cr)}function
-rl(e,d,a){if(a<0||a>y(d))c("Str.partial_match");var
-b=bG(e,d,a,1);return b?b:[0]}function
+rl(e,c,a){if(a<0||a>y(c))d("Str.partial_match");var
+b=bG(e,c,a,1);return b?b:[0]}function
 pa(){var
 a=new
 Date().getTime(),b=a^0xffffffff*Math.random();return[0,b]}function
@@ -2686,10 +2687,10 @@ b=a.caml_pasta_pallas_random();r(b);return b}function
 iq(b){return bS(a.caml_bigint_256_to_bytes(b))}function
 pz(){return 0}function
 h6(b,f){f=aa(f);var
-d=f.length,e=[],g=[],h;if(d>b.dims.length)c("Bigarray.slice: too many indices");if(b.layout==0){for(var
-a=0;a<d;a++)e[a]=f[a];for(;a<b.dims.length;a++)e[a]=0;g=b.dims.slice(d)}else{for(var
-a=0;a<d;a++)e[b.dims.length-d+a]=f[a];for(var
-a=0;a<b.dims.length-d;a++)e[a]=1;g=b.dims.slice(0,b.dims.length-d)}h=b.offset(e);var
+c=f.length,e=[],g=[],h;if(c>b.dims.length)d("Bigarray.slice: too many indices");if(b.layout==0){for(var
+a=0;a<c;a++)e[a]=f[a];for(;a<b.dims.length;a++)e[a]=0;g=b.dims.slice(c)}else{for(var
+a=0;a<c;a++)e[b.dims.length-c+a]=f[a];for(var
+a=0;a<b.dims.length-c;a++)e[a]=1;g=b.dims.slice(0,b.dims.length-c)}h=b.offset(e);var
 k=aS(g),i=a_(b.kind),j=b.data.subarray(h*i,(h+k)*i);return Z(b.kind,b.layout,g,j)}function
 q0(a){return dL(a)}var
 n8=a.caml_pasta_vesta_endo_scalar;function
@@ -2701,7 +2702,7 @@ f=b(0),h=b(1);e=b(e);d=b(d);c=b(c);if(c.equals(f))S();if(c.abs().equals(h))retur
 g=b(gR(e,c)),a=g.modPow(d.negate(),c);if(a.lt(f))a=a.add(c.abs());return j(a)}else{var
 a=b(e).modPow(d,c);if(a.lt(f))a=a.add(c.abs());return j(a)}}function
 q4(f,e,a){a=b(a).abs();var
-d=b(1);if(b(e).lt(d))c("Z.powm_sec: exponent must be positive");if(!b(a).and(d).equals(d))c("Z.powm_sec: modulus must be odd");return gV(f,e,a)}function
+c=b(1);if(b(e).lt(c))d("Z.powm_sec: exponent must be positive");if(!b(a).and(c).equals(c))d("Z.powm_sec: modulus must be odd");return gV(f,e,a)}function
 kH(a){return a()}var
 px=bN;function
 pt(a,c,b,d){if(a.data[c]>b.data[d])return 1;if(a.data[c]<b.data[d])return-1;return 0}function
@@ -2758,11 +2759,11 @@ rg(a){return dM(a)}function
 hz(c,d,f,g,e){for(var
 a=0;a<e;a++){var
 b=b1(n(c,d+a),t(f,g+a));if(b!=0)return b}return 0}function
-X(b,c,a){if(a&&d.toplevelReloc)b=d.toplevelReloc(a);l[b+1]=c;if(a)l[a]=c}function
+X(b,d,a){if(a&&c.toplevelReloc)b=c.toplevelReloc(a);l[b+1]=d;if(a)l[a]=d}function
 pJ(c,d,a,e){var
 b=M(a);e7(c,d,b,0,a);var
 f=c_(b,0,a);cM(f,0,e,0,16);return 0}function
-or(a,c,b){if(d.toplevelCompile)return[0,0,d.toplevelCompile(a)];else
+or(a,d,b){if(c.toplevelCompile)return[0,0,c.toplevelCompile(a)];else
 e("Toplevel not initialized (toplevelCompile)")}function
 je(a){if(a<0)u();var
 a=a+1|0,b=new
@@ -2808,7 +2809,7 @@ Array(b),e=Math.min(arguments.length,b);for(var
 a=0;a<e;a++)d[a]=arguments[a];return al(c,d)}}function
 qw(a,c,b,d){a.data[c]&=b.data[d];return 0}function
 kg(a,b){return a.mod(b)}function
-iM(b,a){if(d.caml_create_file)d.caml_create_file(b,a);else{if(!d.caml_fs_tmp)d.caml_fs_tmp=[];d.caml_fs_tmp.push({name:b,content:a})}return 0}function
+iM(b,a){if(c.caml_create_file)c.caml_create_file(b,a);else{if(!c.caml_fs_tmp)c.caml_fs_tmp=[];c.caml_fs_tmp.push({name:b,content:a})}return 0}function
 kd(a){return(a&0x000000FF)<<24|(a&0x0000FF00)<<8|(a&0x00FF0000)>>>8|(a&0xFF000000)>>>24}function
 rB(){}function
 mP(a){return a.length-1}function
@@ -2841,8 +2842,8 @@ qr(a){return 4}function
 ll(a){return bs(h[a].offset)}function
 jK(a,f,g){var
 b=q();if(!a.image){var
-c=document.createElement(d2);c.width=b.width;c.height=b.height;c.getContext(ea).putImageData(a,0,0);var
-e=new(d.Image)();e.onload=function(){b.context.drawImage(e,f,b.height-a.height-g);a.image=e};e.src=c.toDataURL("image/png")}else
+d=document.createElement(d2);d.width=b.width;d.height=b.height;d.getContext(ea).putImageData(a,0,0);var
+e=new(c.Image)();e.onload=function(){b.context.drawImage(e,f,b.height-a.height-g);a.image=e};e.src=d.toDataURL("image/png")}else
 b.context.drawImage(a.image,f,b.height-a.height-g);return 0}function
 oO(b,a,c){if(a>>>0>=b.l)bg();return cg(b,a,c)}function
 p1(b,a){if(a.value==0)S();return new
@@ -2895,7 +2896,7 @@ a=="function")return 247;else
 if(a&&a.caml_custom)return aO;else
 return V}function
 ks(){return typeof
-module!=="undefined"&&module&&module.exports?module.exports:d}function
+module!=="undefined"&&module&&module.exports?module.exports:c}function
 iz(b,a){if(a>>>0>=b.l-3)aD();var
 c=I(b,a),d=I(b,a+1),e=I(b,a+2),f=I(b,a+3);return f<<24|e<<16|d<<8|c}function
 pB(){return 0}function
@@ -2949,7 +2950,7 @@ a=0;a<c.data.length;a+=4){b.data[a]=c.data[a];b.data[a+1]=c.data[a+1];b.data[a+2
 j5(a){e("caml_gr_window_id not Implemented")}var
 ie=a.caml_bigint_256_bytes_per_limb;function
 kG(){var
-a=d.navigator?d.navigator.userAgent:g;return a.indexOf("MSIE")!=-1&&a.indexOf("Opera")!=0}function
+a=c.navigator?c.navigator.userAgent:g;return a.indexOf("MSIE")!=-1&&a.indexOf("Opera")!=0}function
 nL(b,d,c){if(b===0)b=undefined;else
 b=b[1];return a.caml_pasta_fq_urs_write(b,d,k(c))}function
 hZ(a){return a.layout}function
@@ -3029,4 +3030,4 @@ lv(b,c){var
 a=h[b];l.fds[a.fd].output=c;return 0}function
 nj(e,c,d){var
 f=e.length,g=new(a.WasmVecVecPallasPolyComm)(f-1);for(var
-b=1;b<f;b++)g.push(C(e[b],ay));c=C(c,bf);d=C(d,bz);return a.caml_pasta_fq_plonk_proof_batch_verify(g,c,d)}d.jsoo_runtime={integers_uint64_compare:gJ,integers_uint32_compare:gE,integers_uint32_hash:gG,integers_uint32_deserialize:gF,integers_uint16_deserialize:gD,integers_uint8_deserialize:gK,integers_uint32_serialize:gI,integers_ushort_size:qr,integers_unsigned_init:qq,integers_ulonglong_size:qp,integers_ulong_size:qo,integers_uint_size:qn,integers_uint8_of_string:qm,integers_uint64_to_string:ql,integers_uint64_to_int64:qk,integers_uint64_to_int:qj,integers_uint64_sub:qi,integers_uint64_shift_right:qh,integers_uint64_shift_left:qg,integers_uint64_rem:qf,integers_uint64_of_string:qe,integers_uint_of_string:dH,integers_uint64_of_int64:qd,integers_uint64_of_int:qc,integers_uint64_mul:qb,integers_uint64_max:qa,integers_uint64_logxor:p$,integers_uint64_logor:p_,integers_uint64_logand:p9,integers_uint64_div:p8,integers_uint64_add:p7,integers_uint32_to_string:p6,integers_uint32_to_int64:dG,integers_uint32_to_int:p5,integers_uint32_shift_right:p3,integers_uint32_shift_left:p2,integers_uint32_rem:p1,integers_uint32_of_string:dF,integers_uint32_of_int64:gH,integers_uint32_of_int32:p0,integers_uint32_of_int:pZ,integers_uint32_mul:pY,integers_uint32_max:pX,integers_uint32_logxor:pW,integers_uint32_logor:pV,integers_uint32_logand:pU,integers_uint32_div:pT,integers_uint32_sub:p4,integers_uint32_add:pS,integers_uint16_of_string:pR,integers_size_t_size:pQ,integers_int32_of_uint32:pP,UInt32:H,plonk_wasm:a,startWorkers:dQ,wasm_ready:g4,_workers:e6,worker_threads:a3,caml_pasta_fq_plonk_oracles_deep_copy:nh,caml_pasta_fq_plonk_oracles_dummy:ni,caml_pasta_fq_plonk_oracles_create:ng,caml_pasta_fp_plonk_oracles_deep_copy:mh,caml_pasta_fp_plonk_oracles_dummy:mi,caml_pasta_fp_plonk_oracles_create:mg,caml_oracles_to_rust:dd,caml_oracles_of_rust:aY,caml_random_oracles_to_rust:gk,caml_random_oracles_of_rust:gj,caml_pasta_fq_plonk_proof_deep_copy:nl,caml_pasta_fq_plonk_proof_dummy:nm,caml_pasta_fq_plonk_proof_batch_verify:nj,caml_pasta_fq_plonk_proof_verify:nn,caml_pasta_fq_plonk_proof_create:nk,caml_pasta_fq_proof_of_rust:b$,caml_pasta_fq_proof_to_rust:bz,caml_pasta_fq_messages_of_rust:f7,caml_pasta_fq_messages_to_rust:f8,caml_pasta_fq_opening_proof_of_rust:f_,caml_pasta_fq_opening_proof_to_rust:f$,caml_pasta_fq_proof_evaluations_of_rust:dj,caml_pasta_fq_proof_evaluations_to_rust:dk,caml_pasta_fp_plonk_proof_deep_copy:ml,caml_pasta_fp_plonk_proof_dummy:mm,caml_pasta_fp_plonk_proof_batch_verify:mj,caml_pasta_fp_plonk_proof_verify:mn,caml_pasta_fp_plonk_proof_create:mk,caml_pasta_fp_proof_of_rust:b_,caml_pasta_fp_proof_to_rust:bw,caml_pasta_fp_messages_of_rust:fZ,caml_pasta_fp_messages_to_rust:f0,caml_pasta_fp_opening_proof_of_rust:f2,caml_pasta_fp_opening_proof_to_rust:f3,caml_pasta_fp_proof_evaluations_of_rust:dg,caml_pasta_fp_proof_evaluations_to_rust:dh,caml_pasta_fq_plonk_verifier_index_deep_copy:np,caml_pasta_fq_plonk_verifier_index_dummy:nq,caml_pasta_fq_plonk_verifier_index_shifts:ns,caml_pasta_fq_plonk_verifier_index_write:nt,caml_pasta_fq_plonk_verifier_index_read:nr,caml_pasta_fq_plonk_verifier_index_create:no,caml_pasta_fq_plonk_verifier_index_to_rust:bf,caml_pasta_fq_plonk_verifier_index_of_rust:by,caml_pasta_fp_plonk_verifier_index_deep_copy:mp,caml_pasta_fp_plonk_verifier_index_dummy:mq,caml_pasta_fp_plonk_verifier_index_shifts:ms,caml_pasta_fp_plonk_verifier_index_write:mt,caml_pasta_fp_plonk_verifier_index_read:mr,caml_pasta_fp_plonk_verifier_index_create:mo,caml_pasta_fp_plonk_verifier_index_to_rust:be,caml_pasta_fp_plonk_verifier_index_of_rust:bd,caml_plonk_verifier_index_to_rust:dn,caml_plonk_verifier_index_of_rust:dm,caml_plonk_verification_shifts_to_rust:gg,caml_plonk_verification_shifts_of_rust:ca,caml_plonk_verification_evals_to_rust:gf,caml_plonk_verification_evals_of_rust:ge,caml_plonk_domain_to_rust:gd,caml_plonk_domain_of_rust:gc,caml_pasta_fq_plonk_index_write:nf,caml_pasta_fq_plonk_index_read:ne,caml_pasta_fq_plonk_index_domain_d8_size:nb,caml_pasta_fq_plonk_index_domain_d4_size:na,caml_pasta_fq_plonk_index_domain_d1_size:m$,caml_pasta_fq_plonk_index_public_inputs:nd,caml_pasta_fq_plonk_index_max_degree:nc,caml_pasta_fq_plonk_index_create:m_,caml_pasta_fp_plonk_index_write:mf,caml_pasta_fp_plonk_index_read:me,caml_pasta_fp_plonk_index_domain_d8_size:mb,caml_pasta_fp_plonk_index_domain_d4_size:ma,caml_pasta_fp_plonk_index_domain_d1_size:l$,caml_pasta_fp_plonk_index_public_inputs:md,caml_pasta_fp_plonk_index_max_degree:mc,caml_pasta_fp_plonk_index_create:l_,caml_pasta_fq_plonk_gate_vector_wrap:m9,caml_pasta_fq_plonk_gate_vector_get:m8,caml_pasta_fq_plonk_gate_vector_add:m6,caml_pasta_fq_plonk_gate_vector_create:m7,caml_pasta_fp_plonk_gate_vector_wrap:l9,caml_pasta_fp_plonk_gate_vector_get:l8,caml_pasta_fp_plonk_gate_vector_add:l6,caml_pasta_fp_plonk_gate_vector_create:l7,caml_fq_plonk_gate_to_rust:fo,caml_fp_plonk_gate_to_rust:fn,caml_plonk_gate_of_rust:dl,caml_plonk_wires_to_rust:dp,caml_plonk_wires_of_rust:gh,caml_plonk_wire_to_rust:aL,caml_plonk_wire_of_rust:cb,caml_pasta_fq_urs_h:nI,caml_pasta_fq_urs_batch_accumulator_check:nF,caml_pasta_fq_urs_b_poly_commitment:nE,caml_pasta_fq_urs_commit_evaluations:nG,caml_pasta_fq_urs_lagrange_commitment:nJ,caml_pasta_fq_urs_read:nK,caml_pasta_fq_urs_write:nL,caml_pasta_fq_urs_create:nH,caml_pasta_fp_urs_h:mI,caml_pasta_fp_urs_batch_accumulator_check:mF,caml_pasta_fp_urs_b_poly_commitment:mE,caml_pasta_fp_urs_commit_evaluations:mG,caml_pasta_fp_urs_lagrange_commitment:mJ,caml_pasta_fp_urs_read:mK,caml_pasta_fp_urs_write:mL,caml_pasta_fp_urs_create:mH,caml_pasta_pallas_poly_comm_to_rust:ay,caml_pasta_pallas_poly_comm_of_rust:ax,caml_pasta_vesta_poly_comm_to_rust:aA,caml_pasta_vesta_poly_comm_of_rust:az,caml_poly_comm_to_rust_poly_comm:cd,caml_poly_comm_of_rust_poly_comm:cc,caml_array_to_rust_vector:C,caml_array_of_rust_vector:bP,caml_pasta_vesta_affine_deep_copy:n5,caml_pasta_vesta_endo_scalar:n8,caml_pasta_vesta_endo_base:n7,caml_pasta_vesta_of_affine_coordinates:n$,caml_pasta_vesta_of_affine:n_,caml_pasta_vesta_to_affine:of,caml_pasta_vesta_rng:oc,caml_pasta_vesta_random:ob,caml_pasta_vesta_scale:od,caml_pasta_vesta_double:n6,caml_pasta_vesta_negate:n9,caml_pasta_vesta_sub:oe,caml_pasta_vesta_add:n4,caml_pasta_vesta_one:oa,caml_pasta_pallas_affine_deep_copy:nR,caml_pasta_pallas_endo_scalar:nU,caml_pasta_pallas_endo_base:nT,caml_pasta_pallas_of_affine_coordinates:nX,caml_pasta_pallas_of_affine:nW,caml_pasta_pallas_to_affine:n3,caml_pasta_pallas_rng:n0,caml_pasta_pallas_random:nZ,caml_pasta_pallas_scale:n1,caml_pasta_pallas_double:nS,caml_pasta_pallas_negate:nV,caml_pasta_pallas_sub:n2,caml_pasta_pallas_add:nQ,caml_pasta_pallas_one:nY,rust_affine_of_caml_affine:F,rust_affine_to_caml_affine:N,free_on_finalize:r,free_finalization_registry:dD,caml_pasta_fq_vector_of_rust:aq,caml_pasta_fq_vector_to_rust:K,caml_pasta_fq_vector_get:nO,caml_pasta_fq_vector_emplace_back:nN,caml_pasta_fq_vector_length:nP,caml_pasta_fq_vector_create:nM,caml_pasta_fp_vector_of_rust:ap,caml_pasta_fp_vector_to_rust:J,caml_pasta_fp_vector_get:mO,caml_pasta_fp_vector_emplace_back:mN,caml_pasta_fp_vector_length:mP,caml_pasta_fp_vector_create:mM,js_class_vector_of_rust_vector:cj,js_class_vector_to_rust_vector:ck,caml_u8array_vector_of_rust_flat_vector:bi,caml_u8array_vector_to_rust_flat_vector:a1,caml_pasta_fq_deep_copy:mR,caml_pasta_fq_of_bytes:m3,caml_pasta_fq_to_bytes:nB,caml_pasta_fq_domain_generator:mT,caml_pasta_fq_two_adic_root_of_unity:nD,caml_pasta_fq_of_bigint:m2,caml_pasta_fq_to_bigint:nA,caml_pasta_fq_rng:nw,caml_pasta_fq_random:nv,caml_pasta_fq_equal:mU,caml_pasta_fq_compare:mQ,caml_pasta_fq_mut_square:mZ,caml_pasta_fq_mut_mul:mY,caml_pasta_fq_mut_sub:m0,caml_pasta_fq_mut_add:mX,caml_pasta_fq_print:nu,caml_pasta_fq_of_string:m5,caml_pasta_fq_to_string:nC,caml_pasta_fq_of_int:m4,caml_pasta_fq_sqrt:nz,caml_pasta_fq_is_square:mW,caml_pasta_fq_square:ga,caml_pasta_fq_inv:mV,caml_pasta_fq_div:mS,caml_pasta_fq_mul:f9,caml_pasta_fq_negate:m1,caml_pasta_fq_sub:gb,caml_pasta_fq_add:f6,caml_pasta_fq_size:nx,caml_pasta_fq_size_in_bits:ny,caml_pasta_fq_option:di,caml_pasta_fq_copy:bx,caml_pasta_fp_deep_copy:lR,caml_pasta_fp_of_bytes:l3,caml_pasta_fp_to_bytes:mB,caml_pasta_fp_domain_generator:lT,caml_pasta_fp_two_adic_root_of_unity:mD,caml_pasta_fp_of_bigint:l2,caml_pasta_fp_to_bigint:mA,caml_pasta_fp_rng:mw,caml_pasta_fp_random:mv,caml_pasta_fp_equal:lU,caml_pasta_fp_compare:lQ,caml_pasta_fp_mut_square:lZ,caml_pasta_fp_mut_mul:lY,caml_pasta_fp_mut_sub:l0,caml_pasta_fp_mut_add:lX,caml_pasta_fp_print:mu,caml_pasta_fp_of_string:l5,caml_pasta_fp_to_string:mC,caml_pasta_fp_of_int:l4,caml_pasta_fp_sqrt:mz,caml_pasta_fp_is_square:lW,caml_pasta_fp_square:f4,caml_pasta_fp_inv:lV,caml_pasta_fp_div:lS,caml_pasta_fp_mul:f1,caml_pasta_fp_negate:l1,caml_pasta_fp_sub:f5,caml_pasta_fp_add:fY,caml_pasta_fp_size:mx,caml_pasta_fp_size_in_bits:my,caml_pasta_fp_option:df,caml_pasta_fp_copy:bv,caml_bigint_256_deep_copy:ih,caml_bigint_256_of_bytes:ik,caml_bigint_256_to_bytes:iq,caml_bigint_256_test_bit:ip,caml_bigint_256_to_string:ir,caml_bigint_256_print:io,caml_bigint_256_compare:ig,caml_bigint_256_div:ii,caml_bigint_256_bytes_per_limb:ie,caml_bigint_256_num_limbs:ij,caml_bigint_256_of_decimal_string:il,caml_bigint_256_of_numeral:im,caml_bytes_to_uint8array:bT,caml_bytes_of_uint8array:bS,bigstringaf_memcmp_string:hz,bigstringaf_memcmp_bigstring:hy,bigstringaf_blit_from_bytes:hv,bigstringaf_blit_to_bigstring:hw,bigstringaf_blit_to_bytes:hx,caml_zarith_unmarshal:gx,caml_zarith_marshal:gw,ml_z_divexact:qE,ml_z_size:q_,ml_z_hamdist:qM,ml_z_popcount:gT,ml_z_trailing_zeros:rh,ml_z_sqrt_rem:ra,ml_z_sqrt:q$,ml_z_gcdext_intern:gP,ml_z_extract:qG,ml_z_nextprime:qV,ml_z_probab_prime:q6,ml_z_perfect_square:q3,ml_z_perfect_power:q2,ml_z_invert:gR,ml_z_root:bE,ml_z_powm_sec:q4,ml_z_of_bits:qW,ml_z_to_bits:rd,ml_z_hash:gQ,ml_z_pow:gU,ml_z_powm:gV,ml_z_fits_nativeint:qJ,ml_z_fits_int64:gO,ml_z_fits_int32:qI,ml_z_fits_int:dK,ml_z_numbits:gS,ml_z_gcd:qL,ml_z_sign:bF,ml_z_equal:qF,ml_z_compare:qC,ml_z_of_substring_base:q1,jsoo_z_of_js_string_base:gM,ml_z_format:qK,ml_z_to_nativeint:rg,ml_z_testbit:rc,ml_z_to_int64:rf,ml_z_to_int32:re,ml_z_to_int:dM,ml_z_of_float:qX,ml_z_of_int64:qZ,ml_z_of_nativeint:q0,ml_z_of_int32:qY,ml_z_of_int:dL,ml_z_shift_right_trunc:q9,ml_z_shift_right:q8,ml_z_shift_left:q7,ml_z_lognot:qQ,ml_z_logxor:qS,ml_z_logor:qR,ml_z_logand:qP,ml_z_abs:qA,ml_z_pred:q5,ml_z_succ:rb,ml_z_div_rem:qD,ml_z_rem:gW,ml_z_fdiv:qH,ml_z_cdiv:qB,ml_z_div:aN,ml_z_mul:qT,ml_z_sub:gX,ml_z_add:gN,ml_z_neg:qU,ml_z_install_frametable:qO,ml_z_init:qN,ml_z_normalize:j,bigInt:b,bigstring_realloc:hs,bigstring_destroy_stub:e8,core_md5_digest_subbigstring:pJ,core_md5_fd:pK,Core_kernel_heap_block_is_heap_block:hi,core_kernel_gc_top_heap_words:pH,core_kernel_gc_promoted_words:pG,core_kernel_gc_minor_words:pF,core_kernel_gc_minor_collections:pE,core_kernel_gc_major_words:pD,core_kernel_gc_major_plus_minor_words:pC,core_kernel_gc_major_collections:pB,core_kernel_gc_heap_words:pA,core_kernel_gc_heap_chunks:pz,core_kernel_gc_compactions:py,core_kernel_time_ns_format:pI,core_array_unsafe_float_blit:pw,core_array_unsafe_int_blit:px,bigstring_find:hn,internalhash_fold_bigstring:qs,bigstring_memcmp_stub:hp,bigstring_memset_stub:hq,bigstring_blit_string_bigstring_stub:hl,bigstring_blit_bigstring_bytes_stub:e7,bigstring_blit_bytes_bigstring_stub:hk,bigstring_blit_stub:hm,bigstring_is_mmapped_stub:ho,bigstring_alloc:hj,caml_out_channel_pos_fd:lL,expect_test_collector_after_test:pM,expect_test_collector_before_test:pN,expect_test_collector_saved_stderr:dB,expect_test_collector_saved_stdout:dC,time_now_nanoseconds_since_unix_epoch_or_zero:rt,bin_prot_blit_buf_stub:hC,bin_prot_blit_bytes_buf_stub:hD,bin_prot_blit_string_buf_stub:hF,bin_prot_blit_float_array_buf_stub:hE,bin_prot_blit_buf_bytes_stub:hA,bin_prot_blit_buf_float_array_stub:hB,Base_am_testing:g5,Base_hash_double:g7,Base_hash_string:g8,Base_int_math_int64_pow_stub:g_,Base_int_math_int_pow_stub:hb,Base_int_math_int64_clz:g9,Base_int_math_nativeint_clz:hc,Base_int_math_int_clz:g$,Base_int_math_int32_clz:cC,Base_clear_caml_backtrace_pos:g6,Base_int_math_int_popcount:ha,Base_internalhash_get_hash_value:hh,Base_internalhash_fold_string:hg,Base_internalhash_fold_float:hd,Base_internalhash_fold_int:he,Base_internalhash_fold_int64:hf,caml_remove_debug_info:os,caml_add_debug_info:hI,caml_register_code_fragment:op,caml_dynlink_get_current_libs:iR,caml_dynlink_add_primitive:iP,caml_dynlink_lookup_symbol:iS,caml_dynlink_close_lib:iQ,caml_dynlink_open_lib:iT,current_libs:aM,caml_realloc_global:om,caml_static_free:oF,caml_static_alloc:oE,caml_static_release_bytecode:oG,caml_reify_bytecode:or,caml_get_section_table:jy,caml_get_current_environment:jt,caml_invoke_traced_function:kk,caml_terminfo_rows:pk,caml_terminfo_resume:pj,caml_terminfo_standout:pm,caml_terminfo_backup:pi,caml_terminfo_setup:pl,caml_ephe_check_data:iW,caml_ephe_unset_data:i5,caml_ephe_set_data:i3,caml_ephe_get_data_copy:i0,caml_ephe_get_data:iZ,caml_ephe_blit_data:iU,caml_ephe_unset_key:i6,caml_ephe_set_key:i4,caml_ephe_check_key:iX,caml_ephe_get_key_copy:i2,caml_ephe_get_key:i1,caml_ephe_blit_key:iV,caml_ephe_create:iY,caml_weak_blit:gs,caml_weak_check:gt,caml_weak_get_copy:gv,caml_weak_get:dx,caml_weak_set:dy,caml_weak_create:gu,caml_ephe_data_offset:at,caml_ephe_key_offset:_,unix_isatty:rw,win_handle_fd:rA,win_cleanup:rz,win_startup:rB,unix_mktime:rx,unix_localtime:g3,unix_gmtime:ru,unix_time:ry,unix_gettimeofday:g2,re_replacement_text:rm,re_partial_match:rl,re_string_match:rp,re_search_backward:rn,re_search_forward:ro,re_match:bG,caml_spacetime_only_works_for_native_code:oD,caml_register_channel_for_spacetime:oo,caml_spacetime_enabled:oC,caml_ml_runtime_warnings_enabled:lo,caml_ml_enable_runtime_warnings:lb,caml_runtime_warnings:ds,unix_inet_addr_of_string:rv,caml_install_signal_handler:kc,caml_runtime_parameters:ov,caml_runtime_variant:ow,caml_sys_isatty:o9,caml_sys_get_config:o6,caml_sys_const_backend_type:oU,caml_sys_const_ostype_cygwin:oY,caml_sys_const_ostype_win32:o0,caml_sys_const_ostype_unix:oZ,caml_sys_const_max_wosize:oX,caml_sys_const_int_size:oW,caml_sys_const_word_size:o1,caml_sys_const_big_endian:oV,caml_sys_random_seed:pa,caml_sys_time_include_children:pf,caml_sys_time:gp,caml_sys_system_command:pe,caml_sys_executable_name:o2,caml_sys_modify_argv:o_,caml_sys_argv:oS,caml_sys_get_argv:o5,caml_executable_name:fl,caml_argv:a9,caml_sys_unsafe_getenv:pg,caml_sys_getenv:go,caml_set_static_env:oz,caml_sys_exit:o3,caml_raise_sys_error:o,caml_is_printable:km,caml_get_global_data:jw,caml_register_global:X,caml_global_data:l,caml_named_value:aw,caml_register_named_value:oq,caml_named_values:da,caml_call_gen:al,caml_set_parser_trace:oy,caml_parse_engine:lP,caml_fresh_oo_id:jh,caml_set_oo_id:ox,caml_oo_last_id:dc,caml_get_public_method:jx,caml_lazy_make_forward:kV,caml_obj_make_forward:lF,caml_obj_truncate:lI,caml_obj_dup:db,caml_obj_with_tag:lJ,caml_obj_block:lD,caml_obj_set_tag:lG,caml_obj_tag:lH,caml_obj_is_block:lE,caml_update_dummy:gq,deserialize_nat:gA,serialize_nat:g0,lxor_digit_nat:qz,lor_digit_nat:qy,land_digit_nat:qw,compare_nat_real:pu,compare_nat:dz,compare_digits_nat:pt,shift_right_nat:dP,div_nat:pL,div_digit_nat:gB,div_helper:dA,shift_left_nat:dO,square_nat:rs,mult_nat:gY,mult_digit_nat:dN,sub_nat:dR,decr_nat:gz,complement_nat:pv,add_nat:cE,incr_nat:gC,is_digit_odd:qu,is_digit_zero:qv,is_digit_int:qt,num_leading_zero_bits_in_digit:gZ,num_digits_nat:cl,nth_digit_nat_native:rk,set_digit_nat_native:rr,nth_digit_nat:rj,set_digit_nat:rq,blit_nat:hG,set_to_zero_nat:g1,create_nat:gy,nat_of_array:a2,caml_hash_nat:fC,MlNat:bl,initialize_nat:pO,caml_js_to_string:fM,caml_to_js_string:dw,caml_js_from_string:kw,caml_new_string:bu,caml_js_to_byte_string:kK,caml_is_ml_string:aW,caml_is_ml_bytes:aH,caml_string_of_jsstring:T,caml_jsstring_of_string:k,caml_jsbytes_of_string:x,caml_string_of_jsbytes:i,caml_bytes_of_string:aT,caml_string_of_bytes:bB,caml_string_lessthan:gm,caml_string_lessequal:gl,caml_string_equal:du,caml_string_compare:oH,caml_ml_string_length:y,caml_string_unsafe_set:cg,caml_string_unsafe_get:t,caml_bytes_of_jsbytes:cR,caml_ml_bytes_length:av,caml_blit_string:cM,caml_blit_bytes:aI,caml_fill_string:i_,caml_fill_bytes:fm,caml_bytes_greaterthan:iC,caml_string_greaterthan:oM,caml_bytes_greaterequal:iB,caml_string_greaterequal:oL,caml_bytes_lessthan:cQ,caml_bytes_lessequal:cP,caml_bytes_notequal:iD,caml_string_notequal:oN,caml_bytes_equal:fg,caml_bytes_compare:cN,caml_bytes_of_array:bR,caml_string_of_array:bh,caml_create_bytes:M,caml_create_string:iN,caml_array_of_string:bn,caml_array_of_bytes:bm,caml_convert_bytes_to_array:bo,caml_convert_string_to_bytes:Q,MlBytes:ag,caml_bytes_of_utf16_jsstring:fh,caml_bytes_set:cS,caml_string_set64:oR,caml_bytes_set64:fk,caml_string_set32:oQ,caml_bytes_set32:fj,caml_string_set16:oP,caml_bytes_set16:fi,caml_string_set:oO,caml_bytes_get:cO,caml_bytes_get64:iA,caml_string_get64:oK,caml_bytes_get32:iz,caml_string_get32:oJ,caml_bytes_get16:iy,caml_string_get16:oI,caml_string_get:dv,caml_bytes_bound_error:aD,caml_string_bound_error:bg,caml_bytes_unsafe_set:ak,caml_bytes_unsafe_get:I,jsoo_is_ascii:dJ,caml_utf16_of_utf8:ci,caml_utf8_of_utf16:gr,caml_subarray_to_jsbytes:bC,caml_str_repeat:a0,caml_md5_bytes:fR,caml_md5_string:c_,caml_md5_chan:fS,caml_output_value_to_buffer:lN,caml_output_value_to_bytes:lO,caml_output_value_to_string:fX,caml_output_val:b8,caml_legacy_custom_code:fN,MlObjectTable:a8,caml_marshal_data_size:fQ,caml_input_value_from_reader:c3,caml_custom_ops:E,caml_nativeint_unmarshal:fW,caml_int32_unmarshal:fE,caml_int64_marshal:c6,caml_int64_unmarshal:c9,caml_input_value_from_bytes:fD,caml_input_value_from_string:kb,caml_float_of_bytes:aU,BigStringReader:e5,MlStringReader:bM,caml_marshal_constants:k7,caml_new_lex_engine:lA,caml_lex_engine:kZ,caml_lex_array:s,caml_xmlhttprequest_create:ps,caml_js_export_var:ks,caml_js_object:kF,caml_pure_js_expr:og,caml_js_expr:kt,caml_js_eval_string:kr,caml_js_equals:kp,caml_js_wrap_meth_callback_unsafe:kU,caml_js_wrap_meth_callback_strict:kT,caml_js_wrap_meth_callback_arguments:kS,caml_js_wrap_meth_callback:kR,caml_js_wrap_callback_strict:kQ,caml_js_wrap_callback_arguments:kP,caml_js_wrap_callback:kO,caml_ojs_new_arr:lK,caml_js_new:kE,caml_js_meth_call:kD,caml_js_fun_call:kx,caml_js_call:kn,caml_js_var:kN,caml_list_to_js_array:fP,caml_list_of_js_array:k2,caml_js_to_array:kJ,caml_js_from_array:aa,caml_js_to_float:kL,caml_js_from_float:kv,caml_js_to_bool:b3,caml_js_from_bool:ku,caml_js_error_of_exception:kq,caml_exn_with_js_backtrace:i8,caml_wrap_exception:pr,caml_is_js:kl,js_print_stderr:bD,js_print_stdout:gL,caml_trampoline_return:po,caml_trampoline:pn,caml_js_get_console:kz,caml_js_html_entities:kA,caml_js_html_escape:kB,caml_js_on_ie:kG,caml_js_typeof:kM,caml_js_instanceof:kC,caml_js_delete:ko,caml_js_get:ky,caml_js_set:kI,caml_js_pure_expr:kH,caml_ml_output_int:lj,caml_ml_pos_out_64:ln,caml_ml_pos_out:lm,caml_ml_seek_out_64:ls,caml_ml_seek_out:lr,caml_output_value:lM,caml_ml_output_char:li,caml_ml_output:b6,caml_ml_output_bytes:fV,caml_ml_flush:aX,caml_ml_input_scan_line:lf,caml_ml_pos_in_64:ll,caml_ml_pos_in:lk,caml_ml_seek_in_64:lq,caml_ml_seek_in:lp,caml_ml_input_int:le,caml_ml_input_char:ld,caml_input_value:ka,caml_ml_input:lc,caml_ml_may_refill_input:c$,caml_ml_refill_input:b7,caml_ml_set_channel_refill:lw,caml_ml_set_channel_output:lv,caml_ml_channel_size_64:la,caml_ml_channel_size:k$,caml_ml_close_channel:fT,caml_ml_set_binary_mode:lt,caml_channel_descriptor:iE,caml_ml_open_descriptor_in:fU,caml_ml_open_descriptor_out:lg,caml_ml_out_channels_list:lh,caml_ml_channels:h,caml_ml_set_channel_name:lu,caml_sys_open:o$,caml_std_output:dt,caml_sys_close:gn,caml_int64_bswap:ke,caml_int32_bswap:kd,caml_bswap16:ix,caml_mod:lx,caml_div:iO,caml_mul:bt,caml_int_of_string:kj,caml_parse_digit:bc,caml_parse_sign_and_base:de,caml_format_int:jg,caml_CamlinternalMod_update_mod:e9,caml_CamlinternalMod_init_mod:hH,caml_int64_hash:c5,caml_int64_to_bytes:ao,caml_int64_of_bytes:$,caml_int64_hi32:bZ,caml_int64_lo32:b0,caml_int64_create_lo_hi:fG,caml_int64_create_lo_mi_hi:am,caml_int64_of_string:kh,caml_int64_format:fH,caml_int64_of_float:bs,caml_int64_to_float:c8,caml_int64_to_int32:ba,caml_int64_of_int32:an,caml_int64_mod:kg,caml_int64_div:kf,caml_int64_shift_right:ki,caml_int64_shift_right_unsigned:aG,caml_int64_shift_left:fK,caml_int64_xor:fL,caml_int64_or:fJ,caml_int64_and:fF,caml_int64_is_negative:fI,caml_int64_is_zero:aF,caml_int64_mul:au,caml_int64_sub:c7,caml_int64_add:bq,caml_int64_neg:br,caml_int64_compare:c4,caml_int64_ult:bb,MlInt64:f,caml_int64_offset:a$,caml_float_of_string:jd,caml_format_float:jf,caml_round_float:ou,caml_tanh_float:ph,caml_sinh_float:oB,caml_cosh_float:iL,caml_log10_float:k3,caml_hypot_float:j_,caml_log1p_float:k4,caml_expm1_float:i9,caml_signbit_float:oA,caml_copysign_float:iK,caml_float_compare:jc,caml_frexp_float:ji,caml_ldexp_float:kW,caml_modf_float:ly,caml_classify_float:iG,caml_int32_float_of_bits:bY,caml_trunc_float:pp,caml_nextafter_float:lB,caml_int64_float_of_bits:aV,caml_hexstring_of_float:j9,caml_int32_bits_of_float:bX,caml_int64_bits_of_float:aK,jsoo_floor_log2:dI,caml_hash:cY,caml_hash_mix_string:c2,caml_hash_mix_bytes:fB,caml_hash_mix_bytes_arr:cZ,caml_hash_mix_jsbytes:bW,caml_hash_mix_int64:c1,caml_hash_mix_float:bp,caml_hash_mix_final:c0,caml_hash_mix_int:w,caml_hash_univ_param:j8,caml_gr_close_subwindow:jC,caml_gr_open_subwindow:jU,caml_gr_window_id:j5,caml_gr_display_mode:jG,caml_gr_remember_mode:jX,caml_gr_synchronize:j2,caml_gr_wait_event:j4,caml_gr_sigio_signal:jZ,caml_gr_sigio_handler:jY,caml_gr_blit_image:jz,caml_gr_create_image:jD,caml_gr_draw_image:jK,caml_gr_dump_image:jN,caml_gr_make_image:jS,caml_gr_text_size:j3,caml_gr_set_text_size:fv,caml_gr_set_font:ft,caml_gr_draw_string:jM,caml_gr_draw_char:jJ,caml_gr_draw_str:cX,caml_gr_fill_arc:jO,caml_gr_fill_poly:jP,caml_gr_fill_rect:jQ,caml_gr_set_line_width:fu,caml_gr_draw_arc:jI,caml_gr_arc_aux:cW,caml_gr_draw_rect:jL,caml_gr_lineto:jR,caml_gr_current_y:jF,caml_gr_current_x:jE,caml_gr_moveto:fq,caml_gr_point_color:jW,caml_gr_plot:jV,caml_gr_set_color:fs,caml_gr_size_y:j1,caml_gr_size_x:j0,caml_gr_clear_graph:jA,caml_gr_resize_window:fr,caml_gr_set_window_title:fw,caml_gr_close_graph:jB,caml_gr_doc_of_state:jH,caml_gr_state_create:fx,caml_gr_state_init:fy,caml_gr_open_graph:jT,caml_gr_state_set:fz,caml_gr_state_get:q,caml_gr_state:R,caml_memprof_stop:k_,caml_memprof_start:k9,caml_final_release:jb,caml_final_register_called_without_value:ja,caml_final_register:i$,caml_memprof_set:k8,caml_gc_get:jm,caml_gc_set:jq,caml_gc_stat:jr,caml_gc_quick_stat:jp,caml_gc_counters:jk,caml_gc_compaction:jj,caml_gc_full_major:jl,caml_gc_major:jn,caml_gc_minor:jo,MlNodeFile:ai,MlNodeDevice:ah,fs_node_supported:dE,MlFakeFile:A,MlFakeDevice:P,caml_read_file_content:ol,caml_create_file:cV,caml_fs_init:fp,caml_create_file_extern:iM,caml_ba_map_file_bytecode:h0,caml_ba_map_file:fc,caml_sys_rename:pd,caml_sys_is_directory:o8,caml_sys_remove:pc,caml_sys_read_directory:pb,caml_sys_file_exists:o4,caml_raise_not_a_dir:oh,caml_raise_no_such_file:bA,caml_sys_chdir:oT,caml_sys_getcwd:o7,caml_unmount:pq,caml_mount_autoload:lz,resolve_fs_device:ar,caml_list_mount_point:k1,jsoo_mount_point:ab,caml_make_path:b4,MlFile:cD,caml_root:aZ,caml_current_dir:aE,caml_finish_formatting:bV,caml_parse_format:b9,caml_array_bound_error:u,caml_raise_not_found:gi,caml_raise_zero_divide:S,caml_raise_end_of_file:ce,caml_invalid_argument:c,caml_failwith:e,caml_raise_with_string:cf,caml_raise_with_arg:dq,caml_return_exn_constant:dr,caml_raise_constant:aB,caml_lessthan:kY,caml_lessequal:kX,caml_greaterthan:j7,caml_greaterequal:j6,caml_notequal:lC,caml_equal:i7,caml_int_compare:b1,caml_compare:iH,caml_compare_val:aJ,caml_compare_val_number_custom:cT,caml_compare_val_get_custom:bU,caml_compare_val_tag:cU,caml_blit_string_to_bigstring:iw,caml_blit_bigstring_to_string:iv,caml_blit_bigstring_to_bigstring:iu,caml_bigstring_blit_ba_to_bytes:fe,caml_bigstring_blit_bytes_to_ba:is,caml_bigstring_blit_string_to_ba:ff,caml_bigstring_blit_ba_to_ba:fd,caml_bigstring_memcmp:it,bigstring_of_typed_array:hr,bigstring_of_array_buffer:cF,bigstring_to_typed_array:hu,bigstring_to_array_buffer:ht,caml_hash_mix_bigstring:fA,caml_ba_from_typed_array:hT,caml_ba_kind_of_typed_array:fb,caml_ba_to_typed_array:h8,caml_ba_hash:cK,caml_ba_create_from:cI,caml_ba_deserialize:cJ,caml_ba_serialize:cL,caml_ba_reshape:h2,caml_ba_slice:h6,caml_ba_sub:h7,caml_ba_blit:hN,caml_ba_fill:hS,caml_ba_set_3:h4,caml_ba_set_2:h3,caml_ba_set_1:aj,caml_ba_uint8_set64:ic,caml_ba_uint8_set32:ib,caml_ba_uint8_set16:ia,caml_ba_set_generic:h5,caml_ba_get_3:hV,caml_ba_get_2:hU,caml_ba_get_1:n,caml_ba_uint8_get64:h$,caml_ba_uint8_get32:h_,caml_ba_uint8_get16:h9,caml_ba_get_generic:hW,caml_ba_dim_3:hR,caml_ba_dim_2:hQ,caml_ba_dim_1:hP,caml_ba_dim:bQ,caml_ba_num_dims:h1,caml_ba_layout:hZ,caml_ba_kind:hY,caml_ba_change_layout:hO,caml_ba_create:e$,caml_ba_create_unsafe:Z,caml_ba_compare:cG,Ml_Bigarray_c_1_1:aR,Ml_Bigarray:aC,caml_ba_custom_name:fa,caml_ba_create_buffer:cH,caml_ba_get_size_per_element:a_,caml_ba_get_size:aS,caml_ba_init:hX,caml_convert_raw_backtrace_slot:iJ,caml_get_current_callstack:js,caml_restore_raw_backtrace:ot,caml_raw_backtrace_slot:ok,caml_raw_backtrace_next_slot:oj,caml_raw_backtrace_length:oi,caml_convert_raw_backtrace:iI,caml_record_backtrace:on,caml_get_exception_raw_backtrace:jv,caml_get_exception_backtrace:ju,caml_backtrace_status:id,caml_floatarray_create:je,caml_make_float_vect:k5,caml_make_vect:k6,caml_check_bound:iF,caml_array_fill:hL,caml_array_get:bO,caml_array_set:e_,caml_array_blit:bN,caml_array_concat:hK,caml_array_append:hJ,caml_array_sub:hM};fp();X(0,[W,i(eU),0],eU);X(1,[W,i(d6),-1],d6);X(2,[W,i(d9),-2],d9);X(3,[W,i(eu),-3],eu);X(4,[W,i(d_),-4],d_);X(5,[W,i(eG),-5],eG);X(6,[W,i(ez),-6],ez);X(7,[W,i(eh),-7],eh);X(8,[W,i(eA),-8],eA);X(9,[W,i(er),-9],er);X(10,[W,i(eN),-10],eN);X(11,[W,i(dT),-11],dT);return}(function(){return this}()));
+b=1;b<f;b++)g.push(C(e[b],ay));c=C(c,bf);d=C(d,bz);return a.caml_pasta_fq_plonk_proof_batch_verify(g,c,d)}c.jsoo_runtime={integers_uint64_compare:gJ,integers_uint32_compare:gE,integers_uint32_hash:gG,integers_uint32_deserialize:gF,integers_uint16_deserialize:gD,integers_uint8_deserialize:gK,integers_uint32_serialize:gI,integers_ushort_size:qr,integers_unsigned_init:qq,integers_ulonglong_size:qp,integers_ulong_size:qo,integers_uint_size:qn,integers_uint8_of_string:qm,integers_uint64_to_string:ql,integers_uint64_to_int64:qk,integers_uint64_to_int:qj,integers_uint64_sub:qi,integers_uint64_shift_right:qh,integers_uint64_shift_left:qg,integers_uint64_rem:qf,integers_uint64_of_string:qe,integers_uint_of_string:dH,integers_uint64_of_int64:qd,integers_uint64_of_int:qc,integers_uint64_mul:qb,integers_uint64_max:qa,integers_uint64_logxor:p$,integers_uint64_logor:p_,integers_uint64_logand:p9,integers_uint64_div:p8,integers_uint64_add:p7,integers_uint32_to_string:p6,integers_uint32_to_int64:dG,integers_uint32_to_int:p5,integers_uint32_shift_right:p3,integers_uint32_shift_left:p2,integers_uint32_rem:p1,integers_uint32_of_string:dF,integers_uint32_of_int64:gH,integers_uint32_of_int32:p0,integers_uint32_of_int:pZ,integers_uint32_mul:pY,integers_uint32_max:pX,integers_uint32_logxor:pW,integers_uint32_logor:pV,integers_uint32_logand:pU,integers_uint32_div:pT,integers_uint32_sub:p4,integers_uint32_add:pS,integers_uint16_of_string:pR,integers_size_t_size:pQ,integers_int32_of_uint32:pP,UInt32:H,plonk_wasm:a,startWorkers:dQ,wasm_ready:g4,_workers:e6,worker_threads:a3,caml_pasta_fq_plonk_oracles_deep_copy:nh,caml_pasta_fq_plonk_oracles_dummy:ni,caml_pasta_fq_plonk_oracles_create:ng,caml_pasta_fp_plonk_oracles_deep_copy:mh,caml_pasta_fp_plonk_oracles_dummy:mi,caml_pasta_fp_plonk_oracles_create:mg,caml_oracles_to_rust:dd,caml_oracles_of_rust:aY,caml_random_oracles_to_rust:gk,caml_random_oracles_of_rust:gj,caml_pasta_fq_plonk_proof_deep_copy:nl,caml_pasta_fq_plonk_proof_dummy:nm,caml_pasta_fq_plonk_proof_batch_verify:nj,caml_pasta_fq_plonk_proof_verify:nn,caml_pasta_fq_plonk_proof_create:nk,caml_pasta_fq_proof_of_rust:b$,caml_pasta_fq_proof_to_rust:bz,caml_pasta_fq_messages_of_rust:f7,caml_pasta_fq_messages_to_rust:f8,caml_pasta_fq_opening_proof_of_rust:f_,caml_pasta_fq_opening_proof_to_rust:f$,caml_pasta_fq_proof_evaluations_of_rust:dj,caml_pasta_fq_proof_evaluations_to_rust:dk,caml_pasta_fp_plonk_proof_deep_copy:ml,caml_pasta_fp_plonk_proof_dummy:mm,caml_pasta_fp_plonk_proof_batch_verify:mj,caml_pasta_fp_plonk_proof_verify:mn,caml_pasta_fp_plonk_proof_create:mk,caml_pasta_fp_proof_of_rust:b_,caml_pasta_fp_proof_to_rust:bw,caml_pasta_fp_messages_of_rust:fZ,caml_pasta_fp_messages_to_rust:f0,caml_pasta_fp_opening_proof_of_rust:f2,caml_pasta_fp_opening_proof_to_rust:f3,caml_pasta_fp_proof_evaluations_of_rust:dg,caml_pasta_fp_proof_evaluations_to_rust:dh,caml_pasta_fq_plonk_verifier_index_deep_copy:np,caml_pasta_fq_plonk_verifier_index_dummy:nq,caml_pasta_fq_plonk_verifier_index_shifts:ns,caml_pasta_fq_plonk_verifier_index_write:nt,caml_pasta_fq_plonk_verifier_index_read:nr,caml_pasta_fq_plonk_verifier_index_create:no,caml_pasta_fq_plonk_verifier_index_to_rust:bf,caml_pasta_fq_plonk_verifier_index_of_rust:by,caml_pasta_fp_plonk_verifier_index_deep_copy:mp,caml_pasta_fp_plonk_verifier_index_dummy:mq,caml_pasta_fp_plonk_verifier_index_shifts:ms,caml_pasta_fp_plonk_verifier_index_write:mt,caml_pasta_fp_plonk_verifier_index_read:mr,caml_pasta_fp_plonk_verifier_index_create:mo,caml_pasta_fp_plonk_verifier_index_to_rust:be,caml_pasta_fp_plonk_verifier_index_of_rust:bd,caml_plonk_verifier_index_to_rust:dn,caml_plonk_verifier_index_of_rust:dm,caml_plonk_verification_shifts_to_rust:gg,caml_plonk_verification_shifts_of_rust:ca,caml_plonk_verification_evals_to_rust:gf,caml_plonk_verification_evals_of_rust:ge,caml_plonk_domain_to_rust:gd,caml_plonk_domain_of_rust:gc,caml_pasta_fq_plonk_index_write:nf,caml_pasta_fq_plonk_index_read:ne,caml_pasta_fq_plonk_index_domain_d8_size:nb,caml_pasta_fq_plonk_index_domain_d4_size:na,caml_pasta_fq_plonk_index_domain_d1_size:m$,caml_pasta_fq_plonk_index_public_inputs:nd,caml_pasta_fq_plonk_index_max_degree:nc,caml_pasta_fq_plonk_index_create:m_,caml_pasta_fp_plonk_index_write:mf,caml_pasta_fp_plonk_index_read:me,caml_pasta_fp_plonk_index_domain_d8_size:mb,caml_pasta_fp_plonk_index_domain_d4_size:ma,caml_pasta_fp_plonk_index_domain_d1_size:l$,caml_pasta_fp_plonk_index_public_inputs:md,caml_pasta_fp_plonk_index_max_degree:mc,caml_pasta_fp_plonk_index_create:l_,caml_pasta_fq_plonk_gate_vector_wrap:m9,caml_pasta_fq_plonk_gate_vector_get:m8,caml_pasta_fq_plonk_gate_vector_add:m6,caml_pasta_fq_plonk_gate_vector_create:m7,caml_pasta_fp_plonk_gate_vector_wrap:l9,caml_pasta_fp_plonk_gate_vector_get:l8,caml_pasta_fp_plonk_gate_vector_add:l6,caml_pasta_fp_plonk_gate_vector_create:l7,caml_fq_plonk_gate_to_rust:fo,caml_fp_plonk_gate_to_rust:fn,caml_plonk_gate_of_rust:dl,caml_plonk_wires_to_rust:dp,caml_plonk_wires_of_rust:gh,caml_plonk_wire_to_rust:aL,caml_plonk_wire_of_rust:cb,caml_pasta_fq_urs_h:nI,caml_pasta_fq_urs_batch_accumulator_check:nF,caml_pasta_fq_urs_b_poly_commitment:nE,caml_pasta_fq_urs_commit_evaluations:nG,caml_pasta_fq_urs_lagrange_commitment:nJ,caml_pasta_fq_urs_read:nK,caml_pasta_fq_urs_write:nL,caml_pasta_fq_urs_create:nH,caml_pasta_fp_urs_h:mI,caml_pasta_fp_urs_batch_accumulator_check:mF,caml_pasta_fp_urs_b_poly_commitment:mE,caml_pasta_fp_urs_commit_evaluations:mG,caml_pasta_fp_urs_lagrange_commitment:mJ,caml_pasta_fp_urs_read:mK,caml_pasta_fp_urs_write:mL,caml_pasta_fp_urs_create:mH,caml_pasta_pallas_poly_comm_to_rust:ay,caml_pasta_pallas_poly_comm_of_rust:ax,caml_pasta_vesta_poly_comm_to_rust:aA,caml_pasta_vesta_poly_comm_of_rust:az,caml_poly_comm_to_rust_poly_comm:cd,caml_poly_comm_of_rust_poly_comm:cc,caml_array_to_rust_vector:C,caml_array_of_rust_vector:bP,caml_pasta_vesta_affine_deep_copy:n5,caml_pasta_vesta_endo_scalar:n8,caml_pasta_vesta_endo_base:n7,caml_pasta_vesta_of_affine_coordinates:n$,caml_pasta_vesta_of_affine:n_,caml_pasta_vesta_to_affine:of,caml_pasta_vesta_rng:oc,caml_pasta_vesta_random:ob,caml_pasta_vesta_scale:od,caml_pasta_vesta_double:n6,caml_pasta_vesta_negate:n9,caml_pasta_vesta_sub:oe,caml_pasta_vesta_add:n4,caml_pasta_vesta_one:oa,caml_pasta_pallas_affine_deep_copy:nR,caml_pasta_pallas_endo_scalar:nU,caml_pasta_pallas_endo_base:nT,caml_pasta_pallas_of_affine_coordinates:nX,caml_pasta_pallas_of_affine:nW,caml_pasta_pallas_to_affine:n3,caml_pasta_pallas_rng:n0,caml_pasta_pallas_random:nZ,caml_pasta_pallas_scale:n1,caml_pasta_pallas_double:nS,caml_pasta_pallas_negate:nV,caml_pasta_pallas_sub:n2,caml_pasta_pallas_add:nQ,caml_pasta_pallas_one:nY,rust_affine_of_caml_affine:F,rust_affine_to_caml_affine:N,free_on_finalize:r,free_finalization_registry:dD,caml_pasta_fq_vector_of_rust:aq,caml_pasta_fq_vector_to_rust:K,caml_pasta_fq_vector_get:nO,caml_pasta_fq_vector_emplace_back:nN,caml_pasta_fq_vector_length:nP,caml_pasta_fq_vector_create:nM,caml_pasta_fp_vector_of_rust:ap,caml_pasta_fp_vector_to_rust:J,caml_pasta_fp_vector_get:mO,caml_pasta_fp_vector_emplace_back:mN,caml_pasta_fp_vector_length:mP,caml_pasta_fp_vector_create:mM,js_class_vector_of_rust_vector:cj,js_class_vector_to_rust_vector:ck,caml_u8array_vector_of_rust_flat_vector:bi,caml_u8array_vector_to_rust_flat_vector:a1,caml_pasta_fq_deep_copy:mR,caml_pasta_fq_of_bytes:m3,caml_pasta_fq_to_bytes:nB,caml_pasta_fq_domain_generator:mT,caml_pasta_fq_two_adic_root_of_unity:nD,caml_pasta_fq_of_bigint:m2,caml_pasta_fq_to_bigint:nA,caml_pasta_fq_rng:nw,caml_pasta_fq_random:nv,caml_pasta_fq_equal:mU,caml_pasta_fq_compare:mQ,caml_pasta_fq_mut_square:mZ,caml_pasta_fq_mut_mul:mY,caml_pasta_fq_mut_sub:m0,caml_pasta_fq_mut_add:mX,caml_pasta_fq_print:nu,caml_pasta_fq_of_string:m5,caml_pasta_fq_to_string:nC,caml_pasta_fq_of_int:m4,caml_pasta_fq_sqrt:nz,caml_pasta_fq_is_square:mW,caml_pasta_fq_square:ga,caml_pasta_fq_inv:mV,caml_pasta_fq_div:mS,caml_pasta_fq_mul:f9,caml_pasta_fq_negate:m1,caml_pasta_fq_sub:gb,caml_pasta_fq_add:f6,caml_pasta_fq_size:nx,caml_pasta_fq_size_in_bits:ny,caml_pasta_fq_option:di,caml_pasta_fq_copy:bx,caml_pasta_fp_deep_copy:lR,caml_pasta_fp_of_bytes:l3,caml_pasta_fp_to_bytes:mB,caml_pasta_fp_domain_generator:lT,caml_pasta_fp_two_adic_root_of_unity:mD,caml_pasta_fp_of_bigint:l2,caml_pasta_fp_to_bigint:mA,caml_pasta_fp_rng:mw,caml_pasta_fp_random:mv,caml_pasta_fp_equal:lU,caml_pasta_fp_compare:lQ,caml_pasta_fp_mut_square:lZ,caml_pasta_fp_mut_mul:lY,caml_pasta_fp_mut_sub:l0,caml_pasta_fp_mut_add:lX,caml_pasta_fp_print:mu,caml_pasta_fp_of_string:l5,caml_pasta_fp_to_string:mC,caml_pasta_fp_of_int:l4,caml_pasta_fp_sqrt:mz,caml_pasta_fp_is_square:lW,caml_pasta_fp_square:f4,caml_pasta_fp_inv:lV,caml_pasta_fp_div:lS,caml_pasta_fp_mul:f1,caml_pasta_fp_negate:l1,caml_pasta_fp_sub:f5,caml_pasta_fp_add:fY,caml_pasta_fp_size:mx,caml_pasta_fp_size_in_bits:my,caml_pasta_fp_option:df,caml_pasta_fp_copy:bv,caml_bigint_256_deep_copy:ih,caml_bigint_256_of_bytes:ik,caml_bigint_256_to_bytes:iq,caml_bigint_256_test_bit:ip,caml_bigint_256_to_string:ir,caml_bigint_256_print:io,caml_bigint_256_compare:ig,caml_bigint_256_div:ii,caml_bigint_256_bytes_per_limb:ie,caml_bigint_256_num_limbs:ij,caml_bigint_256_of_decimal_string:il,caml_bigint_256_of_numeral:im,caml_bytes_to_uint8array:bT,caml_bytes_of_uint8array:bS,bigstringaf_memcmp_string:hz,bigstringaf_memcmp_bigstring:hy,bigstringaf_blit_from_bytes:hv,bigstringaf_blit_to_bigstring:hw,bigstringaf_blit_to_bytes:hx,caml_zarith_unmarshal:gx,caml_zarith_marshal:gw,ml_z_divexact:qE,ml_z_size:q_,ml_z_hamdist:qM,ml_z_popcount:gT,ml_z_trailing_zeros:rh,ml_z_sqrt_rem:ra,ml_z_sqrt:q$,ml_z_gcdext_intern:gP,ml_z_extract:qG,ml_z_nextprime:qV,ml_z_probab_prime:q6,ml_z_perfect_square:q3,ml_z_perfect_power:q2,ml_z_invert:gR,ml_z_root:bE,ml_z_powm_sec:q4,ml_z_of_bits:qW,ml_z_to_bits:rd,ml_z_hash:gQ,ml_z_pow:gU,ml_z_powm:gV,ml_z_fits_nativeint:qJ,ml_z_fits_int64:gO,ml_z_fits_int32:qI,ml_z_fits_int:dK,ml_z_numbits:gS,ml_z_gcd:qL,ml_z_sign:bF,ml_z_equal:qF,ml_z_compare:qC,ml_z_of_substring_base:q1,jsoo_z_of_js_string_base:gM,ml_z_format:qK,ml_z_to_nativeint:rg,ml_z_testbit:rc,ml_z_to_int64:rf,ml_z_to_int32:re,ml_z_to_int:dM,ml_z_of_float:qX,ml_z_of_int64:qZ,ml_z_of_nativeint:q0,ml_z_of_int32:qY,ml_z_of_int:dL,ml_z_shift_right_trunc:q9,ml_z_shift_right:q8,ml_z_shift_left:q7,ml_z_lognot:qQ,ml_z_logxor:qS,ml_z_logor:qR,ml_z_logand:qP,ml_z_abs:qA,ml_z_pred:q5,ml_z_succ:rb,ml_z_div_rem:qD,ml_z_rem:gW,ml_z_fdiv:qH,ml_z_cdiv:qB,ml_z_div:aN,ml_z_mul:qT,ml_z_sub:gX,ml_z_add:gN,ml_z_neg:qU,ml_z_install_frametable:qO,ml_z_init:qN,ml_z_normalize:j,bigInt:b,bigstring_realloc:hs,bigstring_destroy_stub:e8,core_md5_digest_subbigstring:pJ,core_md5_fd:pK,Core_kernel_heap_block_is_heap_block:hi,core_kernel_gc_top_heap_words:pH,core_kernel_gc_promoted_words:pG,core_kernel_gc_minor_words:pF,core_kernel_gc_minor_collections:pE,core_kernel_gc_major_words:pD,core_kernel_gc_major_plus_minor_words:pC,core_kernel_gc_major_collections:pB,core_kernel_gc_heap_words:pA,core_kernel_gc_heap_chunks:pz,core_kernel_gc_compactions:py,core_kernel_time_ns_format:pI,core_array_unsafe_float_blit:pw,core_array_unsafe_int_blit:px,bigstring_find:hn,internalhash_fold_bigstring:qs,bigstring_memcmp_stub:hp,bigstring_memset_stub:hq,bigstring_blit_string_bigstring_stub:hl,bigstring_blit_bigstring_bytes_stub:e7,bigstring_blit_bytes_bigstring_stub:hk,bigstring_blit_stub:hm,bigstring_is_mmapped_stub:ho,bigstring_alloc:hj,caml_out_channel_pos_fd:lL,expect_test_collector_after_test:pM,expect_test_collector_before_test:pN,expect_test_collector_saved_stderr:dB,expect_test_collector_saved_stdout:dC,time_now_nanoseconds_since_unix_epoch_or_zero:rt,bin_prot_blit_buf_stub:hC,bin_prot_blit_bytes_buf_stub:hD,bin_prot_blit_string_buf_stub:hF,bin_prot_blit_float_array_buf_stub:hE,bin_prot_blit_buf_bytes_stub:hA,bin_prot_blit_buf_float_array_stub:hB,Base_am_testing:g5,Base_hash_double:g7,Base_hash_string:g8,Base_int_math_int64_pow_stub:g_,Base_int_math_int_pow_stub:hb,Base_int_math_int64_clz:g9,Base_int_math_nativeint_clz:hc,Base_int_math_int_clz:g$,Base_int_math_int32_clz:cC,Base_clear_caml_backtrace_pos:g6,Base_int_math_int_popcount:ha,Base_internalhash_get_hash_value:hh,Base_internalhash_fold_string:hg,Base_internalhash_fold_float:hd,Base_internalhash_fold_int:he,Base_internalhash_fold_int64:hf,caml_remove_debug_info:os,caml_add_debug_info:hI,caml_register_code_fragment:op,caml_dynlink_get_current_libs:iR,caml_dynlink_add_primitive:iP,caml_dynlink_lookup_symbol:iS,caml_dynlink_close_lib:iQ,caml_dynlink_open_lib:iT,current_libs:aM,caml_realloc_global:om,caml_static_free:oF,caml_static_alloc:oE,caml_static_release_bytecode:oG,caml_reify_bytecode:or,caml_get_section_table:jy,caml_get_current_environment:jt,caml_invoke_traced_function:kk,caml_terminfo_rows:pk,caml_terminfo_resume:pj,caml_terminfo_standout:pm,caml_terminfo_backup:pi,caml_terminfo_setup:pl,caml_ephe_check_data:iW,caml_ephe_unset_data:i5,caml_ephe_set_data:i3,caml_ephe_get_data_copy:i0,caml_ephe_get_data:iZ,caml_ephe_blit_data:iU,caml_ephe_unset_key:i6,caml_ephe_set_key:i4,caml_ephe_check_key:iX,caml_ephe_get_key_copy:i2,caml_ephe_get_key:i1,caml_ephe_blit_key:iV,caml_ephe_create:iY,caml_weak_blit:gs,caml_weak_check:gt,caml_weak_get_copy:gv,caml_weak_get:dx,caml_weak_set:dy,caml_weak_create:gu,caml_ephe_data_offset:at,caml_ephe_key_offset:_,unix_isatty:rw,win_handle_fd:rA,win_cleanup:rz,win_startup:rB,unix_mktime:rx,unix_localtime:g3,unix_gmtime:ru,unix_time:ry,unix_gettimeofday:g2,re_replacement_text:rm,re_partial_match:rl,re_string_match:rp,re_search_backward:rn,re_search_forward:ro,re_match:bG,caml_spacetime_only_works_for_native_code:oD,caml_register_channel_for_spacetime:oo,caml_spacetime_enabled:oC,caml_ml_runtime_warnings_enabled:lo,caml_ml_enable_runtime_warnings:lb,caml_runtime_warnings:ds,unix_inet_addr_of_string:rv,caml_install_signal_handler:kc,caml_runtime_parameters:ov,caml_runtime_variant:ow,caml_sys_isatty:o9,caml_sys_get_config:o6,caml_sys_const_backend_type:oU,caml_sys_const_ostype_cygwin:oY,caml_sys_const_ostype_win32:o0,caml_sys_const_ostype_unix:oZ,caml_sys_const_max_wosize:oX,caml_sys_const_int_size:oW,caml_sys_const_word_size:o1,caml_sys_const_big_endian:oV,caml_sys_random_seed:pa,caml_sys_time_include_children:pf,caml_sys_time:gp,caml_sys_system_command:pe,caml_sys_executable_name:o2,caml_sys_modify_argv:o_,caml_sys_argv:oS,caml_sys_get_argv:o5,caml_executable_name:fl,caml_argv:a9,caml_sys_unsafe_getenv:pg,caml_sys_getenv:go,caml_set_static_env:oz,caml_sys_exit:o3,caml_raise_sys_error:o,caml_is_printable:km,caml_get_global_data:jw,caml_register_global:X,caml_global_data:l,caml_named_value:aw,caml_register_named_value:oq,caml_named_values:da,caml_call_gen:al,caml_set_parser_trace:oy,caml_parse_engine:lP,caml_fresh_oo_id:jh,caml_set_oo_id:ox,caml_oo_last_id:dc,caml_get_public_method:jx,caml_lazy_make_forward:kV,caml_obj_make_forward:lF,caml_obj_truncate:lI,caml_obj_dup:db,caml_obj_with_tag:lJ,caml_obj_block:lD,caml_obj_set_tag:lG,caml_obj_tag:lH,caml_obj_is_block:lE,caml_update_dummy:gq,deserialize_nat:gA,serialize_nat:g0,lxor_digit_nat:qz,lor_digit_nat:qy,land_digit_nat:qw,compare_nat_real:pu,compare_nat:dz,compare_digits_nat:pt,shift_right_nat:dP,div_nat:pL,div_digit_nat:gB,div_helper:dA,shift_left_nat:dO,square_nat:rs,mult_nat:gY,mult_digit_nat:dN,sub_nat:dR,decr_nat:gz,complement_nat:pv,add_nat:cE,incr_nat:gC,is_digit_odd:qu,is_digit_zero:qv,is_digit_int:qt,num_leading_zero_bits_in_digit:gZ,num_digits_nat:cl,nth_digit_nat_native:rk,set_digit_nat_native:rr,nth_digit_nat:rj,set_digit_nat:rq,blit_nat:hG,set_to_zero_nat:g1,create_nat:gy,nat_of_array:a2,caml_hash_nat:fC,MlNat:bl,initialize_nat:pO,caml_js_to_string:fM,caml_to_js_string:dw,caml_js_from_string:kw,caml_new_string:bu,caml_js_to_byte_string:kK,caml_is_ml_string:aW,caml_is_ml_bytes:aH,caml_string_of_jsstring:T,caml_jsstring_of_string:k,caml_jsbytes_of_string:x,caml_string_of_jsbytes:i,caml_bytes_of_string:aT,caml_string_of_bytes:bB,caml_string_lessthan:gm,caml_string_lessequal:gl,caml_string_equal:du,caml_string_compare:oH,caml_ml_string_length:y,caml_string_unsafe_set:cg,caml_string_unsafe_get:t,caml_bytes_of_jsbytes:cR,caml_ml_bytes_length:av,caml_blit_string:cM,caml_blit_bytes:aI,caml_fill_string:i_,caml_fill_bytes:fm,caml_bytes_greaterthan:iC,caml_string_greaterthan:oM,caml_bytes_greaterequal:iB,caml_string_greaterequal:oL,caml_bytes_lessthan:cQ,caml_bytes_lessequal:cP,caml_bytes_notequal:iD,caml_string_notequal:oN,caml_bytes_equal:fg,caml_bytes_compare:cN,caml_bytes_of_array:bR,caml_string_of_array:bh,caml_create_bytes:M,caml_create_string:iN,caml_array_of_string:bn,caml_array_of_bytes:bm,caml_convert_bytes_to_array:bo,caml_convert_string_to_bytes:Q,MlBytes:ag,caml_bytes_of_utf16_jsstring:fh,caml_bytes_set:cS,caml_string_set64:oR,caml_bytes_set64:fk,caml_string_set32:oQ,caml_bytes_set32:fj,caml_string_set16:oP,caml_bytes_set16:fi,caml_string_set:oO,caml_bytes_get:cO,caml_bytes_get64:iA,caml_string_get64:oK,caml_bytes_get32:iz,caml_string_get32:oJ,caml_bytes_get16:iy,caml_string_get16:oI,caml_string_get:dv,caml_bytes_bound_error:aD,caml_string_bound_error:bg,caml_bytes_unsafe_set:ak,caml_bytes_unsafe_get:I,jsoo_is_ascii:dJ,caml_utf16_of_utf8:ci,caml_utf8_of_utf16:gr,caml_subarray_to_jsbytes:bC,caml_str_repeat:a0,caml_md5_bytes:fR,caml_md5_string:c_,caml_md5_chan:fS,caml_output_value_to_buffer:lN,caml_output_value_to_bytes:lO,caml_output_value_to_string:fX,caml_output_val:b8,caml_legacy_custom_code:fN,MlObjectTable:a8,caml_marshal_data_size:fQ,caml_input_value_from_reader:c3,caml_custom_ops:E,caml_nativeint_unmarshal:fW,caml_int32_unmarshal:fE,caml_int64_marshal:c6,caml_int64_unmarshal:c9,caml_input_value_from_bytes:fD,caml_input_value_from_string:kb,caml_float_of_bytes:aU,BigStringReader:e5,MlStringReader:bM,caml_marshal_constants:k7,caml_new_lex_engine:lA,caml_lex_engine:kZ,caml_lex_array:s,caml_xmlhttprequest_create:ps,caml_js_export_var:ks,caml_js_object:kF,caml_pure_js_expr:og,caml_js_expr:kt,caml_js_eval_string:kr,caml_js_equals:kp,caml_js_wrap_meth_callback_unsafe:kU,caml_js_wrap_meth_callback_strict:kT,caml_js_wrap_meth_callback_arguments:kS,caml_js_wrap_meth_callback:kR,caml_js_wrap_callback_strict:kQ,caml_js_wrap_callback_arguments:kP,caml_js_wrap_callback:kO,caml_ojs_new_arr:lK,caml_js_new:kE,caml_js_meth_call:kD,caml_js_fun_call:kx,caml_js_call:kn,caml_js_var:kN,caml_list_to_js_array:fP,caml_list_of_js_array:k2,caml_js_to_array:kJ,caml_js_from_array:aa,caml_js_to_float:kL,caml_js_from_float:kv,caml_js_to_bool:b3,caml_js_from_bool:ku,caml_js_error_of_exception:kq,caml_exn_with_js_backtrace:i8,caml_wrap_exception:pr,caml_is_js:kl,js_print_stderr:bD,js_print_stdout:gL,caml_trampoline_return:po,caml_trampoline:pn,caml_js_get_console:kz,caml_js_html_entities:kA,caml_js_html_escape:kB,caml_js_on_ie:kG,caml_js_typeof:kM,caml_js_instanceof:kC,caml_js_delete:ko,caml_js_get:ky,caml_js_set:kI,caml_js_pure_expr:kH,caml_ml_output_int:lj,caml_ml_pos_out_64:ln,caml_ml_pos_out:lm,caml_ml_seek_out_64:ls,caml_ml_seek_out:lr,caml_output_value:lM,caml_ml_output_char:li,caml_ml_output:b6,caml_ml_output_bytes:fV,caml_ml_flush:aX,caml_ml_input_scan_line:lf,caml_ml_pos_in_64:ll,caml_ml_pos_in:lk,caml_ml_seek_in_64:lq,caml_ml_seek_in:lp,caml_ml_input_int:le,caml_ml_input_char:ld,caml_input_value:ka,caml_ml_input:lc,caml_ml_may_refill_input:c$,caml_ml_refill_input:b7,caml_ml_set_channel_refill:lw,caml_ml_set_channel_output:lv,caml_ml_channel_size_64:la,caml_ml_channel_size:k$,caml_ml_close_channel:fT,caml_ml_set_binary_mode:lt,caml_channel_descriptor:iE,caml_ml_open_descriptor_in:fU,caml_ml_open_descriptor_out:lg,caml_ml_out_channels_list:lh,caml_ml_channels:h,caml_ml_set_channel_name:lu,caml_sys_open:o$,caml_std_output:dt,caml_sys_close:gn,caml_int64_bswap:ke,caml_int32_bswap:kd,caml_bswap16:ix,caml_mod:lx,caml_div:iO,caml_mul:bt,caml_int_of_string:kj,caml_parse_digit:bc,caml_parse_sign_and_base:de,caml_format_int:jg,caml_CamlinternalMod_update_mod:e9,caml_CamlinternalMod_init_mod:hH,caml_int64_hash:c5,caml_int64_to_bytes:ao,caml_int64_of_bytes:$,caml_int64_hi32:bZ,caml_int64_lo32:b0,caml_int64_create_lo_hi:fG,caml_int64_create_lo_mi_hi:am,caml_int64_of_string:kh,caml_int64_format:fH,caml_int64_of_float:bs,caml_int64_to_float:c8,caml_int64_to_int32:ba,caml_int64_of_int32:an,caml_int64_mod:kg,caml_int64_div:kf,caml_int64_shift_right:ki,caml_int64_shift_right_unsigned:aG,caml_int64_shift_left:fK,caml_int64_xor:fL,caml_int64_or:fJ,caml_int64_and:fF,caml_int64_is_negative:fI,caml_int64_is_zero:aF,caml_int64_mul:au,caml_int64_sub:c7,caml_int64_add:bq,caml_int64_neg:br,caml_int64_compare:c4,caml_int64_ult:bb,MlInt64:f,caml_int64_offset:a$,caml_float_of_string:jd,caml_format_float:jf,caml_round_float:ou,caml_tanh_float:ph,caml_sinh_float:oB,caml_cosh_float:iL,caml_log10_float:k3,caml_hypot_float:j_,caml_log1p_float:k4,caml_expm1_float:i9,caml_signbit_float:oA,caml_copysign_float:iK,caml_float_compare:jc,caml_frexp_float:ji,caml_ldexp_float:kW,caml_modf_float:ly,caml_classify_float:iG,caml_int32_float_of_bits:bY,caml_trunc_float:pp,caml_nextafter_float:lB,caml_int64_float_of_bits:aV,caml_hexstring_of_float:j9,caml_int32_bits_of_float:bX,caml_int64_bits_of_float:aK,jsoo_floor_log2:dI,caml_hash:cY,caml_hash_mix_string:c2,caml_hash_mix_bytes:fB,caml_hash_mix_bytes_arr:cZ,caml_hash_mix_jsbytes:bW,caml_hash_mix_int64:c1,caml_hash_mix_float:bp,caml_hash_mix_final:c0,caml_hash_mix_int:w,caml_hash_univ_param:j8,caml_gr_close_subwindow:jC,caml_gr_open_subwindow:jU,caml_gr_window_id:j5,caml_gr_display_mode:jG,caml_gr_remember_mode:jX,caml_gr_synchronize:j2,caml_gr_wait_event:j4,caml_gr_sigio_signal:jZ,caml_gr_sigio_handler:jY,caml_gr_blit_image:jz,caml_gr_create_image:jD,caml_gr_draw_image:jK,caml_gr_dump_image:jN,caml_gr_make_image:jS,caml_gr_text_size:j3,caml_gr_set_text_size:fv,caml_gr_set_font:ft,caml_gr_draw_string:jM,caml_gr_draw_char:jJ,caml_gr_draw_str:cX,caml_gr_fill_arc:jO,caml_gr_fill_poly:jP,caml_gr_fill_rect:jQ,caml_gr_set_line_width:fu,caml_gr_draw_arc:jI,caml_gr_arc_aux:cW,caml_gr_draw_rect:jL,caml_gr_lineto:jR,caml_gr_current_y:jF,caml_gr_current_x:jE,caml_gr_moveto:fq,caml_gr_point_color:jW,caml_gr_plot:jV,caml_gr_set_color:fs,caml_gr_size_y:j1,caml_gr_size_x:j0,caml_gr_clear_graph:jA,caml_gr_resize_window:fr,caml_gr_set_window_title:fw,caml_gr_close_graph:jB,caml_gr_doc_of_state:jH,caml_gr_state_create:fx,caml_gr_state_init:fy,caml_gr_open_graph:jT,caml_gr_state_set:fz,caml_gr_state_get:q,caml_gr_state:R,caml_memprof_stop:k_,caml_memprof_start:k9,caml_final_release:jb,caml_final_register_called_without_value:ja,caml_final_register:i$,caml_memprof_set:k8,caml_gc_get:jm,caml_gc_set:jq,caml_gc_stat:jr,caml_gc_quick_stat:jp,caml_gc_counters:jk,caml_gc_compaction:jj,caml_gc_full_major:jl,caml_gc_major:jn,caml_gc_minor:jo,MlNodeFile:ai,MlNodeDevice:ah,fs_node_supported:dE,MlFakeFile:A,MlFakeDevice:P,caml_read_file_content:ol,caml_create_file:cV,caml_fs_init:fp,caml_create_file_extern:iM,caml_ba_map_file_bytecode:h0,caml_ba_map_file:fc,caml_sys_rename:pd,caml_sys_is_directory:o8,caml_sys_remove:pc,caml_sys_read_directory:pb,caml_sys_file_exists:o4,caml_raise_not_a_dir:oh,caml_raise_no_such_file:bA,caml_sys_chdir:oT,caml_sys_getcwd:o7,caml_unmount:pq,caml_mount_autoload:lz,resolve_fs_device:ar,caml_list_mount_point:k1,jsoo_mount_point:ab,caml_make_path:b4,MlFile:cD,caml_root:aZ,caml_current_dir:aE,caml_finish_formatting:bV,caml_parse_format:b9,caml_array_bound_error:u,caml_raise_not_found:gi,caml_raise_zero_divide:S,caml_raise_end_of_file:ce,caml_invalid_argument:d,caml_failwith:e,caml_raise_with_string:cf,caml_raise_with_arg:dq,caml_return_exn_constant:dr,caml_raise_constant:aB,caml_lessthan:kY,caml_lessequal:kX,caml_greaterthan:j7,caml_greaterequal:j6,caml_notequal:lC,caml_equal:i7,caml_int_compare:b1,caml_compare:iH,caml_compare_val:aJ,caml_compare_val_number_custom:cT,caml_compare_val_get_custom:bU,caml_compare_val_tag:cU,caml_blit_string_to_bigstring:iw,caml_blit_bigstring_to_string:iv,caml_blit_bigstring_to_bigstring:iu,caml_bigstring_blit_ba_to_bytes:fe,caml_bigstring_blit_bytes_to_ba:is,caml_bigstring_blit_string_to_ba:ff,caml_bigstring_blit_ba_to_ba:fd,caml_bigstring_memcmp:it,bigstring_of_typed_array:hr,bigstring_of_array_buffer:cF,bigstring_to_typed_array:hu,bigstring_to_array_buffer:ht,caml_hash_mix_bigstring:fA,caml_ba_from_typed_array:hT,caml_ba_kind_of_typed_array:fb,caml_ba_to_typed_array:h8,caml_ba_hash:cK,caml_ba_create_from:cI,caml_ba_deserialize:cJ,caml_ba_serialize:cL,caml_ba_reshape:h2,caml_ba_slice:h6,caml_ba_sub:h7,caml_ba_blit:hN,caml_ba_fill:hS,caml_ba_set_3:h4,caml_ba_set_2:h3,caml_ba_set_1:aj,caml_ba_uint8_set64:ic,caml_ba_uint8_set32:ib,caml_ba_uint8_set16:ia,caml_ba_set_generic:h5,caml_ba_get_3:hV,caml_ba_get_2:hU,caml_ba_get_1:n,caml_ba_uint8_get64:h$,caml_ba_uint8_get32:h_,caml_ba_uint8_get16:h9,caml_ba_get_generic:hW,caml_ba_dim_3:hR,caml_ba_dim_2:hQ,caml_ba_dim_1:hP,caml_ba_dim:bQ,caml_ba_num_dims:h1,caml_ba_layout:hZ,caml_ba_kind:hY,caml_ba_change_layout:hO,caml_ba_create:e$,caml_ba_create_unsafe:Z,caml_ba_compare:cG,Ml_Bigarray_c_1_1:aR,Ml_Bigarray:aC,caml_ba_custom_name:fa,caml_ba_create_buffer:cH,caml_ba_get_size_per_element:a_,caml_ba_get_size:aS,caml_ba_init:hX,caml_convert_raw_backtrace_slot:iJ,caml_get_current_callstack:js,caml_restore_raw_backtrace:ot,caml_raw_backtrace_slot:ok,caml_raw_backtrace_next_slot:oj,caml_raw_backtrace_length:oi,caml_convert_raw_backtrace:iI,caml_record_backtrace:on,caml_get_exception_raw_backtrace:jv,caml_get_exception_backtrace:ju,caml_backtrace_status:id,caml_floatarray_create:je,caml_make_float_vect:k5,caml_make_vect:k6,caml_check_bound:iF,caml_array_fill:hL,caml_array_get:bO,caml_array_set:e_,caml_array_blit:bN,caml_array_concat:hK,caml_array_append:hJ,caml_array_sub:hM};fp();X(0,[W,i(eU),0],eU);X(1,[W,i(d6),-1],d6);X(2,[W,i(d9),-2],d9);X(3,[W,i(eu),-3],eu);X(4,[W,i(d_),-4],d_);X(5,[W,i(eG),-5],eG);X(6,[W,i(ez),-6],ez);X(7,[W,i(eh),-7],eh);X(8,[W,i(eA),-8],eA);X(9,[W,i(er),-9],er);X(10,[W,i(eN),-10],eN);X(11,[W,i(dT),-11],dT);return}(function(){return this}()));

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -351,3 +351,8 @@ export const sizeInFieldElements: (x: any[]) => number;
 export const NumberAsField: AsFieldElements<Number>;
 
 export const array: <T>(x: AsFieldElements<T>, length: number) => AsFieldElements<T[]>;
+
+/* This function *must* be called at the end of a nodejs program, otherwise the
+ * worker threads will continue running and the program will never terminate.
+ * From web applications, this function is a no-op. */
+export const shutdown: () => Promise<undefined>

--- a/src/snarky.js
+++ b/src/snarky.js
@@ -1,6 +1,15 @@
 // To build for node: Uncomment this export and comment the chrome exports
 export * from './node_bindings/snarky_js_node.bc.js'
 
+export const shutdown = () => {
+    if (global.wasm_rayon_poolbuilder) {
+        global.wasm_rayon_poolbuilder.free();
+        return Promise.all(global.wasm_workers.map(async (worker) => {
+            await worker.terminate();
+        }));
+    }
+};
+
 // To build for web: Uncomment this section and comment the node exports
 // export let Field
 // export let Bool


### PR DESCRIPTION
This PR adds a `shutdown` function, which kills the rust thread pool and then terminates the nodejs worker threads.

The corresponding mina code changes to support this are [here](https://github.com/MinaProtocol/mina/commit/b5ac777889fb2a5dcd9f33b1631a63610fd5f68c)