### PR TITLE
Simpler state

### DIFF
--- a/src/examples/simple_snapp.ts
+++ b/src/examples/simple_snapp.ts
@@ -16,7 +16,7 @@ class SimpleSnapp extends SmartContract {
 
   deploy(initialBalance: UInt64, x: Field) {
     this.balance.addInPlace(initialBalance);
-    this.x = State.init(x);
+    this.x.set(x);
   }
 
   @method async update(y: Field) {


### PR DESCRIPTION
conceptually simplify `@state`, merge init and set

This mainly simplifies the *implementation* of `@state`, makes the State constructor "real"

For users of our library the only change is how we initialize the state inside `deploy`.

This was the old version:
```ts
class MyContract extends SmartContract {
  @state(Field) x = State<Field>();

  deploy(x: Field) {
    this.x = State.init(x); // setting initial state with decorator magic! State / State.init is "fake"
  }
}
```

And this is the new version:
```ts
class MyContract extends SmartContract {
  @state(Field) x = State<Field>();

  deploy(x: Field) {
    this.x.set(x); // can set initial state with x.set(), because State() returns basically the real thing
  }
}
```