### PR TITLE
`@state` refactor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/circuit_value';
 export * from './lib/int';
 export * as Mina from './lib/mina';
 export * from './lib/zkapp';
+export { state, State, declareState } from './lib/state';
 // export * from './lib/proof_system';
 export * from './lib/party';
 export {

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,0 +1,272 @@
+import { Circuit, Field, Bool, AsFieldElements } from '../snarky';
+import { Party } from './party';
+import { PublicKey } from './signature';
+import * as Mina from './mina';
+import { Account, fetchAccount } from './fetch';
+import * as GlobalContext from './global-context';
+import { SmartContract } from './zkapp';
+
+export { State, state, declareState };
+
+/**
+ * Gettable and settable state that can be checked for equality.
+ */
+type State<A> = {
+  get(): A;
+  set(a: A): void;
+  fetch(): Promise<A | undefined>;
+  assertEquals(a: A): void;
+};
+
+/**
+ * Gettable and settable state that can be checked for equality.
+ */
+function State<A>(): State<A> {
+  return createState<A>();
+}
+
+// metadata defined by @state, which link state to a particular SmartContract
+type StateAttachedContract<A> = {
+  key: string;
+  stateType: AsFieldElements<A>;
+  instance: SmartContract;
+  class: typeof SmartContract & {
+    _layout: () => Map<string, { offset: number; length: number }>;
+  };
+};
+
+function getLayoutPosition<A>({
+  key,
+  class: contractClass,
+}: StateAttachedContract<A>) {
+  let layout = contractClass._layout();
+  let stateLayout = layout.get(key);
+  if (stateLayout === undefined) {
+    throw new Error(`state ${key} not found`);
+  }
+  return stateLayout;
+}
+type InternalStateType<A> = State<A> & { _contract?: StateAttachedContract<A> };
+
+function createState<A>(): InternalStateType<A> {
+  return {
+    _contract: undefined as StateAttachedContract<A> | undefined,
+
+    set(a: A) {
+      if (this._contract === undefined)
+        throw Error(
+          'set can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let stateAsFields = this._contract.stateType.toFields(a);
+      let e = this._contract.instance.executionState();
+      stateAsFields.forEach((x, i) => {
+        Party.setValue(e.party.body.update.appState[layout.offset + i], x);
+      });
+    },
+
+    assertEquals(a: A) {
+      if (this._contract === undefined)
+        throw Error(
+          'assertEquals can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let stateAsFields = this._contract.stateType.toFields(a);
+      let e = this._contract.instance.executionState();
+
+      stateAsFields.forEach((x, i) => {
+        e.party.body.preconditions.account.state[layout.offset + i].isSome =
+          Bool(true);
+        e.party.body.preconditions.account.state[layout.offset + i].value = x;
+      });
+    },
+
+    get() {
+      if (this._contract === undefined)
+        throw Error(
+          'get can only be called when the State is assigned to a SmartContract @state.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let address: PublicKey = this._contract.instance.address;
+      let stateAsFields: Field[];
+      let inProver = GlobalContext.inProver();
+      if (!GlobalContext.inCompile()) {
+        let a: Account;
+        try {
+          a = Mina.getAccount(address);
+        } catch (err) {
+          // TODO: there should also be a reasonable error here
+          if (inProver) {
+            throw err;
+          }
+          throw Error(
+            `${this._contract.key}.get() failed, because the zkapp account was not found in the cache. ` +
+              `Try calling \`await fetchAccount(zkappAddress)\` first.`
+          );
+        }
+        if (a.zkapp === undefined) {
+          // if the account is not a zkapp account, let the default state be all zeroes
+          stateAsFields = Array(layout.length).fill(Field.zero);
+        } else {
+          stateAsFields = [];
+          for (let i = 0; i < layout.length; ++i) {
+            stateAsFields.push(a.zkapp.appState[layout.offset + i]);
+          }
+        }
+        // in prover, create a new witness with the state values
+        // outside, just return the state values
+        stateAsFields = inProver
+          ? Circuit.witness(
+              Circuit.array(Field, layout.length),
+              () => stateAsFields
+            )
+          : stateAsFields;
+      } else {
+        // in compile, we don't need the witness values
+        stateAsFields = Circuit.witness(
+          Circuit.array(Field, layout.length),
+          (): Field[] => {
+            throw Error('this should never happen');
+          }
+        );
+      }
+      let state = this._contract.stateType.ofFields(stateAsFields);
+      (this._contract.stateType as any).check?.(state);
+      return state;
+    },
+
+    async fetch() {
+      if (this._contract === undefined)
+        throw Error(
+          'fetch can only be called when the State is assigned to a SmartContract @state.'
+        );
+      if (Mina.currentTransaction !== undefined)
+        throw Error(
+          'fetch is not intended to be called inside a transaction block.'
+        );
+      let layout = getLayoutPosition(this._contract);
+      let address: PublicKey = this._contract.instance.address;
+      let { account } = await fetchAccount(address);
+      if (account === undefined) return undefined;
+      let stateAsFields: Field[];
+      if (account.zkapp === undefined) {
+        stateAsFields = Array(layout.length).fill(Field.zero);
+      } else {
+        stateAsFields = [];
+        for (let i = 0; i < layout.length; ++i) {
+          stateAsFields.push(account.zkapp.appState[layout.offset + i]);
+        }
+      }
+      return this._contract.stateType.ofFields(stateAsFields);
+    },
+  };
+}
+
+const reservedPropNames = new Set(['_states', '_layout', '_methods', '_']);
+
+/**
+ * A decorator to use within a zkapp to indicate what will be stored on-chain.
+ * For example, if you want to store a field element `some_state` in a zkapp,
+ * you can use the following in the declaration of your zkapp:
+ *
+ * ```
+ * @state(Field) some_state = State<Field>();
+ * ```
+ *
+ */
+function state<A>(ty: AsFieldElements<A>) {
+  return function (
+    target: SmartContract & { constructor: any },
+    key: string,
+    _descriptor?: PropertyDescriptor
+  ) {
+    const ZkappClass = target.constructor;
+    if (reservedPropNames.has(key)) {
+      throw Error(`Property name ${key} is reserved.`);
+    }
+
+    if (ZkappClass._states == undefined) {
+      ZkappClass._states = [];
+      let layout: Map<string, { offset: number; length: number }>;
+      ZkappClass._layout = () => {
+        if (layout === undefined) {
+          layout = new Map();
+
+          let offset = 0;
+          ZkappClass._states.forEach(([key, ty]: [any, any]) => {
+            let length = ty.sizeInFields();
+            layout.set(key, { offset, length });
+            offset += length;
+          });
+        }
+        return layout;
+      };
+    }
+
+    ZkappClass._states.push([key, ty]);
+
+    Object.defineProperty(target, key, {
+      get(this) {
+        return this._?.[key];
+      },
+      set(this, v: InternalStateType<A>) {
+        if (v._contract !== undefined)
+          throw Error(
+            'A State should only be assigned once to a SmartContract'
+          );
+        if (this._?.[key]) throw Error('A @state should only be assigned once');
+        v._contract = {
+          key,
+          stateType: ty,
+          instance: this,
+          class: ZkappClass,
+        };
+        (this._ ?? (this._ = {}))[key] = v;
+      },
+    });
+  };
+}
+
+/**
+ * `declareState` can be used in place of the `@state` decorator to declare on-chain state on a SmartContract.
+ * It should be placed _after_ the class declaration.
+ * Here is an example of declaring a state property `x` of type `Field`.
+ * ```ts
+ * class MyContract extends SmartContract {
+ *   x = State<Field>();
+ *   // ...
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ *
+ * If you're using pure JS, it's _not_ possible to use the built-in class field syntax,
+ * i.e. the following will _not_ work:
+ *
+ * ```js
+ * // THIS IS WRONG IN JS!
+ * class MyContract extends SmartContract {
+ *   x = State();
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ *
+ * Instead, add a constructor where you assign the property:
+ * ```js
+ * class MyContract extends SmartContract {
+ *   constructor(x) {
+ *     super();
+ *     this.x = State();
+ *   }
+ * }
+ * declareState(MyContract, { x: Field });
+ * ```
+ */
+function declareState<T extends typeof SmartContract>(
+  SmartContract: T,
+  states: Record<string, AsFieldElements<unknown>>
+) {
+  for (let key in states) {
+    let CircuitValue = states[key];
+    state(CircuitValue)(SmartContract.prototype, key);
+  }
+}

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -28,7 +28,7 @@ import {
 
 export { deploy, DeployArgs, call, callUnproved, signFeePayer, declareMethods };
 
-const reservedPropNames = new Set(['_states', '_layout', '_methods', '_']);
+const reservedPropNames = new Set(['_methods', '_']);
 
 /**
  * A decorator to use in a zkapp to mark a method as callable by anyone.

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1,7 +1,6 @@
 import {
   Circuit,
   Field,
-  Bool,
   Poseidon,
   AsFieldElements,
   Ledger,
@@ -20,243 +19,16 @@ import {
 import { PrivateKey, PublicKey } from './signature';
 import * as Mina from './mina';
 import { UInt32, UInt64 } from './int';
-import { Account, fetchAccount } from './fetch';
 import {
   withContext,
   withContextAsync,
   getContext,
   mainContext,
 } from './global-context';
-import * as GlobalContext from './global-context';
 
-export {
-  deploy,
-  DeployArgs,
-  call,
-  callUnproved,
-  signFeePayer,
-  declareState,
-  declareMethods,
-};
-
-/**
- * Gettable and settable state that can be checked for equality.
- */
-export type State<A> = {
-  get(): A;
-  set(a: A): void;
-  fetch(): Promise<A | undefined>;
-  assertEquals(a: A): void;
-};
-
-/**
- * Gettable and settable state that can be checked for equality.
- */
-export function State<A>(): State<A> {
-  return createState<A>();
-}
-
-// metadata defined by @state, which link state to a particular SmartContract
-type StateAttachedContract<A> = {
-  key: string;
-  stateType: AsFieldElements<A>;
-  instance: SmartContract;
-  class: typeof SmartContract & {
-    _layout: () => Map<string, { offset: number; length: number }>;
-  };
-};
-
-function getLayoutPosition<A>({
-  key,
-  class: contractClass,
-}: StateAttachedContract<A>) {
-  let layout = contractClass._layout();
-  let stateLayout = layout.get(key);
-  if (stateLayout === undefined) {
-    throw new Error(`state ${key} not found`);
-  }
-  return stateLayout;
-}
-type InternalStateType<A> = State<A> & { _contract?: StateAttachedContract<A> };
-
-function createState<A>(): InternalStateType<A> {
-  return {
-    _contract: undefined as StateAttachedContract<A> | undefined,
-
-    set(a: A) {
-      if (this._contract === undefined)
-        throw Error(
-          'set can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = getLayoutPosition(this._contract);
-      let stateAsFields = this._contract.stateType.toFields(a);
-      let e: ExecutionState = this._contract.instance.executionState();
-      stateAsFields.forEach((x, i) => {
-        Party.setValue(e.party.body.update.appState[layout.offset + i], x);
-      });
-    },
-
-    assertEquals(a: A) {
-      if (this._contract === undefined)
-        throw Error(
-          'assertEquals can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = getLayoutPosition(this._contract);
-      let stateAsFields = this._contract.stateType.toFields(a);
-      let e: ExecutionState = this._contract.instance.executionState();
-
-      stateAsFields.forEach((x, i) => {
-        e.party.body.preconditions.account.state[layout.offset + i].isSome =
-          Bool(true);
-        e.party.body.preconditions.account.state[layout.offset + i].value = x;
-      });
-    },
-
-    get() {
-      if (this._contract === undefined)
-        throw Error(
-          'get can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = getLayoutPosition(this._contract);
-      let address: PublicKey = this._contract.instance.address;
-      let stateAsFields: Field[];
-      let inProver = GlobalContext.inProver();
-      if (!GlobalContext.inCompile()) {
-        let a: Account;
-        try {
-          a = Mina.getAccount(address);
-        } catch (err) {
-          // TODO: there should also be a reasonable error here
-          if (inProver) {
-            throw err;
-          }
-          throw Error(
-            `${this._contract.key}.get() failed, because the zkapp account was not found in the cache. ` +
-              `Try calling \`await fetchAccount(zkappAddress)\` first.`
-          );
-        }
-        if (a.zkapp === undefined) {
-          // if the account is not a zkapp account, let the default state be all zeroes
-          stateAsFields = Array(layout.length).fill(Field.zero);
-        } else {
-          stateAsFields = [];
-          for (let i = 0; i < layout.length; ++i) {
-            stateAsFields.push(a.zkapp.appState[layout.offset + i]);
-          }
-        }
-        // in prover, create a new witness with the state values
-        // outside, just return the state values
-        stateAsFields = inProver
-          ? Circuit.witness(
-              Circuit.array(Field, layout.length),
-              () => stateAsFields
-            )
-          : stateAsFields;
-      } else {
-        // in compile, we don't need the witness values
-        stateAsFields = Circuit.witness(
-          Circuit.array(Field, layout.length),
-          (): Field[] => {
-            throw Error('this should never happen');
-          }
-        );
-      }
-      let state = this._contract.stateType.ofFields(stateAsFields);
-      (this._contract.stateType as any).check?.(state);
-      return state;
-    },
-
-    async fetch() {
-      if (this._contract === undefined)
-        throw Error(
-          'fetch can only be called when the State is assigned to a SmartContract @state.'
-        );
-      if (Mina.currentTransaction !== undefined)
-        throw Error(
-          'fetch is not intended to be called inside a transaction block.'
-        );
-      let layout = getLayoutPosition(this._contract);
-      let address: PublicKey = this._contract.instance.address;
-      let { account } = await fetchAccount(address);
-      if (account === undefined) return undefined;
-      let stateAsFields: Field[];
-      if (account.zkapp === undefined) {
-        stateAsFields = Array(layout.length).fill(Field.zero);
-      } else {
-        stateAsFields = [];
-        for (let i = 0; i < layout.length; ++i) {
-          stateAsFields.push(account.zkapp.appState[layout.offset + i]);
-        }
-      }
-      return this._contract.stateType.ofFields(stateAsFields);
-    },
-  };
-}
+export { deploy, DeployArgs, call, callUnproved, signFeePayer, declareMethods };
 
 const reservedPropNames = new Set(['_states', '_layout', '_methods', '_']);
-
-/**
- * A decorator to use within a zkapp to indicate what will be stored on-chain.
- * For example, if you want to store a field element `some_state` in a zkapp,
- * you can use the following in the declaration of your zkapp:
- *
- * ```
- * @state(Field) some_state = State<Field>();
- * ```
- *
- */
-export function state<A>(ty: AsFieldElements<A>) {
-  return function (
-    target: SmartContract & { constructor: any },
-    key: string,
-    _descriptor?: PropertyDescriptor
-  ) {
-    const ZkappClass = target.constructor;
-    if (reservedPropNames.has(key)) {
-      throw Error(`Property name ${key} is reserved.`);
-    }
-
-    if (ZkappClass._states == undefined) {
-      ZkappClass._states = [];
-      let layout: Map<string, { offset: number; length: number }>;
-      ZkappClass._layout = () => {
-        if (layout === undefined) {
-          layout = new Map();
-
-          let offset = 0;
-          ZkappClass._states.forEach(([key, ty]: [any, any]) => {
-            let length = ty.sizeInFields();
-            layout.set(key, { offset, length });
-            offset += length;
-          });
-        }
-        return layout;
-      };
-    }
-
-    ZkappClass._states.push([key, ty]);
-
-    Object.defineProperty(target, key, {
-      get(this) {
-        return this._?.[key];
-      },
-      set(this, v: InternalStateType<A>) {
-        if (v._contract !== undefined)
-          throw Error(
-            'A State should only be assigned once to a SmartContract'
-          );
-        if (this._?.[key]) throw Error('A @state should only be assigned once');
-        v._contract = {
-          key,
-          stateType: ty,
-          instance: this,
-          class: ZkappClass,
-        };
-        (this._ ?? (this._ = {}))[key] = v;
-      },
-    });
-  };
-}
 
 /**
  * A decorator to use in a zkapp to mark a method as callable by anyone.
@@ -814,50 +586,6 @@ function signFeePayer(
 }
 
 // alternative API which can replace decorators, works in pure JS
-
-/**
- * `declareState` can be used in place of the `@state` decorator to declare on-chain state on a SmartContract.
- * It should be placed _after_ the class declaration.
- * Here is an example of declaring a state property `x` of type `Field`.
- * ```ts
- * class MyContract extends SmartContract {
- *   x = State<Field>();
- *   // ...
- * }
- * declareState(MyContract, { x: Field });
- * ```
- *
- * If you're using pure JS, it's _not_ possible to use the built-in class field syntax,
- * i.e. the following will _not_ work:
- *
- * ```js
- * // THIS IS WRONG IN JS!
- * class MyContract extends SmartContract {
- *   x = State();
- * }
- * declareState(MyContract, { x: Field });
- * ```
- *
- * Instead, add a constructor where you assign the property:
- * ```js
- * class MyContract extends SmartContract {
- *   constructor(x) {
- *     super();
- *     this.x = State();
- *   }
- * }
- * declareState(MyContract, { x: Field });
- * ```
- */
-function declareState<T extends typeof SmartContract>(
-  SmartContract: T,
-  states: Record<string, AsFieldElements<unknown>>
-) {
-  for (let key in states) {
-    let CircuitValue = states[key];
-    state(CircuitValue)(SmartContract.prototype, key);
-  }
-}
 
 /**
  * `declareMethods` can be used in place of the `@method` decorator

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -451,6 +451,7 @@ declare interface AsFieldElements<T> {
   toFields(x: T): Field[];
   ofFields(x: Field[]): T;
   sizeInFields(): number;
+  check?: (x: T) => void;
 }
 
 declare interface CircuitMain<W, P> {


### PR DESCRIPTION
* moves the logic required for the `@state` decorator into its own file, `state.ts`. the original file `zkapp.ts` was already too big to comfortably navigate. https://github.com/o1-labs/snarkyjs/pull/235/commits/484d4a263108265b4180634f7f7a0cfc79ae4ffe
* moves secret / internal methods from the object returned by `State()`, to standalone functions that are internal to our module. this avoids mixing internal interfaces with public APIs. https://github.com/o1-labs/snarkyjs/pull/235/commits/40d9ce845883ff9c277f1e8f886781eecd1010f0
* move secret properties that were stored on subclasses of `SmartContract` to an internal `WeakMap`. this also avoids mixing internal interfaces with public APIs, and makes `@state` code more self-contained / easier to reason about. https://github.com/o1-labs/snarkyjs/pull/235/commits/e881a921a7cbc7fa427615ccea26251ba9f2da5a

moving away from properties secretly stored on public-facing objects, or objects from other modules, is a general direction I want to take, so this would be a good opportunity to speak up against it (if you're opposed)

in general I think using `WeakMap` is a good way of doing book-keeping à la "this `State` belongs to this `SmartContract`"