### PR TITLE
Restrict Group.fromJSON type to an object literal

### DIFF
--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -619,7 +619,13 @@ export class Group {
   static sizeInFields(): number;
 
   static toJSON(x: Group): JSONValue;
-  static fromJSON(x: JSONValue): Group | null;
+  static fromJSON({
+    x,
+    y,
+  }: {
+    x: string | number;
+    y: string | number;
+  }): Group | null;
 }
 
 declare class Sponge {


### PR DESCRIPTION
**Description**
Fixes the weird behavior outlined in https://github.com/o1-labs/snarkyjs/issues/210

The `Group.fromJSON` function was defined in the `snarky.d.ts` file to accept parameters that the OCaml side was not handling. This PR changes the types that `Group.fromJSON` expects to be only valid ones, being an object literal with `x` and `y` values defined as either numbers or strings.