### PR TITLE
Properly constrain zkApp party

### DIFF
--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -326,7 +326,15 @@ let complexTypes = new Set(['object', 'function']);
 // TODO properly type this at the interface
 // create recursive type that describes JSON-like structures of circuit types
 // TODO unit-test this
-function circuitValue<T>(typeObj: any): AsFieldElements<T> {
+function circuitValue<T>(
+  typeObj: any,
+  advanced?: { customObjectKeys: string[] }
+): AsFieldElements<T> {
+  let objectKeys =
+    typeof typeObj === 'object'
+      ? advanced?.customObjectKeys ?? Object.keys(typeObj).sort()
+      : [];
+
   function sizeInFields(typeObj: any): number {
     if (!complexTypes.has(typeof typeObj) || typeObj === null) return 0;
     if (Array.isArray(typeObj))
@@ -341,10 +349,7 @@ function circuitValue<T>(typeObj: any): AsFieldElements<T> {
     if (Array.isArray(typeObj))
       return typeObj.map((t, i) => toFields(t, obj[i])).flat();
     if ('toFields' in typeObj) return typeObj.toFields(obj);
-    return Object.keys(typeObj)
-      .sort()
-      .map((k) => toFields(typeObj[k], obj[k]))
-      .flat();
+    return objectKeys.map((k) => toFields(typeObj[k], obj[k])).flat();
   }
   function ofFields(typeObj: any, fields: Field[]): any {
     if (!complexTypes.has(typeof typeObj) || typeObj === null) return null;
@@ -359,21 +364,18 @@ function circuitValue<T>(typeObj: any): AsFieldElements<T> {
       return array;
     }
     if ('ofFields' in typeObj) return typeObj.ofFields(fields);
-    let keys = Object.keys(typeObj).sort();
     let values = ofFields(
-      keys.map((k) => typeObj[k]),
+      objectKeys.map((k) => typeObj[k]),
       fields
     );
-    return Object.fromEntries(keys.map((k, i) => [k, values[i]]));
+    return Object.fromEntries(objectKeys.map((k, i) => [k, values[i]]));
   }
   function check(typeObj: any, obj: any): void {
     if (typeof typeObj !== 'object' || typeObj === null) return;
     if (Array.isArray(typeObj))
       return typeObj.forEach((t, i) => check(t, obj[i]));
     if ('check' in typeObj) return typeObj.check(obj);
-    return Object.keys(typeObj)
-      .sort()
-      .forEach((k) => check(typeObj[k], obj[k]));
+    return objectKeys.forEach((k) => check(typeObj[k], obj[k]));
   }
   return {
     sizeInFields: () => sizeInFields(typeObj),

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -328,11 +328,11 @@ let complexTypes = new Set(['object', 'function']);
 // TODO unit-test this
 function circuitValue<T>(
   typeObj: any,
-  advanced?: { customObjectKeys: string[] }
+  options?: { customObjectKeys: string[] }
 ): AsFieldElements<T> {
   let objectKeys =
     typeof typeObj === 'object'
-      ? advanced?.customObjectKeys ?? Object.keys(typeObj).sort()
+      ? options?.customObjectKeys ?? Object.keys(typeObj).sort()
       : [];
 
   function sizeInFields(typeObj: any): number {

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -958,8 +958,8 @@ async function addMissingProofs(parties: Parties): Promise<{
     authorization: Control | LazySignature;
   })[] = [];
   let proofs: (Proof<ZkappPublicInput> | undefined)[] = [];
-  for (let i = 0; i < otherParties.length; i++) {
-    let { partyProved, proof } = await addProof(otherParties[i], i);
+  for (let party of otherParties) {
+    let { partyProved, proof } = await addProof(party);
     otherPartiesProved.push(partyProved);
     proofs.push(proof);
   }

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -885,9 +885,9 @@ type PartiesProved = {
 };
 
 /**
- * The public input for zkApps consists of certain hashes of the transaction and of the proving Party which is constructed during method execution.
+ * The public input for zkApps consists of certain hashes of the proving Party (and its child parties) which is constructed during method execution.
 
-  In SmartContract.prove, a method is run twice: First outside the proof, to obtain the public input, and once in the prover,
+  For SmartContract proving, a method is run twice: First outside the proof, to obtain the public input, and once in the prover,
   which takes the public input as input. The current transaction is hashed again inside the prover, which asserts that the result equals the input public input,
   as part of the snark circuit. The block producer will also hash the transaction they receive and pass it as a public input to the verifier.
   Thus, the transaction is fully constrained by the proof - the proof couldn't be used to attest to a different transaction.
@@ -911,7 +911,7 @@ async function addMissingProofs(parties: Parties): Promise<{
 }> {
   type PartyProved = Party & { authorization: Control | LazySignature };
 
-  async function addProof(party: Party, index: number) {
+  async function addProof(party: Party) {
     party = Party.clone(party);
     if (
       !('kind' in party.authorization) ||

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -740,7 +740,7 @@ declare class Ledger {
   static zkappPublicInput(
     txJson: string,
     partyIndex: number
-  ): [transaction: Field, atParty: Field];
+  ): { party: Field; calls: Field };
   static signFieldElement(
     messageHash: Field,
     privateKey: { s: Scalar }


### PR DESCRIPTION
- Stacked on top of https://github.com/o1-labs/snarkyjs/pull/274
- Closes #98 - zkApps are now properly constrained 🎉 
- This means that zkApps take the party they produced, hash it and assert that it equals the public input. So the public input can't be anything else than the hash of the exact same party. Essentially, the party _is_ the public input.
- Without this assertion, a transaction containing an entirely different party, which might not comply with the smart contract logic at all, could also have had a valid proof!
- This PR was easier than originally expected, thanks to the fact that the protocol definition of the zkApp public input changed, to a hash of the zkApp party we had already implemented. (It used to be something that didn't really make sense,)