### PR TITLE
Add tests for Bool primitive 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepublishOnly": "npm run prepublish:web && npm run prepublish:node",
     "bootstrap": "npm run build && node src/build/extractJsooMethods.js && npm run build",
     "format": "prettier --write --ignore-unknown **/*",
-    "test": "node --experimental-wasm-modules --experimental-modules --experimental-wasm-threads --experimental-vm-modules ./node_modules/jest/bin/jest.js --silent",
+    "test": "node --experimental-wasm-modules --experimental-modules --experimental-wasm-threads --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "clean": "rm -rf dist"
   },
   "author": "O(1) Labs",

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -272,4 +272,29 @@ describe('bool', () => {
       });
     });
   });
+  describe('outside circuit', () => {
+    describe('toField', () => {
+      it('should return a Field', async () => {
+        expect(true).toEqual(true);
+      });
+      it('should convert false to Field element 0', () => {
+        expect(new Bool(false).toField()).toEqual(new Field(0));
+      });
+      it('should throw when false toField is compared to Field element other than 0 ', () => {
+        expect(() => {
+          expect(new Bool(false).toField()).toEqual(new Field(1));
+        }).toThrow();
+      });
+
+      it('should convert true to Field element 1', () => {
+        expect(new Bool(true).toField()).toEqual(new Field(1));
+      });
+
+      it('should throw when true toField is compared to Field element other than 1 ', () => {
+        expect(() => {
+          expect(new Bool(true).toField()).toEqual(new Field(0));
+        }).toThrow();
+      });
+    });
+  });
 });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -296,5 +296,15 @@ describe('bool', () => {
         }).toThrow();
       });
     });
+
+    describe('toFields', () => {
+      it('should return an array of Fields', () => {
+        const x = new Bool(false);
+        const fieldArr = x.toFields();
+        const isArr = Array.isArray(fieldArr);
+        expect(isArr).toBe(true);
+        expect(fieldArr[0]).toEqual(new Field(0));
+      });
+    });
   });
 });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -54,6 +54,7 @@ describe('bool', () => {
         }).toThrow();
       });
     });
+
     describe('and', () => {
       it('true "and" true should return true', async () => {
         expect(() => {
@@ -149,6 +150,63 @@ describe('bool', () => {
             xTrue.not().assertEquals(xTrue);
           });
         }).toThrow();
+      });
+    });
+
+    describe('or', () => {
+      it('true "or" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.or(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if true "or" true is compared to false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.or(yTrue).assertEquals(new Bool(false));
+          });
+        }).toThrow();
+      });
+
+      it('false "or" false should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.or(yFalse).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "or" false is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.or(yFalse).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+
+      it('false "or" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.or(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
       });
     });
   });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -211,7 +211,7 @@ describe('bool', () => {
     });
 
     describe('assertEquals', () => {
-      it('should not throw on x "assertEqual" x', async () => {
+      it('should not throw on true "assertEqual" true', async () => {
         expect(() => {
           Circuit.runAndCheck(() => {
             const x = Circuit.witness(Bool, () => new Bool(true));
@@ -221,13 +221,35 @@ describe('bool', () => {
         }).not.toThrow();
       });
 
-      it('should throw on x "assertEquals" y', async () => {
+      it('should throw on true "assertEquals" false', async () => {
         expect(() => {
           Circuit.runAndCheck(() => {
             const x = Circuit.witness(Bool, () => new Bool(true));
             const y = Circuit.witness(Bool, () => new Bool(false));
 
             x.assertEquals(y);
+          });
+        }).toThrow();
+      });
+    });
+    describe('equals', () => {
+      it('should not throw on true "equals" true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+
+            x.equals(x);
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw on true "equals" false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+            const y = Circuit.witness(Bool, () => new Bool(false));
+
+            x.equals(y);
           });
         }).toThrow();
       });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -274,9 +274,6 @@ describe('bool', () => {
   });
   describe('outside circuit', () => {
     describe('toField', () => {
-      it('should return a Field', async () => {
-        expect(true).toEqual(true);
-      });
       it('should convert false to Field element 0', () => {
         expect(new Bool(false).toField()).toEqual(new Field(0));
       });
@@ -361,8 +358,58 @@ describe('bool', () => {
         expect(() => {
           const xTrue = new Bool(true);
 
-          expect(xTrue.not()).toEqual(xTrue);
+          xTrue.not().assertEquals(xTrue);
         }).toThrow();
+      });
+    });
+
+    describe('or', () => {
+      it('true "or" true should return true', async () => {
+        const xTrue = new Bool(true);
+        const yTrue = new Bool(true);
+
+        xTrue.or(yTrue).assertEquals(new Bool(true));
+      });
+
+      it('should throw if true "or" true is compared to false', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+          const yTrue = new Bool(true);
+
+          expect(xTrue.or(yTrue)).toEqual(new Bool(false));
+        }).toThrow();
+      });
+
+      it('false "or" false should return false', async () => {
+        const xFalse = new Bool(false);
+        const yFalse = new Bool(false);
+
+        xFalse.or(yFalse).assertEquals(new Bool(false));
+      });
+
+      it('should throw if false "or" false is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+
+          expect(xFalse.or(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+
+      it('false "or" true should return true', async () => {
+        const xFalse = new Bool(false);
+        const yTrue = new Bool(true);
+        xFalse.or(yTrue).assertEquals(new Bool(true));
+      });
+    });
+    describe('toBoolean', () => {
+      it('should return a true javascript boolean', () => {
+        const xTrue = new Bool(true);
+        expect(xTrue.toBoolean()).toEqual(true);
+      });
+      it('should return a false javascript boolean', () => {
+        const xFalse = new Bool(false);
+        expect(xFalse.toBoolean()).toEqual(false);
       });
     });
   });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -349,5 +349,21 @@ describe('bool', () => {
         }).toThrow();
       });
     });
+    describe('not', () => {
+      it('should return a new bool that is the negation of the input', async () => {
+        const xTrue = new Bool(true);
+        const yFalse = new Bool(false);
+        expect(xTrue.not()).toEqual(new Bool(false));
+        expect(yFalse.not()).toEqual(new Bool(true));
+      });
+
+      it('should throw if input.not() is compared to input', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+
+          expect(xTrue.not()).toEqual(xTrue);
+        }).toThrow();
+      });
+    });
   });
 });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -9,7 +9,7 @@ describe('bool', () => {
   afterAll(async () => {
     setTimeout(async () => {
       await shutdown();
-    }, 1500);
+    }, 0);
   });
 
   describe('inside circuit', () => {
@@ -207,6 +207,29 @@ describe('bool', () => {
             xFalse.or(yTrue).assertEquals(new Bool(true));
           });
         }).not.toThrow();
