### PR TITLE
Bug Report: SnarkyJS Node on Circuit.generateKeypair()

### DIFF
--- a/src/examples/ex00_preimage.ts
+++ b/src/examples/ex00_preimage.ts
@@ -14,10 +14,15 @@ class Main extends Circuit {
     Poseidon.hash([preimage]).assertEquals(hash);
   }
 }
+export default () => {
+  console.log('Executing... Main.generateKeypair()');
+  const kp = Main.generateKeypair();
 
-const kp = Main.generateKeypair();
-
-const preimage = Field.random();
-const hash = Poseidon.hash([preimage]);
-const pi = Main.prove([preimage], [hash], kp);
-console.log('proof', pi);
+  console.log('Executing... Field.random()');
+  const preimage = Field.random();
+  console.log('Executing... Poseidon.hash()');
+  const hash = Poseidon.hash([preimage]);
+  console.log('Executing... Main.prove()');
+  const pi = Main.prove([preimage], [hash], kp);
+  console.log('proof', pi);
+};

--- a/src/examples/ex01_small_preimage.ts
+++ b/src/examples/ex01_small_preimage.ts
@@ -15,10 +15,11 @@ class Main extends Circuit {
     Poseidon.hash([preimage]).assertEquals(hash);
   }
 }
+export default () => {
+  const kp = Main.generateKeypair();
 
-const kp = Main.generateKeypair();
-
-const preimage = Field.ofBits(Field.random().toBits().slice(0, 32));
-const hash = Poseidon.hash([preimage]);
-const pi = Main.prove([preimage], [hash], kp);
-console.log('proof', pi);
+  const preimage = Field.ofBits(Field.random().toBits().slice(0, 32));
+  const hash = Poseidon.hash([preimage]);
+  const pi = Main.prove([preimage], [hash], kp);
+  console.log('proof', pi);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export * from './lib/signature';
 export * from './lib/circuit_value';
 export * from './lib/merkle_proof';
 
+import * as preimage from './examples/ex01_small_preimage';
+preimage.default();
+
+// import * as small_preimage from './examples/ex01_small_preimage';
+// small_preimage.default()
+
 import { shutdown } from './snarky';
 if (typeof window === 'undefined') {
   shutdown();


### PR DESCRIPTION
**Description**:
When running example `src/examples/ex00_preimage.ts` or `src/examples/ex01_small_preimage.ts`, a `RuntimeError: unreachable` error occures on the call to `Circuit.generateKeypair()`

**Reproduce**:
1. Check out into branch.
2. Run `npm run start:server`
3. Crash occures

**Output**:
```
$ npm run start:server

> @o1labs/snarkyjs@0.1.1 start:server
> ./scripts/build-and-run-server.sh


> @o1labs/snarkyjs@0.1.1 build:server
> webpack --config ./webpack/webpack.server.dev.js --stats-error-details

...
webpack 5.58.1 compiled successfully in 8387 ms
wasm://wasm/00696056:1


RuntimeError: unreachable
    at <anonymous>:wasm-function[1519]:0x18c2df
    at <anonymous>:wasm-function[682]:0x15c05c
    at <anonymous>:wasm-function[1304]:0x188492
    at <anonymous>:wasm-function[1482]:0x18bcfc
    at <anonymous>:wasm-function[1448]:0x18b68e
    at <anonymous>:wasm-function[1484]:0x18bd62
    at <anonymous>:wasm-function[1321]:0x188c8b
    at <anonymous>:wasm-function[1126]:0x18056e
    at <anonymous>:wasm-function[1372]:0x18a035
    at <anonymous>:wasm-function[301]:0x114081
```

**System Info**:
```
$ node --version
v16.9.1
```