### PR TITLE
Transaction Construction, Pt 3. Prove smart contract execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepublish:web": "NODE_ENV=production node src/build/buildWeb.mjs",
     "prepublish:both": "npm run prepublish:web && npm run prepublish:server",
     "prepublishOnly": "npm run prepublish:web && npm run prepublish:server",
+    "bootstrap-build": "npm run build && node src/build/extractJsooMethods.js && npm run build",
     "format": "prettier --write --ignore-unknown **/*",
     "test": "node --experimental-wasm-modules --experimental-modules --experimental-wasm-threads --experimental-vm-modules ./node_modules/jest/bin/jest.js --silent",
     "clean": "rm -rf dist"

--- a/src/examples/rollup/wip.ts
+++ b/src/examples/rollup/wip.ts
@@ -328,7 +328,10 @@ class RollupSnapp extends SmartContract {
     this.operatorsCommitment.set(operatorsDb.commitment());
   }
 
-  @method depositFunds(depositor: Party<UInt32>, depositAmount: UInt64) {
+  @method depositFunds(
+    depositor: Party & { predicate: UInt32 },
+    depositAmount: UInt64
+  ) {
     const self = this.self;
 
     self.balance.addInPlace(depositAmount);

--- a/src/examples/simple_snapp.mjs
+++ b/src/examples/simple_snapp.mjs
@@ -52,6 +52,15 @@ let account2 = Local.testAccounts[1].privateKey;
 let snappPrivKey = PrivateKey.random();
 let snappPubKey = snappPrivKey.toPublicKey();
 
+console.log('compile');
+let { provers, getVerificationKey } = SimpleSnapp.compile(snappPubKey);
+
+console.log('prove');
+let snapp = new SimpleSnapp(snappPubKey);
+let proof = snapp.prove(provers, 'update', [Field(3)]);
+console.log({ proof });
+
+console.log('deploy');
 await Mina.transaction(account1, async () => {
   let snapp = new SimpleSnapp(snappPubKey);
   const amount = UInt64.fromNumber(1e6);

--- a/src/examples/simple_snapp.mjs
+++ b/src/examples/simple_snapp.mjs
@@ -56,10 +56,10 @@ console.log('compile');
 let { provers, getVerificationKey } = SimpleSnapp.compile(snappPubKey);
 
 console.log('deploy');
-await Mina.transaction(account1, async () => {
+await Mina.transaction(account1, () => {
   let snapp = new SimpleSnapp(snappPubKey);
   const amount = UInt64.fromNumber(1e6);
-  const p = await Party.createSigned(account2);
+  const p = Party.createSigned(account2);
   p.balance.subInPlace(amount);
   snapp.deploy(amount, Field(1));
 })
@@ -73,9 +73,9 @@ let snapp = new SimpleSnapp(snappPubKey);
 let proof = await snapp.prove(provers, 'update', [Field(3)]);
 console.log({ proof });
 
-await Mina.transaction(account1, async () => {
+await Mina.transaction(account1, () => {
   let snapp = new SimpleSnapp(snappPubKey);
-  await snapp.update(Field(3));
+  snapp.update(Field(3));
 })
   .send()
   .wait();

--- a/src/examples/simple_snapp.mjs
+++ b/src/examples/simple_snapp.mjs
@@ -55,11 +55,6 @@ let snappPubKey = snappPrivKey.toPublicKey();
 console.log('compile');
 let { provers, getVerificationKey } = SimpleSnapp.compile(snappPubKey);
 
-console.log('prove');
-let snapp = new SimpleSnapp(snappPubKey);
-let proof = snapp.prove(provers, 'update', [Field(3)]);
-console.log({ proof });
-
 console.log('deploy');
 await Mina.transaction(account1, async () => {
   let snapp = new SimpleSnapp(snappPubKey);
@@ -72,6 +67,11 @@ await Mina.transaction(account1, async () => {
   .wait();
 var snappState = (await Mina.getAccount(snappPubKey)).snapp.appState[0];
 console.log('initial state: ' + snappState);
+
+console.log('prove');
+let snapp = new SimpleSnapp(snappPubKey);
+let proof = await snapp.prove(provers, 'update', [Field(3)]);
+console.log({ proof });
 
 await Mina.transaction(account1, async () => {
   let snapp = new SimpleSnapp(snappPubKey);

--- a/src/examples/simple_snapp.mjs
+++ b/src/examples/simple_snapp.mjs
@@ -1,0 +1,76 @@
+// this is a pure JS version of the simple_snapp.ts example, that could be the starting point
+// to develop a more explicit, less pretty API without decorators, which would have the huge benefit
+// of working without a custom TS config and even without TS at all
+
+import {
+  Field,
+  state,
+  State,
+  method,
+  UInt64,
+  PrivateKey,
+  SmartContract,
+  Mina,
+  Party,
+  isReady,
+  shutdown,
+} from 'snarkyjs';
+import 'reflect-metadata';
+
+await isReady;
+
+class SimpleSnapp extends SmartContract {
+  constructor(address) {
+    super(address);
+    this.x = State();
+  }
+  deploy(initialBalance, x) {
+    super.deploy();
+    this.balance.addInPlace(initialBalance);
+    this.x.set(x);
+  }
+  update(y) {
+    let x = this.x.get();
+    this.x.set(x.add(y));
+  }
+}
+
+// manually apply decorators:
+
+// @state(Field) x
+state(Field)(SimpleSnapp.prototype, 'x');
+
+// @method update(y: Field)
+Reflect.metadata('design:paramtypes', [Field])(SimpleSnapp.prototype, 'update');
+method(SimpleSnapp.prototype, 'update');
+
+// usual code
+let Local = Mina.LocalBlockchain();
+Mina.setActiveInstance(Local);
+let account1 = Local.testAccounts[0].privateKey;
+let account2 = Local.testAccounts[1].privateKey;
+let snappPrivKey = PrivateKey.random();
+let snappPubKey = snappPrivKey.toPublicKey();
+
+await Mina.transaction(account1, async () => {
+  let snapp = new SimpleSnapp(snappPubKey);
+  const amount = UInt64.fromNumber(1e6);
+  const p = await Party.createSigned(account2);
+  p.balance.subInPlace(amount);
+  snapp.deploy(amount, Field(1));
+})
+  .send()
+  .wait();
+var snappState = (await Mina.getAccount(snappPubKey)).snapp.appState[0];
+console.log('initial state: ' + snappState);
+
+await Mina.transaction(account1, async () => {
+  let snapp = new SimpleSnapp(snappPubKey);
+  await snapp.update(Field(3));
+})
+  .send()
+  .wait();
+snappState = (await Mina.getAccount(snappPubKey)).snapp.appState[0];
+console.log('final state: ' + snappState);
+
+shutdown();

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -5,6 +5,7 @@ import {
   Poseidon,
   AsFieldElements,
   picklesCompile,
+  Ledger,
 } from '../snarky';
 import { CircuitValue, toFieldsMagic } from './circuit_value';
 import {
@@ -13,6 +14,8 @@ import {
   Body,
   Party,
   PartyBalance,
+  toParty,
+  toProtocolState,
 } from './party';
 import { PrivateKey, PublicKey } from './signature';
 import * as Mina from './mina';
@@ -108,7 +111,7 @@ function createState<A>() {
         }
         p = Circuit.witness(Circuit.array(Field, r.length), () => xs);
       } else {
-        p = Circuit.witness(Circuit.array(Field, r.length), () => {
+        p = Circuit.witness(Circuit.array(Field, r.length), (): Field[] => {
           throw Error('this should never happen');
         });
       }
@@ -257,6 +260,7 @@ type methodEntry<T> = {
   witnessArgs: AsFieldElements<unknown>[];
   proofArgs: unknown[];
   args: { type: string; index: number }[];
+  witnessValues?: unknown[];
 };
 
 function isAsFields(typ: Object) {
@@ -266,6 +270,76 @@ function isAsFields(typ: Object) {
 }
 function isProof(typ: any) {
   return false; // TODO
+}
+
+type Statement = { transaction: Field; atParty: Field };
+
+function toStatement(
+  self: Party,
+  tail: Field,
+  state: ProtocolStatePredicate,
+  checked = false
+) {
+  // TODO implement checked version of hashing
+  // TODO hash together with tail in the right way
+  // console.dir(self, { depth: Infinity });
+  let atParty = Ledger.hashParty(toParty(self)); // this throws when self is not full of constants
+  let protocolStateHash = Ledger.hashProtocolState(toProtocolState(state));
+  let transaction = Ledger.hashTransaction(atParty, protocolStateHash);
+  return { transaction, atParty };
+}
+
+function checkStatement(
+  { transaction, atParty }: Statement,
+  self: Party,
+  tail: Field,
+  protocolState: ProtocolStatePredicate
+) {
+  let otherStatement = toStatement(self, tail, protocolState, true);
+  atParty.assertEquals(otherStatement.atParty);
+  transaction.assertEquals(otherStatement.transaction);
+}
+
+let mainContext = undefined as
+  | {
+      witnesses?: unknown[];
+      self: Party & { predicate: AccountPredicate };
+      protocolState: ProtocolStatePredicate;
+    }
+  | undefined;
+
+function withContext(context: typeof mainContext, f: Function) {
+  mainContext = context;
+  let result = f();
+  mainContext = undefined;
+  return result;
+}
+
+function picklesRuleFromFunction(
+  name: string,
+  func: (...args: unknown[]) => void,
+  witnessTypes: AsFieldElements<unknown>[],
+  onStart?: Function,
+  onEnd?: Function
+) {
+  function main(statement: Statement) {
+    onStart?.();
+    if (mainContext === undefined) throw Error('bug');
+    console.log(statement);
+    let { self, protocolState, witnesses } = mainContext;
+    console.log({ witnesses });
+    witnesses = witnessTypes.map(
+      witnesses
+        ? (type, i) => Circuit.witness(type, () => witnesses![i])
+        : emptyWitness
+    );
+    func(...witnesses);
+    let tail = Field.zero;
+    checkStatement(statement, self, tail, protocolState);
+    onEnd?.();
+  }
+
+  return [0, name, main];
 }
 
 /**
@@ -292,29 +366,47 @@ export class SmartContract {
     // TODO: think about how address should be passed in
     // if address is not provided, create a random one
     address ??= PrivateKey.random().toPublicKey();
-    let dummyInstance = new this(address);
-    let inductiveRules = (this._methods ?? []).map(
-      ({ methodName, witnessArgs }) => {
-        function main(transactionHash: Field) {
-          Mina.setCurrentTransaction({
-            sender: PrivateKey.random(), // TODO
-            parties: [],
-            nextPartyIndex: 0,
-            protocolState: ProtocolStatePredicate.ignoreAll(),
-          });
-          let witnesses = witnessArgs.map(emptyWitness); // TODO is this correct?
-          (dummyInstance[methodName] as any)(...witnesses); // call method in a way that `this` is defined
-          let hash = computeTransactionHash(Mina.currentTransaction);
-          console.log({ transactionHash, hash });
-          hash.assertEquals(transactionHash);
-          Mina.setCurrentTransaction(undefined);
-        }
-        return [0, methodName, main];
-      }
+    let instance = new this(address);
+
+    let rules = (this._methods ?? []).map(({ methodName, witnessArgs }) =>
+      picklesRuleFromFunction(
+        methodName,
+        (...args: unknown[]) => (instance[methodName] as any)(...args),
+        witnessArgs
+      )
     );
-    let output = picklesCompile(inductiveRules);
+
+    let output = withContext(
+      {
+        self: Party.defaultParty(address),
+        protocolState: ProtocolStatePredicate.ignoreAll(),
+      },
+      () => picklesCompile(rules)
+    );
     console.log('output', output);
     return output;
+  }
+
+  prove(provers: any[], methodName: keyof this, args: unknown[]) {
+    let SnappClass = this.constructor as never as typeof SmartContract;
+    let i = SnappClass._methods!.findIndex((m) => m.methodName === methodName);
+    if (!(i + 1)) throw Error(`Method ${methodName} not found!`);
+    let ctx = {
+      self: Party.defaultParty(this.address),
+      protocolState: ProtocolStatePredicate.ignoreAll(),
+    };
+    withContext(ctx, () => (this[methodName] as any)(...args));
+    let statement = toStatement(ctx.self, Field.zero, ctx.protocolState);
+    console.dir({ statement }, { depth: 5 });
+
+    return withContext(
+      {
+        self: Party.defaultParty(this.address),
+        protocolState: ProtocolStatePredicate.ignoreAll(),
+        witnesses: args,
+      },
+      () => provers[i](statement)
+    );
   }
 
   deploy(...args: any[]) {
@@ -326,6 +418,16 @@ export class SmartContract {
   }
 
   executionState(): ExecutionState {
+    // TODO
+    if (mainContext !== undefined) {
+      return {
+        transactionId: 0,
+        partyIndex: 0,
+        party: mainContext.self as Party & { predicate: AccountPredicate },
+        protocolStatePredicate: mainContext.protocolState,
+      };
+    }
+
     if (Mina.currentTransaction === undefined) {
       throw new Error('Cannot execute outside of a Mina.transaction() block.');
     }
@@ -340,7 +442,9 @@ export class SmartContract {
       const index = Mina.currentTransaction.nextPartyIndex++;
       const body = Body.keepAll(this.address);
       const predicate = AccountPredicate.ignoreAll();
-      const party = new Party(body, predicate);
+      const party = new Party(body, predicate) as Party & {
+        predicate: AccountPredicate;
+      };
       Mina.currentTransaction.parties.push(party);
 
       const s = {
@@ -358,7 +462,7 @@ export class SmartContract {
     return this.executionState().protocolStatePredicate;
   }
 
-  get self(): Party<AccountPredicate> {
+  get self() {
     return this.executionState().party;
   }
 
@@ -370,9 +474,9 @@ export class SmartContract {
     let nonce: UInt32;
     if (Circuit.inProver()) {
       let a = Mina.getAccount(this.address);
-      nonce = Circuit.witness<UInt32>(UInt32, () => a.nonce);
+      nonce = Circuit.witness(UInt32, () => a.nonce);
     } else {
-      const res = Circuit.witness<UInt32>(UInt32, () => {
+      const res = Circuit.witness(UInt32, () => {
         throw Error('this should never happen');
       });
       nonce = res;
@@ -400,7 +504,7 @@ export class SmartContract {
 type ExecutionState = {
   transactionId: number;
   partyIndex: number;
-  party: Party<AccountPredicate>;
+  party: Party & { predicate: AccountPredicate };
   protocolStatePredicate: ProtocolStatePredicate;
 };
 
@@ -409,11 +513,4 @@ function emptyWitness<A>(typ: AsFieldElements<A>) {
   return Circuit.witness(typ, () =>
     typ.ofFields(Array(typ.sizeInFields()).fill(Field.zero))
   );
-}
-
-// TODO
-function computeTransactionHash(tx: Mina.CurrentTransaction) {
-  if (tx === undefined) throw Error('Transaction is undefined');
-  let fields = toFieldsMagic(tx);
-  return Poseidon.hash(fields);
 }

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -485,12 +485,9 @@ export class Circuit {
 
   static newVariable(f: () => Field | number | string | boolean): Field;
 
-  static witness<T>(
-    ctor: {
-      toFields(x: T): Field[];
-      ofFields(x: Field[]): T;
-      sizeInFields(): number;
-    },
+  // this convoluted generic typing is needed to give type inference enough flexibility
+  static witness<T, S extends AsFieldElements<T> = AsFieldElements<T>>(
+    ctor: S,
     f: () => T
   ): T;
 
@@ -760,6 +757,10 @@ export class Ledger {
   applyPartiesTransaction(parties: Parties): void;
 
   getAccount(publicKey: { g: Group }): Account | null;
+
+  static hashParty(party: Party_): Field;
+  static hashProtocolState(protocolState: ProtocolStatePredicate_): Field;
+  static hashTransaction(partyHash: Field, protocolStateHash: Field): Field;
 }
 
 /**

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -496,7 +496,7 @@ export class Circuit {
   // static runAndCheck<T>(f : () => Promise<(() => T)>): Promise<T>;
   static runAndCheck<T>(f: () => Promise<() => T>): Promise<T>;
 
-  static runAndCheckSync(f: () => void): void;
+  static runAndCheckSync<T>(f: () => T): T;
 
   static array<T>(
     ctor: AsFieldElements<T>,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -761,6 +761,15 @@ export class Ledger {
   static hashParty(party: Party_): Field;
   static hashProtocolState(protocolState: ProtocolStatePredicate_): Field;
   static hashTransaction(partyHash: Field, protocolStateHash: Field): Field;
+
+  static hashPartyChecked(party: Party_): Field;
+  static hashProtocolStateChecked(
+    protocolState: ProtocolStatePredicate_
+  ): Field;
+  static hashTransactionChecked(
+    partyHash: Field,
+    protocolStateHash: Field
+  ): Field;
 }
 
 /**

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -496,6 +496,8 @@ export class Circuit {
   // static runAndCheck<T>(f : () => Promise<(() => T)>): Promise<T>;
   static runAndCheck<T>(f: () => Promise<() => T>): Promise<T>;
 
+  static runAndCheckSync(f: () => void): void;
+
   static array<T>(
     ctor: AsFieldElements<T>,
     length: number

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -335,6 +335,18 @@
       {
         "name": "create",
         "type": "function"
+      },
+      {
+        "name": "hashParty",
+        "type": "function"
+      },
+      {
+        "name": "hashProtocolState",
+        "type": "function"
+      },
+      {
+        "name": "hashTransaction",
+        "type": "function"
       }
     ]
   }

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -347,6 +347,18 @@
       {
         "name": "hashTransaction",
         "type": "function"
+      },
+      {
+        "name": "hashPartyChecked",
+        "type": "function"
+      },
+      {
+        "name": "hashProtocolStateChecked",
+        "type": "function"
+      },
+      {
+        "name": "hashTransactionChecked",
+        "type": "function"
       }
     ]
   }

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -165,6 +165,10 @@
         "type": "function"
       },
       {
+        "name": "runAndCheckSync",
+        "type": "function"
+      },
+      {
         "name": "asProver",
         "type": "function"
       },


### PR DESCRIPTION
This adds `SmartContract.prove`, which executes methods inside a Pickles prover. The prover is an output of the already existing `compile()` method.

This PR also contains initial work on constructing the public input -- called the _statement_ in the code. The statement consists of certain hashes of the transaction and of the proving `Party` which is constructed during method execution.

In `SmartContract.prove`, a method is run _twice_: First outside the proof, to obtain the statement, and once in the prover, which takes the statement as input. The current transaction is hashed again _inside_ the prover, which asserts that the result equals the input statement, as part of the snark circuit. The block producer will also hash the transaction they receive and pass it as a public input to the verifier. Thus, the transaction is fully constrained by the proof - the proof couldn't be used to attest to a different transaction.

The PR also adds a pure JS example (for quicker iterating), which is maintained as a useful reference to use snarkyjs in environments without TS decorator support.