### PR TITLE
Split constructor and deploy (formerly init)

### DIFF
--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -203,7 +203,7 @@ export abstract class SmartContract {
     // this.state = [];
   }
 
-  init(initialBalance: UInt64 | UInt32) {
+  deploy(...args: any[]) {
     try {
       this.executionState().party.body.update.verificationKey.set = Bool(true);
     } catch (_error) {

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -1,11 +1,4 @@
-import {
-  Circuit,
-  Field,
-  Bool,
-  Poseidon,
-  isReady,
-  AsFieldElements,
-} from '../snarky';
+import { Circuit, Field, Bool, Poseidon, AsFieldElements } from '../snarky';
 import { CircuitValue } from './circuit_value';
 import {
   AccountPredicate,
@@ -17,7 +10,6 @@ import {
 } from './party';
 import { PublicKey } from './signature';
 import * as Mina from './mina';
-import { FullAccountPredicate_ } from '../snarky';
 import { UInt32 } from './int';
 
 /**
@@ -116,7 +108,7 @@ export function state<A>(ty: AsFieldElements<A>) {
         let p: Promise<Field[]>;
 
         if (Circuit.inProver()) {
-          p = Mina.getAccount(addr).then(a => {
+          p = Mina.getAccount(addr).then((a) => {
             const xs: Field[] = [];
             for (let i = 0; i < r.length; ++i) {
               xs.push(a.snapp.appState[r.offset + i]);
@@ -124,11 +116,13 @@ export function state<A>(ty: AsFieldElements<A>) {
             return Circuit.witness(Circuit.array(Field, r.length), () => xs);
           });
         } else {
-          const res = Circuit.witness(Circuit.array(Field, r.length), () => { throw 'unimplemented'});
-          p = new Promise(k => k(res));
+          const res = Circuit.witness(Circuit.array(Field, r.length), () => {
+            throw 'unimplemented';
+          });
+          p = new Promise((k) => k(res));
         }
 
-        return p.then(xs => {
+        return p.then((xs) => {
           const res = ty.ofFields(xs);
           if ((ty as any).check != undefined) {
             (ty as any).check(res);
@@ -206,9 +200,7 @@ export abstract class SmartContract {
   constructor(address: PublicKey) {
     this.address = address;
     try {
-      this.executionState().party.body.update.verificationKey.set = new Bool(
-        true
-      );
+      this.executionState().party.body.update.verificationKey.set = Bool(true);
     } catch (_error) {
       throw new Error(
         'Cannot construct `new` SmartContract instance outside a transaction. Use `SmartContract.fromAddress` to refer to an already deployed instance.'

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -273,10 +273,6 @@ export abstract class SmartContract {
     });
   }
 
-  static fromAddress(address: PublicKey): SmartContract {
-    throw 'fromaddress';
-  }
-
   party(i: number): Body {
     throw 'party';
   }

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -10,7 +10,7 @@ import {
 } from './party';
 import { PublicKey } from './signature';
 import * as Mina from './mina';
-import { UInt32 } from './int';
+import { UInt32, UInt64 } from './int';
 
 /**
  * A decorator to use within a snapp to indicate what will be stored on-chain.
@@ -203,7 +203,7 @@ export abstract class SmartContract {
     // this.state = [];
   }
 
-  init() {
+  init(initialBalance: UInt64 | UInt32) {
     try {
       this.executionState().party.body.update.verificationKey.set = Bool(true);
     } catch (_error) {

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -199,6 +199,11 @@ export abstract class SmartContract {
 
   constructor(address: PublicKey) {
     this.address = address;
+    // this.self = null as unknown as Body;
+    // this.state = [];
+  }
+
+  init() {
     try {
       this.executionState().party.body.update.verificationKey.set = Bool(true);
     } catch (_error) {
@@ -206,8 +211,6 @@ export abstract class SmartContract {
         'Cannot construct `new` SmartContract instance outside a transaction. Use `SmartContract.fromAddress` to refer to an already deployed instance.'
       );
     }
-    // this.self = null as unknown as Body;
-    // this.state = [];
   }
 
   executionState(): ExecutionState {


### PR DESCRIPTION
Make `SmartContract` constructor support instantiating already deployed snapp.

Move the init logic into a new method `.deploy()` that should be implemented by every child class, like that:

```ts
class MyContract extends SmartContract {
  @state(Field) x: State<Field>;

  constructor(address: PublicKey) {
    super(address);
  }

  deploy(initialBalance: UInt64, x: Field) {
    super.deploy();
    this.balance.addInPlace(initialBalance);
    this.x = State.init(x);
  }
}
```

TBD: With the current code, only assigning `this.x = ...` in `deploy` and not in the constructor works (thanks to `@state` decorator magic). IMO, this is also logically what should happen - the state is either initialized
(when deploying) or fetched from the blockchain (by clients which refer to an already deployed smart contract). So it shouldn't be set in the constructor.

TBD: Initially we wanted `@deploy` to be a decorator, for consistency. In the proposed API, I just can't find a use case for such a decorator. IMO, the snapp creator should explicitly call
`smartContract.deploy()` in his transaction, so it's not clear to me what a `@deploy` decorator should do. 

EDIT: This was tested to work with the sudoku example on [this branch](https://github.com/mitschabaude/snarkyjs-sudoku/tree/separate-deploy), which I think covers all relevant cases, but it'd be good to double-check the logic @imeckler 