### PR TITLE
Add memo to transaction creation

### DIFF
--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -65,7 +65,7 @@ function setCurrentTransaction(transaction: CurrentTransaction) {
 
 type SenderSpec =
   | PrivateKey
-  | { feePayerKey: PrivateKey; fee?: number | string | UInt64 }
+  | { feePayerKey: PrivateKey; fee?: number | string | UInt64; memo?: string }
   | undefined;
 
 function createUnsignedTransaction(
@@ -76,10 +76,7 @@ function createUnsignedTransaction(
 }
 
 function createTransaction(
-  feePayer:
-    | PrivateKey
-    | { feePayerKey: PrivateKey; fee?: number | string | UInt64 }
-    | undefined,
+  feePayer: SenderSpec,
   f: () => unknown,
   { fetchMode = 'cached' as FetchMode } = {}
 ): Transaction {
@@ -89,6 +86,7 @@ function createTransaction(
   let feePayerKey =
     feePayer instanceof PrivateKey ? feePayer : feePayer?.feePayerKey;
   let fee = feePayer instanceof PrivateKey ? undefined : feePayer?.fee;
+  let memo = feePayer instanceof PrivateKey ? '' : feePayer?.memo ?? '';
 
   currentTransaction = {
     sender: feePayerKey,
@@ -127,6 +125,7 @@ function createTransaction(
   let transaction: Parties = {
     otherParties: currentTransaction.parties,
     feePayer: feePayerParty,
+    memo,
   };
 
   nextTransactionId.value += 1;

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -795,6 +795,7 @@ function signFeePayer(
   {
     transactionFee = 0 as number | string,
     feePayerNonce = undefined as number | string | undefined,
+    memo = '',
   }
 ) {
   let parties: Types.Json.Parties = JSON.parse(transactionJson);
@@ -808,6 +809,7 @@ function signFeePayer(
   parties.feePayer.body.nonce = `${feePayerNonce}`;
   parties.feePayer.body.publicKey = Ledger.publicKeyToString(senderAddress);
   parties.feePayer.body.fee = `${transactionFee}`;
+  parties.memo = Ledger.memoToBase58(memo);
   return signJsonTransaction(JSON.stringify(parties), feePayerKey);
 }
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -656,6 +656,7 @@ async function deploy<S extends typeof SmartContract>(
     feePayerKey,
     transactionFee,
     feePayerNonce,
+    memo,
   }: {
     zkappKey: PrivateKey;
     verificationKey: { data: string; hash: string | Field };
@@ -664,6 +665,7 @@ async function deploy<S extends typeof SmartContract>(
     shouldSignFeePayer?: boolean;
     transactionFee?: string | number;
     feePayerNonce?: string | number;
+    memo?: string;
   }
 ) {
   let address = zkappKey.toPublicKey();
@@ -698,6 +700,7 @@ async function deploy<S extends typeof SmartContract>(
       zkapp.self.balance.addInPlace(amount);
     }
   });
+  tx.transaction.memo = memo ?? '';
   if (shouldSignFeePayer) {
     if (feePayerKey === undefined || transactionFee === undefined) {
       throw Error(
@@ -767,11 +770,12 @@ async function callUnproved<S extends typeof SmartContract>(
 }
 
 function addFeePayer(
-  { feePayer, otherParties }: Parties,
+  { feePayer, otherParties, memo }: Parties,
   feePayerKey: PrivateKey | string,
   {
     transactionFee = 0 as number | string,
     feePayerNonce = undefined as number | string | undefined,
+    memo: feePayerMemo = undefined as string | undefined,
   }
 ) {
   feePayer = cloneCircuitValue(feePayer);
@@ -782,11 +786,13 @@ function addFeePayer(
     let senderAccount = Mina.getAccount(senderAddress);
     feePayerNonce = senderAccount.nonce.toString();
   }
+  let newMemo = memo;
+  if (feePayerMemo) newMemo = Ledger.memoToBase58(feePayerMemo);
   feePayer.body.nonce = UInt32.fromString(`${feePayerNonce}`);
   feePayer.body.publicKey = senderAddress;
   feePayer.body.fee = UInt64.fromString(`${transactionFee}`);
   Party.signFeePayerInPlace(feePayer, feePayerKey);
-  return { feePayer, otherParties };
+  return { feePayer, otherParties, memo: newMemo };
 }
 
 function signFeePayer(
@@ -795,7 +801,7 @@ function signFeePayer(
   {
     transactionFee = 0 as number | string,
     feePayerNonce = undefined as number | string | undefined,
-    memo = '',
+    memo: feePayerMemo = undefined as string | undefined,
   }
 ) {
   let parties: Types.Json.Parties = JSON.parse(transactionJson);
@@ -806,10 +812,10 @@ function signFeePayer(
     let senderAccount = Mina.getAccount(senderAddress);
     feePayerNonce = senderAccount.nonce.toString();
   }
+  if (feePayerMemo) parties.memo = Ledger.memoToBase58(feePayerMemo);
   parties.feePayer.body.nonce = `${feePayerNonce}`;
   parties.feePayer.body.publicKey = Ledger.publicKeyToString(senderAddress);
   parties.feePayer.body.fee = `${transactionFee}`;
-  parties.memo = Ledger.memoToBase58(memo);
   return signJsonTransaction(JSON.stringify(parties), feePayerKey);
 }
 


### PR DESCRIPTION
**Description**
Adds the memo property to various methods in SnarkyJS. The following methods now have a memo property:
1. signFeePayer
2. addFeePayer
3. Mina.transaction
4. Deploy

These changes allow attaching a memo to a `Parties` structure. If there is no memo passed into these methods, they will simply reuse the memo property in the `Parties` structure. 

All the code to create a signature with the memo field is already included in the backend OCaml code. It just needed to be exposed in SnarkyJS.

**Tested By**
Manual testing