### PR TITLE
Transaction Construction, Pt 5. Fix mock interface

### DIFF
--- a/src/build/extractJsooMethods.js
+++ b/src/build/extractJsooMethods.js
@@ -13,6 +13,7 @@ let classNames = [
   'Group',
   'Scalar',
   'Ledger',
+  'Pickles',
 ];
 
 (async () => {

--- a/src/examples/deploy/deploy.ts
+++ b/src/examples/deploy/deploy.ts
@@ -17,7 +17,7 @@ if (artifact === undefined)
 let { verificationKey } = artifact;
 
 // produce and log the transaction json; the fee payer is a dummy which has to be added later, by the signing logic
-let transactionJson = deploy(SimpleSnapp, snappAddress, verificationKey);
+let transactionJson = deploy(SimpleSnapp, snappPrivateKey, verificationKey);
 
 console.log(transactionJson);
 

--- a/src/lib/int.ts
+++ b/src/lib/int.ts
@@ -1,11 +1,18 @@
 import { Bool, Circuit, Field } from '../snarky';
 import { CircuitValue, prop } from './circuit_value';
 
-function argToField(name: string, x: { value: Field } | number): Field {
+function argToField(
+  name: string,
+  x: { value: Field } | number | string
+): Field {
   if (typeof x === 'number') {
     if (!Number.isInteger(x)) {
       throw new Error(`${name} expected integer argument. Got ${x}`);
     }
+    // looks weird that we pass it as a string.. but this will cover far more cases without error than just passing in the number,
+    // because the number gets truncated to an int32, while the number -> string is accurate for numbers up to 2^53 - 1
+    return new Field(String(x));
+  } else if (typeof x === 'string') {
     return new Field(x);
   } else {
     return x.value;
@@ -38,6 +45,10 @@ export class UInt64 extends CircuitValue {
 
   static fromNumber(x: number): UInt64 {
     return new UInt64(argToField('UInt64.fromNumber', x));
+  }
+
+  static fromString(s: string) {
+    return new UInt64(argToField('UInt64.fromString', s));
   }
 
   static NUM_BITS = 64;
@@ -182,6 +193,10 @@ export class UInt32 extends CircuitValue {
 
   static fromNumber(x: number): UInt32 {
     return new UInt32(argToField('UInt32.fromNumber', x));
+  }
+
+  static fromString(s: string) {
+    return new UInt64(argToField('UInt64.fromString', s));
   }
 
   static NUM_BITS = 32;

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -115,18 +115,19 @@ function createTransaction(sender: PrivateKey | undefined, f: () => unknown) {
 }
 
 interface MockMina extends Mina {
-  addAccount(publicKey: PublicKey, balance: number): void;
+  addAccount(publicKey: PublicKey, balance: string): void;
   /**
    * An array of 10 test accounts that have been pre-filled with
    * 30000000000 units of currency.
    */
   testAccounts: Array<{ publicKey: PublicKey; privateKey: PrivateKey }>;
+  applyJsonTransaction: (tx: string) => void;
 }
 
 /**
  * A mock Mina blockchain running locally and useful for testing.
  */
-export const LocalBlockchain: () => MockMina = () => {
+export function LocalBlockchain(): MockMina {
   const msPerSlot = 3 * 60 * 1000;
   const startTime = new Date().valueOf();
 
@@ -137,13 +138,13 @@ export const LocalBlockchain: () => MockMina = () => {
       Math.ceil((new Date().valueOf() - startTime) / msPerSlot)
     );
 
-  function addAccount(pk: PublicKey, balance: number) {
+  function addAccount(pk: PublicKey, balance: string) {
     ledger.addAccount(pk, balance);
   }
 
   let testAccounts = [];
   for (let i = 0; i < 10; ++i) {
-    const largeValue = 30000000000;
+    const largeValue = '30000000000';
     const k = PrivateKey.random();
     const pk = k.toPublicKey();
     addAccount(pk, largeValue);
@@ -180,14 +181,19 @@ export const LocalBlockchain: () => MockMina = () => {
     };
   }
 
+  function applyJsonTransaction(json: string) {
+    return ledger.applyJsonTransaction(json);
+  }
+
   return {
     currentSlot,
     getAccount,
     transaction,
+    applyJsonTransaction,
     addAccount,
     testAccounts,
   };
-};
+}
 
 let activeInstance: Mina = {
   currentSlot: () => {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -49,7 +49,7 @@ export function setCurrentTransaction(transaction: CurrentTransaction) {
 }
 
 interface Mina {
-  transaction(sender: PrivateKey, f: () => void | Promise<void>): Transaction;
+  transaction(sender: PrivateKey, f: () => unknown): Transaction;
   currentSlot(): UInt32;
   getAccount(publicKey: PublicKey): Account;
 }
@@ -127,7 +127,7 @@ interface MockMina extends Mina {
 /**
  * A mock Mina blockchain running locally and useful for testing.
  */
-export function LocalBlockchain(): MockMina {
+export function LocalBlockchain() {
   const msPerSlot = 3 * 60 * 1000;
   const startTime = new Date().valueOf();
 
@@ -167,7 +167,7 @@ export function LocalBlockchain(): MockMina {
     }
   }
 
-  function transaction(sender: PrivateKey, f: () => void | Promise<void>) {
+  function transaction(sender: PrivateKey, f: () => unknown) {
     let txn = createTransaction(sender, f);
     return {
       ...txn,

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -10,7 +10,7 @@ import {
 } from '../snarky';
 import { UInt32, UInt64 } from './int';
 import { PrivateKey, PublicKey } from './signature';
-import { Body, Predicate } from './party';
+import { Body, Party } from './party';
 import { toParty, toPartyBody } from './party-conversion';
 
 export { createUnsignedTransaction };
@@ -39,7 +39,7 @@ export type CurrentTransaction =
   | undefined
   | {
       sender?: PrivateKey;
-      parties: Array<{ body: Body; predicate: Predicate }>;
+      parties: Party[];
       nextPartyIndex: number;
     };
 
@@ -77,9 +77,7 @@ function createTransaction(sender: PrivateKey | undefined, f: () => unknown) {
     throw err;
   }
 
-  const otherParties: Array<Party_> = currentTransaction.parties.map((party) =>
-    toParty(party)
-  );
+  const otherParties = currentTransaction.parties.map(toParty);
 
   let feePayer: FeePayerParty;
   if (sender !== undefined) {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -13,7 +13,7 @@ import { PrivateKey, PublicKey } from './signature';
 import { Body, Party } from './party';
 import { toParty, toPartyBody } from './party-conversion';
 
-export { createUnsignedTransaction };
+export { createUnsignedTransaction, createSignedTransaction };
 
 interface TransactionId {
   wait(): Promise<void>;
@@ -56,6 +56,9 @@ interface Mina {
 
 function createUnsignedTransaction(f: () => unknown) {
   return createTransaction(undefined, f);
+}
+function createSignedTransaction(sender: PrivateKey, f: () => unknown) {
+  return createTransaction(sender, f);
 }
 
 function createTransaction(sender: PrivateKey | undefined, f: () => unknown) {
@@ -153,7 +156,7 @@ export function LocalBlockchain() {
 
   function getAccount(pk: PublicKey) {
     const r = ledger.getAccount(pk);
-    if (r == null) {
+    if (r == undefined) {
       throw new Error(
         `getAccount: Could not find account for ${JSON.stringify(pk.toJSON())}`
       );

--- a/src/lib/party-conversion.ts
+++ b/src/lib/party-conversion.ts
@@ -37,17 +37,8 @@ function toParty(party: Party): Party_ {
 }
 
 function toPartyBody(body: Body): PartyPredicated['body'] {
-  let p = body.update.permissions;
-  let permissions = { set: new Bool(false) };
-  // TODO
-  if (p.set) {
-  }
   return {
     ...body,
-    update: {
-      ...body.update,
-      permissions,
-    },
     events: body.events.events,
     depth: parseInt(body.depth.toString(), 10),
     // TODO

--- a/src/lib/party-conversion.ts
+++ b/src/lib/party-conversion.ts
@@ -1,39 +1,41 @@
 import {
-  Circuit,
-  Ledger,
   Field,
-  FeePayerParty,
-  Parties,
   Party_,
   ProtocolStatePredicate_,
   EpochDataPredicate_,
+  Control,
 } from '../snarky';
 import {
   Body,
   EpochDataPredicate,
-  Predicate,
+  Party,
   ProtocolStatePredicate,
 } from './party';
 import { UInt32 } from './int';
 
 export { toParty, toPartyBody, toProtocolState };
 
-function toParty(party: { body: Body; predicate: Predicate }): Party_ {
-  let predicate: Party_['predicate'];
+type PartyPredicated = Party_['data'];
+
+function toParty(party: Party): Party_ {
+  let predicate: PartyPredicated['predicate'];
   if (party.predicate === undefined) {
-    predicate = { type: 'accept' };
+    predicate = { kind: 'accept' };
   } else if (party.predicate instanceof UInt32) {
-    predicate = { type: 'nonce', value: party.predicate };
+    predicate = { kind: 'nonce', value: party.predicate };
   } else {
-    predicate = { type: 'full', value: party.predicate };
+    predicate = { kind: 'full', value: party.predicate };
   }
   return {
-    predicate,
-    body: toPartyBody(party.body),
+    data: {
+      predicate,
+      body: toPartyBody(party.body),
+    },
+    authorization: party.authorization,
   };
 }
 
-function toPartyBody(body: Body): Party_['body'] {
+function toPartyBody(body: Body): PartyPredicated['body'] {
   return {
     ...body,
     events: body.events.events,

--- a/src/lib/party-conversion.ts
+++ b/src/lib/party-conversion.ts
@@ -4,6 +4,7 @@ import {
   ProtocolStatePredicate_,
   EpochDataPredicate_,
   Control,
+  Bool,
 } from '../snarky';
 import {
   Body,
@@ -36,8 +37,17 @@ function toParty(party: Party): Party_ {
 }
 
 function toPartyBody(body: Body): PartyPredicated['body'] {
+  let p = body.update.permissions;
+  let permissions = { set: new Bool(false) };
+  // TODO
+  if (p.set) {
+  }
   return {
     ...body,
+    update: {
+      ...body.update,
+      permissions,
+    },
     events: body.events.events,
     depth: parseInt(body.depth.toString(), 10),
     // TODO

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -148,14 +148,6 @@ export class Perm {
  */
 export class Permissions {
   /**
-   * True means that this account can stake directly. False means this account
-   * cannot.
-   *
-   * TODO: Is this correct?
-   */
-  stake: Bool;
-
-  /**
    * The [[ Perm ]] corresponding to the 8 state fields associated with an
    * account.
    */
@@ -202,7 +194,7 @@ export class Permissions {
    * changed whenever the [[ Permissions.setVerificationKey ]] is changed.
    * Effectively "upgradability" of the smart contract.
    */
-  setSnappUri: Perm;
+  setZkappUri: Perm;
 
   /**
    * The [[ Perm ]] corresponding to the ability to change the sequence state
@@ -210,7 +202,7 @@ export class Permissions {
    *
    * TODO: Define sequence state here as well.
    */
-  editRollupState: Perm;
+  editSequenceState: Perm;
 
   /**
    * The [[ Perm ]] corresponding to the ability to set the token symbol for
@@ -218,22 +210,24 @@ export class Permissions {
    */
   setTokenSymbol: Perm;
 
+  // TODO: doccomments
+  incrementNonce: Perm;
+  setVotingFor: Perm;
+
   /**
    * Default permissions are:
-   *   [[ Permissions.stake ]]=true
    *   [[ Permissions.editState ]]=[[ Perm.proof ]]
    *   [[ Permissions.send ]]=[[ Perm.signature ]]
    *   [[ Permissions.receive ]]=[[ Perm.proof ]]
    *   [[ Permissions.setDelegate ]]=[[ Perm.signature ]]
    *   [[ Permissions.setPermissions ]]=[[ Perm.signature ]]
    *   [[ Permissions.setVerificationKey ]]=[[ Perm.signature ]]
-   *   [[ Permissions.setSnappUri ]]=[[ Perm.signature ]]
-   *   [[ Permissions.editRollupState ]]=[[ Perm.proof ]]
+   *   [[ Permissions.setZkappUri ]]=[[ Perm.signature ]]
+   *   [[ Permissions.editSequenceState ]]=[[ Perm.proof ]]
    *   [[ Permissions.setTokenSymbol ]]=[[ Perm.signature ]]
    */
   static default(): Permissions {
     return new Permissions(
-      new Bool(true),
       Perm.proof(),
       Perm.signature(),
       Perm.proof(),
@@ -242,32 +236,36 @@ export class Permissions {
       Perm.signature(),
       Perm.signature(),
       Perm.proof(),
+      Perm.signature(),
+      Perm.signature(),
       Perm.signature()
     );
   }
 
   constructor(
-    stake: Bool,
     editState: Perm,
     send: Perm,
     receive: Perm,
     setDelegate: Perm,
     setPermissions: Perm,
     setVerificationKey: Perm,
-    setSnappUri: Perm,
-    editRollupState: Perm,
-    setTokenSymbol: Perm
+    setZkappUri: Perm,
+    editSequenceState: Perm,
+    setTokenSymbol: Perm,
+    incrementNonce: Perm,
+    setVotingFor: Perm
   ) {
-    this.stake = stake;
     this.editState = editState;
     this.send = send;
     this.receive = receive;
     this.setDelegate = setDelegate;
     this.setPermissions = setPermissions;
     this.setVerificationKey = setVerificationKey;
-    this.setSnappUri = setSnappUri;
-    this.editRollupState = editRollupState;
+    this.setZkappUri = setZkappUri;
+    this.editSequenceState = editSequenceState;
     this.setTokenSymbol = setTokenSymbol;
+    this.incrementNonce = incrementNonce;
+    this.setVotingFor = setVotingFor;
   }
 }
 

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -1,5 +1,5 @@
 import { CircuitValue } from './circuit_value';
-import { Group, Field, Bool, VerificationKey } from '../snarky';
+import { Group, Field, Bool, Control } from '../snarky';
 import { PrivateKey, PublicKey } from './signature';
 import { UInt64, UInt32, Int64 } from './int';
 import * as Mina from './mina';
@@ -742,6 +742,7 @@ export type Predicate = undefined | UInt32 | AccountPredicate;
 export class Party {
   body: Body;
   predicate: Predicate;
+  authorization: Control = { kind: 'none' };
 
   constructor(body: Body, predicate: Predicate) {
     this.body = body;

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -1,4 +1,4 @@
-import { Poseidon, Group, Field, Bool, Scalar } from '../snarky';
+import { Poseidon, Group, Field, Bool, Scalar, Ledger } from '../snarky';
 import { prop, CircuitValue } from './circuit_value';
 
 /**
@@ -41,6 +41,14 @@ export class PrivateKey extends CircuitValue {
   toPublicKey(): PublicKey {
     return new PublicKey(Group.generator.scale(this.s));
   }
+
+  static fromBase58(privateKeyBase58: string) {
+    let scalar = Ledger.privateKeyOfString(privateKeyBase58);
+    return new PrivateKey(scalar);
+  }
+  toBase58() {
+    return Ledger.privateKeyToString(this);
+  }
 }
 
 export class PublicKey extends CircuitValue {
@@ -62,6 +70,14 @@ export class PublicKey extends CircuitValue {
   isEmpty() {
     // there are no curve points with x === 0
     return this.g.x.isZero();
+  }
+
+  static fromBase58(publicKeyBase58: string) {
+    let group = Ledger.publicKeyOfString(publicKeyBase58);
+    return new PublicKey(group);
+  }
+  toBase58() {
+    return Ledger.publicKeyToString(this);
   }
 }
 

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -545,7 +545,9 @@ function deploy<S extends typeof SmartContract>(
       let amount = UInt64.fromString(String(initialBalance));
       snapp.self.balance.addInPlace(amount);
       // optional second party: the sender/fee payer who also funds the zkapp
-      let party = Party.createSigned(initialBalanceFundingAccountKey);
+      let party = Party.createSigned(initialBalanceFundingAccountKey, {
+        isSameAsFeePayer: true,
+      });
       party.balance.subInPlace(amount);
     }
   });

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -542,10 +542,10 @@ async function call<S extends typeof SmartContract>(
     methodName as any,
     methodArguments
   );
-  // turn proof into string
-  let proofString = Pickles.proofToString(proof);
-  console.log(proofString);
-  console.dir(selfParty.body.update.appState, { depth: 10 });
+  selfParty.authorization = {
+    kind: 'proof',
+    value: Pickles.proofToString(proof),
+  };
   let tx = Mina.createUnsignedTransaction(() => {
     Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
   });

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -440,14 +440,6 @@ export class SmartContract {
     return { statement, selfParty };
   }
 
-  deploy() {
-    try {
-      // this.executionState().party.body.update.verificationKey.set = Bool(true);
-    } catch {
-      throw new Error('Cannot deploy SmartContract outside a transaction.');
-    }
-  }
-
   executionState(): ExecutionState {
     // TODO
     if (mainContext !== undefined) {
@@ -582,7 +574,7 @@ async function deploy<S extends typeof SmartContract>(
     }
     // main party: the zkapp account
     let snapp = new SmartContract(address);
-    snapp.deploy();
+    (snapp as any).deploy?.();
     i = Mina.currentTransaction!.nextPartyIndex - 1;
     snapp.self.update.verificationKey.set = Bool(true);
     snapp.self.update.verificationKey.value = verificationKey;

--- a/src/lib/snapp.ts
+++ b/src/lib/snapp.ts
@@ -560,9 +560,11 @@ function compile<S extends typeof SmartContract>(
   SmartContract: S,
   address: PublicKey
 ) {
-  let { getVerificationKeyArtifact } = SmartContract.compile(address);
+  // TODO: instead of returning provers, return an artifact from which provers can be recovered
+  let { getVerificationKeyArtifact, provers } = SmartContract.compile(address);
   return {
     verificationKey: getVerificationKeyArtifact(),
+    provers,
   };
 }
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -794,8 +794,12 @@ export let isReady: Promise<undefined>;
 
 type Statement = { transaction: Field; atParty: Field };
 
-export let picklesCompile: (...args: any) => {
-  getVerificationKeyArtifact: () => string;
-  provers: ((statement: Statement) => Promise<unknown>)[];
-  verify: (statement: Statement, proof: unknown) => Promise<boolean>;
+export const Pickles: {
+  compile: (...args: any) => {
+    getVerificationKeyArtifact: () => string;
+    provers: ((statement: Statement) => Promise<unknown>)[];
+    verify: (statement: Statement, proof: unknown) => Promise<boolean>;
+  };
+
+  proofToString: (proof: unknown) => string;
 };

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -814,7 +814,9 @@ export class Ledger {
   ): string;
 
   static publicKeyToString(publicKey: { g: Group }): string;
+  static publicKeyOfString(publicKeyBase58: string): Group;
   static privateKeyToString(privateKey: { s: Scalar }): string;
+  static privateKeyOfString(privateKeyBase58: string): Scalar;
 
   static partiesToJson(parties: Parties): string;
   static partiesToGraphQL(parties: Parties): string;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -784,6 +784,13 @@ export class Ledger {
     protocolStateHash: Field
   ): Field;
 
+  static signFeePayer(txJson: string, privateKey: { s: Scalar }): string;
+  static signOtherParty(
+    txJson: string,
+    privateKey: { s: Scalar },
+    i: number
+  ): string;
+
   static partiesToJson(parties: Parties): string;
   static partiesToGraphQL(parties: Parties): string;
 }

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -762,12 +762,13 @@ interface Account {
 
 export class Ledger {
   static create(
-    genesisAccounts: Array<{ publicKey: { g: Group }; balance: number }>
+    genesisAccounts: Array<{ publicKey: { g: Group }; balance: string }>
   ): Ledger;
 
-  addAccount(publicKey: { g: Group }, balance: number): void;
+  addAccount(publicKey: { g: Group }, balance: string): void;
 
   applyPartiesTransaction(parties: Parties): void;
+  applyJsonTransaction(parties: string): void;
 
   getAccount(publicKey: { g: Group }): Account | null;
 
@@ -790,6 +791,9 @@ export class Ledger {
     privateKey: { s: Scalar },
     i: number
   ): string;
+
+  static publicKeyToString(publicKey: { g: Group }): string;
+  static privateKeyToString(privateKey: { s: Scalar }): string;
 
   static partiesToJson(parties: Parties): string;
   static partiesToGraphQL(parties: Parties): string;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -723,13 +723,21 @@ interface FullAccountPredicate_ {
 }
 
 type AccountPredicate_ =
-  | { type: 'accept' }
-  | { type: 'nonce'; value: UInt32_ }
-  | { type: 'full'; value: FullAccountPredicate_ };
+  | { kind: 'accept' }
+  | { kind: 'nonce'; value: UInt32_ }
+  | { kind: 'full'; value: FullAccountPredicate_ };
+
+type Control =
+  | { kind: 'none' }
+  | { kind: 'signature'; value: string }
+  | { kind: 'proof'; value: string };
 
 interface Party_ {
-  body: PartyBody;
-  predicate: AccountPredicate_;
+  data: {
+    body: PartyBody;
+    predicate: AccountPredicate_;
+  };
+  authorization: Control;
 }
 
 interface FeePayerParty {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -771,7 +771,7 @@ export class Ledger {
   applyPartiesTransaction(parties: Parties): Account[];
   applyJsonTransaction(parties: string): Account[];
 
-  getAccount(publicKey: { g: Group }): Account | null;
+  getAccount(publicKey: { g: Group }): Account | undefined;
 
   static hashParty(party: Party_): Field;
   static hashProtocolState(protocolState: ProtocolStatePredicate_): Field;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -645,10 +645,10 @@ interface OrIgnore_<A> {
   value: A;
 }
 
-interface SetOrKeep_<A> {
+type SetOrKeep_<A> = {
   set: Bool;
-  value: A;
-}
+  value?: A;
+};
 
 interface ClosedInterval_<A> {
   lower: A;
@@ -686,12 +686,28 @@ interface Int64_ {
   uint64Value(): Field;
 }
 
+type auth_required = string;
+
+interface Permissions {
+  editState: auth_required;
+  send: auth_required;
+  receive: auth_required;
+  setSelegate: auth_required;
+  setPermissions: auth_required;
+  setVerificationKey: auth_required;
+  setZkappUri: auth_required;
+  editSequenceState: auth_required;
+  setTokenSymbol: auth_required;
+  incrementNonce: auth_required;
+  setVotingFor: auth_required;
+}
+
 interface PartyUpdate {
   appState: Array<SetOrKeep_<Field>>;
   delegate: SetOrKeep_<{ g: Group }>;
   votingFor: SetOrKeep_<Field>;
   verificationKey: SetOrKeep_<string>;
-  // TODO: permissions
+  permissions: SetOrKeep_<Permissions>;
   // TODO: snapp uri
   // TODO: token symbol
   // TODO: timing

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -686,20 +686,24 @@ interface Int64_ {
   uint64Value(): Field;
 }
 
-type auth_required = string;
+type AuthRequired = {
+  constant: Bool;
+  signatureNecessary: Bool;
+  signatureSufficient: Bool;
+};
 
-interface Permissions {
-  editState: auth_required;
-  send: auth_required;
-  receive: auth_required;
-  setSelegate: auth_required;
-  setPermissions: auth_required;
-  setVerificationKey: auth_required;
-  setZkappUri: auth_required;
-  editSequenceState: auth_required;
-  setTokenSymbol: auth_required;
-  incrementNonce: auth_required;
-  setVotingFor: auth_required;
+interface Permissions_ {
+  editState: AuthRequired;
+  send: AuthRequired;
+  receive: AuthRequired;
+  setDelegate: AuthRequired;
+  setPermissions: AuthRequired;
+  setVerificationKey: AuthRequired;
+  setZkappUri: AuthRequired;
+  editSequenceState: AuthRequired;
+  setTokenSymbol: AuthRequired;
+  incrementNonce: AuthRequired;
+  setVotingFor: AuthRequired;
 }
 
 interface PartyUpdate {
@@ -707,7 +711,7 @@ interface PartyUpdate {
   delegate: SetOrKeep_<{ g: Group }>;
   votingFor: SetOrKeep_<Field>;
   verificationKey: SetOrKeep_<string>;
-  permissions: SetOrKeep_<Permissions>;
+  permissions: SetOrKeep_<Permissions_>;
   // TODO: snapp uri
   // TODO: token symbol
   // TODO: timing

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -755,6 +755,7 @@ interface SnappAccount {
 }
 
 interface Account {
+  publicKey: { g: Group };
   balance: UInt64_;
   nonce: UInt32_;
   snapp: SnappAccount;
@@ -767,8 +768,8 @@ export class Ledger {
 
   addAccount(publicKey: { g: Group }, balance: string): void;
 
-  applyPartiesTransaction(parties: Parties): void;
-  applyJsonTransaction(parties: string): void;
+  applyPartiesTransaction(parties: Parties): Account[];
+  applyJsonTransaction(parties: string): Account[];
 
   getAccount(publicKey: { g: Group }): Account | null;
 

--- a/src/snarky/index.js
+++ b/src/snarky/index.js
@@ -1,6 +1,6 @@
 import { getSnarky, snarky_ready, shutdown } from './wrapper';
 import snarkySpec from './snarky-class-spec.json';
-import { proxyClasses, proxyFunctions } from './proxy.js';
+import { proxyClasses } from './proxy.js';
 
 export {
   Field,
@@ -12,19 +12,12 @@ export {
   Ledger,
   shutdown,
   isReady,
-  picklesCompile,
+  Pickles,
 };
 
 let isReadyBoolean = false;
 let isReady = snarky_ready.then(() => (isReadyBoolean = true));
 let isItReady = () => isReadyBoolean;
 
-let { Field, Bool, Circuit, Poseidon, Group, Scalar, Ledger } = proxyClasses(
-  getSnarky,
-  isItReady,
-  snarkySpec
-);
-
-let { picklesCompile } = proxyFunctions(getSnarky, isItReady, [
-  'picklesCompile',
-]);
+let { Field, Bool, Circuit, Poseidon, Group, Scalar, Ledger, Pickles } =
+  proxyClasses(getSnarky, isItReady, snarkySpec);

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -373,5 +373,18 @@
         "type": "function"
       }
     ]
+  },
+  {
+    "name": "Pickles",
+    "props": [
+      {
+        "name": "compile",
+        "type": "function"
+      },
+      {
+        "name": "proofToString",
+        "type": "function"
+      }
+    ]
   }
 ]

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -373,6 +373,14 @@
         "type": "function"
       },
       {
+        "name": "publicKeyToString",
+        "type": "function"
+      },
+      {
+        "name": "privateKeyToString",
+        "type": "function"
+      },
+      {
         "name": "partiesToJson",
         "type": "function"
       },

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -377,7 +377,15 @@
         "type": "function"
       },
       {
+        "name": "publicKeyOfString",
+        "type": "function"
+      },
+      {
         "name": "privateKeyToString",
+        "type": "function"
+      },
+      {
+        "name": "privateKeyOfString",
         "type": "function"
       },
       {

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -365,6 +365,14 @@
         "type": "function"
       },
       {
+        "name": "signFeePayer",
+        "type": "function"
+      },
+      {
+        "name": "signOtherParty",
+        "type": "function"
+      },
+      {
         "name": "partiesToJson",
         "type": "function"
       },


### PR DESCRIPTION
This PR was were end-to-end testing began. I added some missing pieces for that, and then focused on getting transactions accepted by the existing mock Mina interface, which gets achieved with this PR.

* Add `call()` to create transactions with proof for calling a method
* Implement signing transactions (in snarkyjs)
* Add `applyJsonTransaction`, to apply a JSON transaction to the mock ledger
* Implement the Permissions API (needed to apply proof transactions, because the default permissions are all `signature`)
* Various other transaction fixes
* Add methods `toBase58` and `fromBase58` to both `PublicKey` and `PrivateKey` -- this is needed to use keys from outside in snarkyjs, e.g. integration test.