### PR TITLE
Transaction Construction, Pt 7. Fully working transactions

### DIFF
--- a/src/examples/rollup/wip.ts
+++ b/src/examples/rollup/wip.ts
@@ -256,7 +256,6 @@ class RollupZkapp extends SmartContract {
     deposits: MerkleStack<RollupDeposit>,
     lastUpatedPeriod: UInt32
   ) {
-    super.deploy();
     this.self.balance.addInPlace(senderAmount);
     this.operatorsCommitment.set(operatorsDb.commitment());
     this.lastUpdatedPeriod.set(lastUpatedPeriod);
@@ -378,7 +377,7 @@ function main() {
   const minaSender = PrivateKey.random();
   const Local = Mina.LocalBlockchain();
   Mina.setActiveInstance(Local);
-  const largeValue = 30000000000;
+  const largeValue = '30000000000';
   Local.addAccount(minaSender.toPublicKey(), largeValue);
 
   // TODO: Put real value

--- a/src/examples/rollup/wip.ts
+++ b/src/examples/rollup/wip.ts
@@ -7,7 +7,6 @@ import {
   Signature,
   Party,
   Permissions,
-  Perm,
   State,
   SmartContract,
   state,
@@ -266,8 +265,8 @@ class RollupZkapp extends SmartContract {
     );
     let perms = Permissions.default();
     // Force users to use the deposit method to send to this account
-    perms.receive = Perm.proof();
-    perms.editState = Perm.proof();
+    perms.receive = Permissions.proof();
+    perms.editState = Permissions.proof();
     this.self.update.permissions.setValue(perms);
   }
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1,10 +1,10 @@
 // This is for an account where any of a list of public keys can update the state
 
-import { Circuit, Ledger, Field, FeePayerParty, Parties } from '../snarky';
+import { Circuit, Ledger, Field } from '../snarky';
 import { UInt32, UInt64 } from './int';
 import { PrivateKey, PublicKey } from './signature';
-import { Body, Party } from './party';
-import { toFeePayerPartyBody, toParty } from './party-conversion';
+import { FeePayer, Party } from './party';
+import { toParties } from './party-conversion';
 
 export { createUnsignedTransaction, createSignedTransaction };
 
@@ -54,13 +54,16 @@ function createSignedTransaction(sender: PrivateKey, f: () => unknown) {
   return createTransaction(sender, f);
 }
 
-function createTransaction(sender: PrivateKey | undefined, f: () => unknown) {
+function createTransaction(
+  senderKey: PrivateKey | undefined,
+  f: () => unknown
+) {
   if (currentTransaction !== undefined) {
     throw new Error('Cannot start new transaction within another transaction');
   }
 
   currentTransaction = {
-    sender,
+    sender: senderKey,
     parties: [],
     nextPartyIndex: 0,
   };
@@ -73,39 +76,39 @@ function createTransaction(sender: PrivateKey | undefined, f: () => unknown) {
     throw err;
   }
 
-  const otherParties = currentTransaction.parties.map(toParty);
-
-  let feePayer: FeePayerParty;
-  if (sender !== undefined) {
-    // if sender is provided, fetch account to get nonce
-    const senderPubkey = sender.toPublicKey();
-    let senderAccount = getAccount(senderPubkey);
-    feePayer = {
-      body: toFeePayerPartyBody(
-        Body.keepAllWithNonce(senderPubkey, senderAccount.nonce)
-      ),
-    };
+  let feePayer: FeePayer;
+  if (senderKey !== undefined) {
+    // if senderKey is provided, fetch account to get nonce and mark to be signed
+    let senderAddress = senderKey.toPublicKey();
+    let senderAccount = getAccount(senderAddress);
+    feePayer = Party.defaultFeePayer(
+      senderAddress,
+      senderKey,
+      senderAccount.nonce
+    );
   } else {
     // otherwise use a dummy fee payer that has to be filled in later
-    feePayer = {
-      body: toFeePayerPartyBody(Body.dummyFeePayer()),
-    };
+    feePayer = Party.dummyFeePayer();
   }
 
-  const txn: Parties = { otherParties, feePayer };
+  let transaction = { otherParties: currentTransaction.parties, feePayer };
 
   nextTransactionId.value += 1;
   currentTransaction = undefined;
   return {
-    transaction: txn,
+    transaction,
+
     toJSON() {
-      return Ledger.partiesToJson(txn);
+      return Ledger.partiesToJson(toParties(this.transaction));
     },
 
+    // TODO: this is untested, investigate if useful
     toGraphQL() {
       return `mutation MyMutation {
         __typename
-        sendZkapp(input: ${Ledger.partiesToGraphQL(txn)})}`;
+        sendZkapp(input: ${Ledger.partiesToGraphQL(
+          toParties(this.transaction)
+        )})}`;
     },
   };
 }
@@ -168,11 +171,8 @@ export function LocalBlockchain() {
     return {
       ...txn,
       send() {
-        const res = (async () =>
-          ledger.applyPartiesTransaction(txn.transaction))();
-        return {
-          wait: () => res,
-        };
+        ledger.applyPartiesTransaction(toParties(txn.transaction));
+        return { wait: async () => {} };
       },
     };
   }

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -3,7 +3,7 @@
 import { Circuit, Ledger, Field } from '../snarky';
 import { UInt32, UInt64 } from './int';
 import { PrivateKey, PublicKey } from './signature';
-import { FeePayer, Party } from './party';
+import { addMissingSignatures, FeePayer, Parties, Party } from './party';
 import { toParties } from './party-conversion';
 
 export { createUnsignedTransaction, createSignedTransaction };
@@ -13,6 +13,8 @@ interface TransactionId {
 }
 
 interface Transaction {
+  transaction: Parties;
+  sign(): void;
   send(): TransactionId;
 }
 
@@ -97,6 +99,11 @@ function createTransaction(
   currentTransaction = undefined;
   return {
     transaction,
+
+    sign(additionalKeys?: PrivateKey[]) {
+      addMissingSignatures(this.transaction, additionalKeys);
+      return this;
+    },
 
     toJSON() {
       return Ledger.partiesToJson(toParties(this.transaction));

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -178,6 +178,7 @@ export function LocalBlockchain() {
     return {
       ...txn,
       send() {
+        txn.sign();
         ledger.applyPartiesTransaction(toParties(txn.transaction));
         return { wait: async () => {} };
       },

--- a/src/lib/party-conversion.ts
+++ b/src/lib/party-conversion.ts
@@ -4,7 +4,7 @@ import {
   ProtocolStatePredicate_,
   EpochDataPredicate_,
   FeePayerParty_,
-  Parties,
+  Parties_,
 } from '../snarky';
 import {
   Body,
@@ -25,7 +25,7 @@ function toParties({
 }: {
   feePayer: FeePayer;
   otherParties: Party[];
-}): Parties {
+}): Parties_ {
   return {
     feePayer: toFeePayer(feePayer),
     otherParties: otherParties.map(toParty),

--- a/src/lib/party-conversion.ts
+++ b/src/lib/party-conversion.ts
@@ -3,23 +3,56 @@ import {
   Party_,
   ProtocolStatePredicate_,
   EpochDataPredicate_,
-  FeePayerParty,
+  FeePayerParty_,
+  Parties,
 } from '../snarky';
 import {
   Body,
   EpochDataPredicate,
+  FeePayer,
+  LazyControl,
   Party,
   ProtocolStatePredicate,
 } from './party';
 import { UInt32 } from './int';
+import { PrivateKey } from './signature';
 
-export { toParty, toPartyBody, toFeePayerPartyBody, toProtocolState };
+export { toParties, toParty, toProtocolState };
+
+function toParties({
+  feePayer,
+  otherParties,
+}: {
+  feePayer: FeePayer;
+  otherParties: Party[];
+}): Parties {
+  return {
+    feePayer: toFeePayer(feePayer),
+    otherParties: otherParties.map(toParty),
+  };
+}
 
 function toParty(party: Party): Party_ {
   return {
     body: toPartyBody(party.body),
-    authorization: party.authorization,
+    authorization: toControl(party.authorization),
   };
+}
+
+function toFeePayer(party: FeePayer): FeePayerParty_ {
+  return {
+    body: toFeePayerPartyBody(party.body),
+    authorization: toControl(party.authorization),
+  };
+}
+
+function toControl<T extends LazyControl>(
+  authorization: T
+):
+  | Exclude<T, { kind: 'lazy-signature'; privateKey?: PrivateKey }>
+  | { kind: 'none' } {
+  if (authorization.kind === 'lazy-signature') return { kind: 'none' };
+  return authorization as never;
 }
 
 function toPartyBody(body: Body): Party_['body'] {
@@ -45,7 +78,7 @@ function toPartyBody(body: Body): Party_['body'] {
 
 function toFeePayerPartyBody(
   body: Body & { accountPrecondition: UInt32 }
-): FeePayerParty['body'] {
+): FeePayerParty_['body'] {
   return {
     ...body,
     events: body.events.events,

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -637,7 +637,7 @@ export class Party {
     return this.body.publicKey;
   }
 
-  sign(privateKey: PrivateKey) {
+  sign(privateKey?: PrivateKey) {
     this.authorization = { kind: 'lazy-signature', privateKey };
   }
 
@@ -702,7 +702,7 @@ export class Party {
     }
 
     // if the fee payer is the same party as this one, we have to start the nonce predicate at one higher bc the fee payer already increases its nonce
-    let nonceIncrease = options?.isSameAsFeePayer
+    let nonceIncrement = options?.isSameAsFeePayer
       ? new UInt32(Field.one)
       : UInt32.zero;
     // now, we check how often this party already updated its nonce in this tx, and increase nonce from `getAccount` by that amount
@@ -710,9 +710,9 @@ export class Party {
       let shouldIncreaseNonce = party.publicKey
         .equals(publicKey)
         .and(party.body.incrementNonce);
-      nonceIncrease.add(new UInt32(shouldIncreaseNonce.toField()));
+      nonceIncrement.add(new UInt32(shouldIncreaseNonce.toField()));
     }
-    let nonce = account.nonce.add(nonceIncrease);
+    let nonce = account.nonce.add(nonceIncrement);
 
     body.accountPrecondition = nonce;
     body.incrementNonce = Bool(true);

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -20,27 +20,13 @@ const ZkappStateLength: number = 8;
 /**
  * Timing info inside an account.
  */
-export class Timing {
+export type Timing = {
   initialMinimumBalance: Balance;
   cliffTime: GlobalSlot;
   cliffAmount: Amount;
   vestingPeriod: GlobalSlot;
   vestingIncrement: Amount;
-
-  constructor(
-    initialMinimumBalance: Balance,
-    cliffTime: GlobalSlot,
-    cliffAmount: Amount,
-    vestingPeriod: GlobalSlot,
-    vestingIncrement: Amount
-  ) {
-    this.initialMinimumBalance = initialMinimumBalance;
-    this.cliffTime = cliffTime;
-    this.cliffAmount = cliffAmount;
-    this.vestingPeriod = vestingPeriod;
-    this.vestingIncrement = vestingIncrement;
-  }
-}
+};
 
 /**
  * Either set a value or keep it the same.
@@ -277,7 +263,7 @@ class TokenSymbol extends CircuitValue {
   // (Bool, Num_bits.n) Pickles_types.Vector.t
 }
 
-export class Update {
+export type Update = {
   appState: Array<SetOrKeep<Field>>;
   delegate: SetOrKeep<PublicKey>;
   verificationKey: SetOrKeep<string>;
@@ -286,28 +272,7 @@ export class Update {
   tokenSymbol: SetOrKeep<TokenSymbol>;
   timing: SetOrKeep<Timing>;
   votingFor: SetOrKeep<Field>;
-
-  constructor(
-    appState: Array<SetOrKeep<Field>>,
-    delegate: SetOrKeep<PublicKey>,
-    verificationKey: SetOrKeep<string>,
-    permissions: SetOrKeep<Permissions>,
-    zkappUri: SetOrKeep<String_>,
-    tokenSymbol: SetOrKeep<TokenSymbol>,
-    timing: SetOrKeep<Timing>,
-    votingFor: SetOrKeep<Field>
-  ) {
-    this.appState = appState;
-    this.delegate = delegate;
-    this.verificationKey = verificationKey;
-    this.permissions = permissions;
-    this.zkappUri = zkappUri;
-    this.tokenSymbol = tokenSymbol;
-    this.timing = timing;
-    this.votingFor = votingFor;
-  }
-}
-
+};
 export const getDefaultTokenId = () => Field.one;
 
 // TODO
@@ -389,16 +354,16 @@ export let Body = {
       appState.push(keep(Field.zero));
     }
 
-    const update = new Update(
+    const update: Update = {
       appState,
-      keep(new PublicKey(Group.generator)),
-      keep(''),
-      keep(Permissions.default()),
-      keep(undefined as any),
-      keep(undefined as any),
-      keep(undefined as any),
-      keep(Field.zero)
-    );
+      delegate: keep(new PublicKey(Group.generator)),
+      verificationKey: keep(''),
+      permissions: keep(Permissions.default()),
+      zkappUri: keep(undefined as any),
+      tokenSymbol: keep(undefined as any),
+      timing: keep(undefined as any),
+      votingFor: keep(Field.zero),
+    };
     return {
       publicKey,
       update,
@@ -665,7 +630,7 @@ const uint32 = () => new ClosedInterval(UInt32.fromNumber(0), UInt32.MAXINT());
  */
 const uint64 = () => new ClosedInterval(UInt64.fromNumber(0), UInt64.MAXINT());
 
-export class AccountPrecondition {
+export type AccountPrecondition = {
   balance: ClosedInterval<UInt64>;
   nonce: ClosedInterval<UInt32>;
   receiptChainHash: OrIgnore<Field>;
@@ -674,45 +639,25 @@ export class AccountPrecondition {
   state: Array<OrIgnore<Field>>;
   sequenceState: OrIgnore<Field>;
   provedState: OrIgnore<Bool>;
-
-  static ignoreAll(): AccountPrecondition {
+};
+export let AccountPrecondition = {
+  ignoreAll(): AccountPrecondition {
     let appState: Array<OrIgnore<Field>> = [];
     for (let i = 0; i < ZkappStateLength; ++i) {
       appState.push(ignore(Field.zero));
     }
-
-    return new AccountPrecondition(
-      uint64(),
-      uint32(),
-      ignore(Field.zero),
-      ignore(new PublicKey(Group.generator)),
-      ignore(new PublicKey(Group.generator)),
-      appState,
-      ignore(Field.zero),
-      ignore(new Bool(false))
-    );
-  }
-
-  constructor(
-    balance: ClosedInterval<UInt64>,
-    nonce: ClosedInterval<UInt32>,
-    receiptChainHash: OrIgnore<Field>,
-    publicKey: OrIgnore<PublicKey>,
-    delegate: OrIgnore<PublicKey>,
-    state: Array<OrIgnore<Field>>,
-    sequenceState: OrIgnore<Field>,
-    provedState: OrIgnore<Bool>
-  ) {
-    this.balance = balance;
-    this.nonce = nonce;
-    this.receiptChainHash = receiptChainHash;
-    this.publicKey = publicKey;
-    this.delegate = delegate;
-    this.state = state;
-    this.sequenceState = sequenceState;
-    this.provedState = provedState;
-  }
-}
+    return {
+      balance: uint64(),
+      nonce: uint32(),
+      receiptChainHash: ignore(Field.zero),
+      publicKey: ignore(new PublicKey(Group.generator)),
+      delegate: ignore(new PublicKey(Group.generator)),
+      state: appState,
+      sequenceState: ignore(Field.zero),
+      provedState: ignore(new Bool(false)),
+    };
+  },
+};
 
 export class PartyBalance {
   private body: Body;

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -200,7 +200,8 @@ export let Permissions = {
     setZkappUri: Permission.signature(),
     editSequenceState: Permission.proof(),
     setTokenSymbol: Permission.signature(),
-    incrementNonce: Permission.signature(),
+    // TODO: this is  a workaround, should be changed to signature() once Parties_replay_check_failed is fixed
+    incrementNonce: Permissions.proofOrSignature(),
     setVotingFor: Permission.signature(),
   }),
 };

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -413,6 +413,7 @@ export let Body = {
       // the default assumption is that snarkyjs transactions don't include the fee payer
       // so useFullCommitment has to be false for signatures to be correct
       useFullCommitment: Bool(false),
+      // this should be set to true if parties are signed
       incrementNonce: Bool(false),
     };
   },
@@ -810,6 +811,7 @@ export class Party {
     let nonce = account.nonce.add(nonceIncrease);
 
     body.accountPrecondition = nonce;
+    body.incrementNonce = new Bool(true);
 
     let party = new Party(body) as Party & {
       body: { accountPrecondition: UInt32 };

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -14,6 +14,7 @@ import {
   Body,
   Party,
   PartyBalance,
+  signJsonTransaction,
 } from './party';
 import { PrivateKey, PublicKey } from './signature';
 import * as Mina from './mina';
@@ -693,39 +694,6 @@ async function signFeePayer(
   parties.feePayer.body.balanceChange = `${transactionFee}`;
   return signJsonTransaction(JSON.stringify(parties), feePayerKey);
   // return Ledger.signFeePayer(JSON.stringify(parties), senderKey);
-}
-
-/**
- * Sign all parties of a transaction which belong to the account determined by [[ `privateKey` ]].
- * @returns the modified transaction JSON
- */
-function signJsonTransaction(
-  transactionJson: string,
-  privateKey: PrivateKey | string
-) {
-  if (typeof privateKey === 'string')
-    privateKey = PrivateKey.fromBase58(privateKey);
-  let publicKey = privateKey.toPublicKey().toBase58();
-  // TODO: we really need types for the parties json
-  let parties = JSON.parse(transactionJson);
-  let feePayer = parties.feePayer;
-  if (feePayer.body.publicKey === publicKey) {
-    parties = JSON.parse(
-      Ledger.signFeePayer(JSON.stringify(parties), privateKey)
-    );
-  }
-  for (let i = 0; i < parties.otherParties.length; i++) {
-    let party = parties.otherParties[i];
-    if (
-      party.body.publicKey === publicKey &&
-      party.authorization.proof === null
-    ) {
-      parties = JSON.parse(
-        Ledger.signOtherParty(JSON.stringify(parties), privateKey, i)
-      );
-    }
-  }
-  return JSON.stringify(parties);
 }
 
 async function compile<S extends typeof SmartContract>(

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -428,10 +428,10 @@ export class SmartContract {
         Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
       }).toJSON();
       let statement = Ledger.transactionStatement(txJson, 0);
-      console.log(
-        'prove: created transaction statement',
-        JSON.stringify(statement)
-      );
+      // console.log(
+      //   'prove: created transaction statement',
+      //   JSON.stringify(statement)
+      // );
       // let statementVar = toStatement(ctx.self, Field.zero);
       // let statement = {
       //   transaction: statementVar.transaction.toConstant(),

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -664,13 +664,12 @@ async function callUnproved<S extends typeof SmartContract>(
     methodName as any,
     methodArguments
   );
+  selfParty.sign(zkappKey);
   selfParty.body.incrementNonce = Bool(true);
   let tx = Mina.createUnsignedTransaction(() => {
     Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
   });
-  let txJson = tx.toJSON();
-  if (zkappKey !== undefined)
-    txJson = Ledger.signOtherParty(txJson, zkappKey, 0);
+  let txJson = tx.sign().toJSON();
   return txJson;
 }
 
@@ -715,7 +714,6 @@ async function signFeePayer(
   parties.feePayer.body.publicKey = Ledger.publicKeyToString(senderAddress);
   parties.feePayer.body.balanceChange = `${transactionFee}`;
   return signJsonTransaction(JSON.stringify(parties), feePayerKey);
-  // return Ledger.signFeePayer(JSON.stringify(parties), senderKey);
 }
 
 async function compile<S extends typeof SmartContract>(

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -404,20 +404,17 @@ export class SmartContract {
       let selfParty = mainContext.self;
       mainContext = undefined;
 
-      // TODO dont create full transaction in here
-      // (fix by deferring proof creation to the end, or being cleverer with statement computation)
-      let tx = Mina.createUnsignedTransaction(() => {
+      // TODO dont create full transaction in here, properly build up atParty
+      let txJson = Mina.createUnsignedTransaction(() => {
         Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
-      }).transaction;
-
-      let statementVar = toStatement(ctx.self, Field.zero);
-      return [
-        {
-          transaction: statementVar.transaction.toConstant(),
-          atParty: statementVar.atParty.toConstant(),
-        },
-        selfParty,
-      ];
+      }).toJSON();
+      let statement = Ledger.transactionStatement(txJson, 0);
+      // let statementVar = toStatement(ctx.self, Field.zero);
+      // let statement = {
+      //   transaction: statementVar.transaction.toConstant(),
+      //   atParty: statementVar.atParty.toConstant(),
+      // };
+      return [statement, selfParty];
     });
     mainContext = { self: Party.defaultParty(this.address), witnesses: args };
     // TODO lazy proof?

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -597,6 +597,14 @@ async function deploy<S extends typeof SmartContract>(
   // TODO modifying the json after calling to ocaml would avoid extra vk serialization.. but need to compute vk hash
   let txJson = tx.toJSON();
   txJson = Ledger.signOtherParty(txJson, zkappKey, i);
+  // TODO this should be done in createTransaction automatically if Party.createSigned was called
+  if (initialBalance !== undefined) {
+    txJson = Ledger.signOtherParty(
+      txJson,
+      initialBalanceFundingAccountKey!,
+      i - 1
+    );
+  }
   if (shouldSignFeePayer) {
     if (feePayerKey === undefined || transactionFee === undefined) {
       throw Error(

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -428,10 +428,10 @@ export class SmartContract {
         Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
       }).toJSON();
       let statement = Ledger.transactionStatement(txJson, 0);
-      // console.log(
-      //   'prove: created transaction statement',
-      //   JSON.stringify(statement)
-      // );
+      console.log(
+        'prove: created transaction statement',
+        JSON.stringify(statement)
+      );
       // let statementVar = toStatement(ctx.self, Field.zero);
       // let statement = {
       //   transaction: statementVar.transaction.toConstant(),

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -437,17 +437,6 @@ export class SmartContract {
       // };
       return [statement, selfParty];
     });
-    // TODO remove this debugging
-    let toHex = (x: Field) =>
-      '0x' + BigInt(x.toString()).toString(16).toUpperCase();
-    console.log(
-      'transaction statement passed to prover (hex):\n',
-      JSON.stringify(
-        Object.fromEntries(
-          Object.entries(statement).map(([k, v]) => [k, toHex(v)])
-        )
-      )
-    );
 
     mainContext = { self: Party.defaultParty(this.address), witnesses: args };
     // TODO lazy proof?

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -332,12 +332,9 @@ function withContext<T>(context: typeof mainContext, f: () => T) {
 function picklesRuleFromFunction(
   name: string,
   func: (...args: unknown[]) => void,
-  witnessTypes: AsFieldElements<unknown>[],
-  onStart?: Function,
-  onEnd?: Function
+  witnessTypes: AsFieldElements<unknown>[]
 ) {
   function main(statement: Statement) {
-    onStart?.();
     if (mainContext === undefined) throw Error('bug');
     let { self, witnesses } = mainContext;
     witnesses = witnessTypes.map(
@@ -347,8 +344,9 @@ function picklesRuleFromFunction(
     );
     func(...witnesses);
     let tail = Field.zero;
-    checkStatement(statement, self, tail);
-    onEnd?.();
+    // FIXME: figure out correct way to constrain statement https://github.com/o1-labs/snarkyjs/issues/98
+    statement.transaction.assertEquals(statement.transaction);
+    // checkStatement(statement, self, tail);
   }
 
   return [0, name, main];

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -428,9 +428,16 @@ export class SmartContract {
         Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
       }).toJSON();
       let statement = Ledger.transactionStatement(txJson, 0);
+      console.log('transaction statement:', JSON.stringify(statement));
+      let toHex = (x: Field) =>
+        '0x' + BigInt(x.toString()).toString(16).toUpperCase();
       console.log(
-        'prove: created transaction statement',
-        JSON.stringify(statement)
+        'transaction statement (hex):',
+        JSON.stringify(
+          Object.fromEntries(
+            Object.entries(statement).map(([k, v]) => [k, toHex(v)])
+          )
+        )
       );
       // let statementVar = toStatement(ctx.self, Field.zero);
       // let statement = {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -655,12 +655,18 @@ async function callUnproved<S extends typeof SmartContract>(
 async function signJsonTransaction(
   transactionJson: string,
   senderKey: PrivateKey,
-  { transactionFee = 0 as number | string }
+  {
+    transactionFee = 0 as number | string,
+    nonce = undefined as string | undefined,
+  }
 ) {
   let parties = JSON.parse(transactionJson);
   let senderAddress = senderKey.toPublicKey();
-  let senderAccount = await Mina.getAccount(senderAddress);
-  parties.feePayer.body.accountPrecondition = senderAccount.nonce.toString();
+  if (nonce === undefined) {
+    let senderAccount = await Mina.getAccount(senderAddress);
+    nonce = senderAccount.nonce.toString();
+  }
+  parties.feePayer.body.accountPrecondition = nonce;
   parties.feePayer.body.publicKey = Ledger.publicKeyToString(senderAddress);
   parties.feePayer.body.balanceChange = `${transactionFee}`;
   return Ledger.signFeePayer(JSON.stringify(parties), senderKey);

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -588,6 +588,7 @@ async function deploy<S extends typeof SmartContract>(
     (zkapp as any).deploy?.();
     i = Mina.currentTransaction!.nextPartyIndex - 1;
     zkapp.self.update.verificationKey.set = Bool(true);
+    zkapp.self.body.incrementNonce = Bool(true);
     zkapp.self.update.verificationKey.value = verificationKey;
     if (initialBalance !== undefined) {
       let amount = UInt64.fromString(String(initialBalance));
@@ -651,6 +652,7 @@ async function callUnproved<S extends typeof SmartContract>(
     methodName as any,
     methodArguments
   );
+  selfParty.body.incrementNonce = Bool(true);
   let tx = Mina.createUnsignedTransaction(() => {
     Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
   });

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -634,6 +634,8 @@ async function call<S extends typeof SmartContract>(
     kind: 'proof',
     value: Pickles.proofToString(proof),
   };
+  // FIXME: a proof-authorized party shouldn't need to increment nonce, this is needed due to a protocol bug
+  selfParty.body.incrementNonce = Bool(true);
   let tx = Mina.createUnsignedTransaction(() => {
     Mina.setCurrentTransaction({ parties: [selfParty], nextPartyIndex: 1 });
   });

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -818,7 +818,7 @@ export class Ledger {
     protocolStateHash: Field
   ): Field;
 
-  static transactionStatement(txJson: string, partyIndex: number): string;
+  static transactionStatement(txJson: string, partyIndex: number): Statement;
   static signFeePayer(txJson: string, privateKey: { s: Scalar }): string;
   static signOtherParty(
     txJson: string,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -777,7 +777,7 @@ interface FeePayerParty_ {
   authorization: Exclude<Control, { kind: 'proof'; value: string }>;
 }
 
-interface Parties {
+interface Parties_ {
   feePayer: FeePayerParty_;
   otherParties: Array<Party_>;
 }
@@ -800,7 +800,7 @@ export class Ledger {
 
   addAccount(publicKey: { g: Group }, balance: string): void;
 
-  applyPartiesTransaction(parties: Parties): Account[];
+  applyPartiesTransaction(parties: Parties_): Account[];
   applyJsonTransaction(parties: string): Account[];
 
   getAccount(publicKey: { g: Group }): Account | undefined;
@@ -818,7 +818,15 @@ export class Ledger {
     protocolStateHash: Field
   ): Field;
 
+  static transactionCommitments(txJson: string): {
+    commitment: Field;
+    fullCommitment: Field;
+  };
   static transactionStatement(txJson: string, partyIndex: number): Statement;
+  static signFieldElement(
+    messageHash: Field,
+    privateKey: { s: Scalar }
+  ): string;
   static signFeePayer(txJson: string, privateKey: { s: Scalar }): string;
   static signOtherParty(
     txJson: string,
@@ -831,8 +839,8 @@ export class Ledger {
   static privateKeyToString(privateKey: { s: Scalar }): string;
   static privateKeyOfString(privateKeyBase58: string): Scalar;
 
-  static partiesToJson(parties: Parties): string;
-  static partiesToGraphQL(parties: Parties): string;
+  static partiesToJson(parties: Parties_): string;
+  static partiesToGraphQL(parties: Parties_): string;
 }
 
 /**

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -772,12 +772,13 @@ interface Party_ {
   authorization: Control;
 }
 
-interface FeePayerParty {
+interface FeePayerParty_ {
   body: FeePayerPartyBody;
+  authorization: Exclude<Control, { kind: 'proof'; value: string }>;
 }
 
 interface Parties {
-  feePayer: FeePayerParty;
+  feePayer: FeePayerParty_;
   otherParties: Array<Party_>;
 }
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -818,6 +818,7 @@ export class Ledger {
     protocolStateHash: Field
   ): Field;
 
+  static transactionStatement(txJson: string, partyIndex: number): string;
   static signFeePayer(txJson: string, privateKey: { s: Scalar }): string;
   static signOtherParty(
     txJson: string,

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -365,7 +365,15 @@
         "type": "function"
       },
       {
+        "name": "transactionCommitments",
+        "type": "function"
+      },
+      {
         "name": "transactionStatement",
+        "type": "function"
+      },
+      {
+        "name": "signFieldElement",
         "type": "function"
       },
       {

--- a/src/snarky/snarky-class-spec.json
+++ b/src/snarky/snarky-class-spec.json
@@ -365,6 +365,10 @@
         "type": "function"
       },
       {
+        "name": "transactionStatement",
+        "type": "function"
+      },
+      {
         "name": "signFeePayer",
         "type": "function"
       },


### PR DESCRIPTION
This includes the remaining fixes to make transactions work in an end-to-end test, and also to make the old mock API -- `Mina.transaction` -- work again.

This PR also makes improvements to how signing is handled in snarkyjs:
* Instead of passing JSON parties back and forth with OCaml to add signatures, add flexible methods to compute transaction commitments and to sign arbitrary field elements
* Implement "lazy signing", that is, decouple _declaring_ a party that should be signed with actually creating the signature. Important because signatures can only be created once the full transaction is known.

Finally, this also contains a large refactor of `party.ts`, to get rid of unnecessary classes (which are replaced by plain types and functions) and reduce code.