### PR TITLE
Fix bug in decrypt funciton

### DIFF
--- a/src/examples/encryption.ts
+++ b/src/examples/encryption.ts
@@ -35,4 +35,51 @@ Circuit.runAndCheckSync(() => {
   });
 });
 
+// With a longer message
+message = JSON.stringify({
+  'coinbase': {
+    'btc': 40000.00,
+    'eth': 3000.00,
+    'usdc': 1.00,
+    'ada': 1.02,
+    'avax': 70.43,
+    'mina': 2.13,
+  },
+  'binance': {
+    'btc': 39999.00,
+    'eth': 3001.00,
+    'usdc': 1.01,
+    'ada': 0.99,
+    'avax': 70.21,
+    'mina': 2.07,
+  }
+})
+messageFields = Encoding.stringToFields(message);
+
+// encrypt
+cipherText = Encryption.encrypt(messageFields, publicKey);
+
+// decrypt
+decryptedFields = Encryption.decrypt(cipherText, privateKey);
+decryptedMessage = Encoding.stringFromFields(decryptedFields);
+
+if (decryptedMessage !== message) throw Error('decryption failed');
+console.log(`Original message: "${message}"`);
+console.log(`Recovered message: "${decryptedMessage}"`);
+
+// the same but in a checked computation
+
+Circuit.runAndCheckSync(() => {
+  // encrypt
+  let cipherText = Encryption.encrypt(messageFields, publicKey);
+
+  // decrypt
+  let decryptedFields = Encryption.decrypt(cipherText, privateKey);
+
+  messageFields.forEach((m, i) => {
+    m.assertEquals(decryptedFields[i]);
+  });
+});
+
+
 console.log('everything works!');

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -73,7 +73,7 @@ function decrypt(
     let messageChunk = cipherText[i].sub(keyStream);
     message.push(messageChunk);
     if (i % 2 === 1) sponge.absorb(cipherText[i - 1]);
-    if (i % 2 === 1 || i === message.length - 1) sponge.absorb(cipherText[i]);
+    if (i % 2 === 1 || i === cipherText.length - 1) sponge.absorb(cipherText[i]);
   }
   // authentication tag
   sponge.squeeze().assertEquals(authenticationTag!);


### PR DESCRIPTION
Fixes https://github.com/o1-labs/snarkyjs/issues/148

## Description of Bug

Decrypting a value longer than one field results in an error being thrown in the decrypt function `Error: assertEquals: not equal`.  The root cause of the error is that the sponge is meant to absorb the final chunk of ciphertext when it is on the final iteration of decrypting chunks, but the check for being on the final iteration is looking at the length of the plaintext that is being built, rather than the ciphertext.  This results in `ciphertext[i]` being absorbed by the sponge on every iteration.

## Fix

Simply replace the check from length of message to length of ciphertext