+      });
+    });
+
+    describe('assertEquals', () => {
+      it('should not throw on x "assertEqual" x', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+
+            x.assertEquals(x);
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw on x "assertEquals" y', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(true));
+            const y = Circuit.witness(Bool, () => new Bool(false));
+
+            x.assertEquals(y);
+          });
+        }).toThrow();
       });
     });
   });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -1,0 +1,58 @@
+import { isReady, shutdown, Field, Bool, Circuit } from '../../dist/server';
+
+describe('bool', () => {
+  beforeAll(async () => {
+    await isReady;
+    return;
+  });
+
+  afterAll(async () => {
+    setTimeout(async () => {
+      await shutdown();
+    }, 1500);
+  });
+
+  describe('inside circuit', () => {
+    describe('toField', () => {
+      it('should return a Field', async () => {
+        expect(true).toEqual(true);
+      });
+      it('should convert false to Field element 0 ', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.toField().assertEquals(new Field(0));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw when false toString is compared to Field element other than 0 ', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            xFalse.toField().assertEquals(new Field(1));
+          });
+        }).toThrow();
+      });
+
+      it('should convert true to Field element 1', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(1));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw when true toString is compared to Field element other than 1 ', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(0));
+          });
+        }).toThrow();
+      });
+    });
+  });
+});

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -121,5 +121,35 @@ describe('bool', () => {
         }).toThrow();
       });
     });
+
+    describe('not', () => {
+      it('should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.toField().assertEquals(new Field(1));
+          });
+        }).not.toThrow();
+      });
+      it('should return a new bool that is the negation of the input', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+            xTrue.not().assertEquals(new Bool(false));
+            yFalse.not().assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if input.not() is compared to input', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            xTrue.not().assertEquals(xTrue);
+          });
+        }).toThrow();
+      });
+    });
   });
 });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -306,5 +306,48 @@ describe('bool', () => {
         expect(fieldArr[0]).toEqual(new Field(0));
       });
     });
+    describe('and', () => {
+      it('true "and" true should return true', async () => {
+        const xTrue = new Bool(true);
+        const yTrue = new Bool(true);
+        expect(xTrue.and(yTrue)).toEqual(new Bool(true));
+      });
+
+      it('should throw if true "and" true is compared to false', async () => {
+        expect(() => {
+          const xTrue = new Bool(true);
+          const yTrue = new Bool(true);
+          expect(xTrue.and(yTrue)).toEqual(new Bool(false));
+        }).toThrow();
+      });
+
+      it('false "and" false should return false', async () => {
+        const xFalse = new Bool(false);
+        const yFalse = new Bool(false);
+        expect(xFalse.and(yFalse)).toEqual(new Bool(false));
+      });
+
+      it('should throw if false "and" false is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+          expect(xFalse.and(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+
+      it('false "and" true should return false', async () => {
+        const xFalse = new Bool(false);
+        const yTrue = new Bool(true);
+        expect(xFalse.and(yTrue)).toEqual(new Bool(false));
+      });
+
+      it('should throw if false "and" true is compared to true', async () => {
+        expect(() => {
+          const xFalse = new Bool(false);
+          const yFalse = new Bool(false);
+          expect(xFalse.and(yFalse)).toEqual(new Bool(true));
+        }).toThrow();
+      });
+    });
   });
 });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -1,4 +1,11 @@
