### PR TITLE
Remove endoScale function with TODO

### DIFF
--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -584,7 +584,7 @@ export class Group {
   sub(y: Group): Group;
   neg(): Group;
   scale(y: Scalar): Group;
-  endoScale(y: EndoScalar): Group;
+  // TODO: Add this function when OCaml bindings are implemented : endoScale(y: EndoScalar): Group;
 
   assertEquals(y: Group): void;
   equals(y: Group): Bool;
@@ -605,7 +605,7 @@ export class Group {
   static sub(x: Group, y: Group): Group;
   static neg(x: Group): Group;
   static scale(x: Group, y: Scalar): Group;
-  static endoScale(x: Group, y: EndoScalar): Group;
+  // TODO: Add this function when OCaml bindings are implemented : static endoScale(x: Group, y: EndoScalar): Group;
 
   static assertEqual(x: Group, y: Group): void;
   static equal(x: Group, y: Group): Bool;


### PR DESCRIPTION
**Description**
Fixes https://github.com/o1-labs/snarkyjs/issues/209

Remove the unimplemented `endoScale` function from the `Group` class. Add a `TODO` comment to later add this function back in when it's properly implemented in the OCaml bindings.

The OCaml function is defined here:
https://github.com/MinaProtocol/mina/blob/49c199c0b86cf88c722e567cadede0bbf055e078/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml#L923