-import { isReady, shutdown, Field, Bool, Circuit } from '../../dist/server';
+import {
+  isReady,
+  shutdown,
+  Field,
+  Bool,
+  Circuit,
+  EpochDataPredicate,
+} from '../../dist/server';
 
 describe('bool', () => {
   beforeAll(async () => {
@@ -17,7 +24,7 @@ describe('bool', () => {
       it('should return a Field', async () => {
         expect(true).toEqual(true);
       });
-      it('should convert false to Field element 0 ', () => {
+      it('should convert false to Field element 0', () => {
         expect(() => {
           Circuit.runAndCheck(() => {
             const xFalse = Circuit.witness(Bool, () => new Bool(false));
@@ -26,7 +33,6 @@ describe('bool', () => {
           });
         }).not.toThrow();
       });
-
       it('should throw when false toString is compared to Field element other than 0 ', () => {
         expect(() => {
           Circuit.runAndCheck(() => {
@@ -45,7 +51,7 @@ describe('bool', () => {
         }).not.toThrow();
       });
 
-      it('should throw when true toString is compared to Field element other than 1 ', () => {
+      it('should throw when true toField is compared to Field element other than 1 ', () => {
         expect(() => {
           Circuit.runAndCheck(() => {
             const xTrue = Circuit.witness(Bool, () => new Bool(true));
@@ -55,6 +61,19 @@ describe('bool', () => {
       });
     });
 
+    describe('toFields', () => {
+      it('should return an array of Fields', () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const x = Circuit.witness(Bool, () => new Bool(false));
+            const fieldArr = x.toFields();
+            const isArr = Array.isArray(fieldArr);
+            expect(isArr).toBe(true);
+            fieldArr[0].assertEquals(new Field(0));
+          });
+        }).not.toThrow();
+      });
+    });
     describe('and', () => {
       it('true "and" true should return true', async () => {
         expect(() => {
@@ -238,18 +257,16 @@ describe('bool', () => {
           Circuit.runAndCheck(() => {
             const x = Circuit.witness(Bool, () => new Bool(true));
 
-            x.equals(x);
+            x.equals(x).assertEquals(true);
           });
         }).not.toThrow();
       });
-
       it('should throw on true "equals" false', async () => {
         expect(() => {
           Circuit.runAndCheck(() => {
             const x = Circuit.witness(Bool, () => new Bool(true));
             const y = Circuit.witness(Bool, () => new Bool(false));
-
-            x.equals(y);
+            x.equals(y).assertEquals(true);
           });
         }).toThrow();
       });

--- a/src/lib/primitive.test.ts
+++ b/src/lib/primitive.test.ts
@@ -54,5 +54,72 @@ describe('bool', () => {
         }).toThrow();
       });
     });
+    describe('and', () => {
+      it('true "and" true should return true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.and(yTrue).assertEquals(new Bool(true));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if true "and" true is compared to false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xTrue = Circuit.witness(Bool, () => new Bool(true));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xTrue.and(yTrue).assertEquals(new Bool(false));
+          });
+        }).toThrow();
+      });
+
+      it('false "and" false should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.and(yFalse).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "and" false is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yFalse = Circuit.witness(Bool, () => new Bool(false));
+
+            xFalse.and(yFalse).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+
+      it('false "and" true should return false', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.and(yTrue).assertEquals(new Bool(false));
+          });
+        }).not.toThrow();
+      });
+
+      it('should throw if false "and" true is compared to true', async () => {
+        expect(() => {
+          Circuit.runAndCheck(() => {
+            const xFalse = Circuit.witness(Bool, () => new Bool(false));
+            const yTrue = Circuit.witness(Bool, () => new Bool(true));
+
+            xFalse.and(yTrue).assertEquals(new Bool(true));
+          });
+        }).toThrow();
+      });
+    });
   });
 });

--- a/src/lib/primitives.test.ts
+++ b/src/lib/primitives.test.ts
@@ -384,7 +384,7 @@ describe('bool', () => {
         const xFalse = new Bool(false);
         const yFalse = new Bool(false);
 
-        xFalse.or(yFalse).assertEquals(new Bool(false));
+        expect(xFalse.or(yFalse)).toEqual(new Bool(false));
       });
 
       it('should throw if false "or" false is compared to true', async () => {


### PR DESCRIPTION
Description
This PR adds initial tests for the Bool primitive. The tests are grouped into in-circuit and outside-circuit sections. The tests are located in lib folder in the primitives.tests.ts file. All future SnarkyJs primitive tests can be added to this file.
