### PR TITLE
Move tokens API to `this.experimental` for release

### DIFF
--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -596,75 +596,76 @@ class Party implements Types.Party {
     return clonedParty;
   }
 
-  token() {
-    let thisParty = this;
-    let customToken = new Token({
-      tokenOwner: thisParty.body.publicKey,
-      parentTokenId: thisParty.body.tokenId,
-    });
+  // This is commented out since the API is not stable yet. Uncomment this in a non release build.
+  // token() {
+  //   let thisParty = this;
+  //   let customToken = new Token({
+  //     tokenOwner: thisParty.body.publicKey,
+  //     parentTokenId: thisParty.body.tokenId,
+  //   });
 
-    return {
-      id: customToken.id,
-      parentTokenId: customToken.parentTokenId,
-      tokenOwner: customToken.tokenOwner,
+  //   return {
+  //     id: customToken.id,
+  //     parentTokenId: customToken.parentTokenId,
+  //     tokenOwner: customToken.tokenOwner,
 
-      mint({ address, amount }: MintOrBurnParams) {
-        let receiverParty = createChildParty(thisParty, address, {
-          caller: this.id,
-          tokenId: this.id,
-        });
+  //     mint({ address, amount }: MintOrBurnParams) {
+  //       let receiverParty = createChildParty(thisParty, address, {
+  //         caller: this.id,
+  //         tokenId: this.id,
+  //       });
 
-        // Add the amount to mint to the receiver's account
-        let { magnitude, sgn } = receiverParty.body.balanceChange;
-        receiverParty.body.balanceChange = new Int64(magnitude, sgn).add(
-          amount
-        );
-      },
+  //       // Add the amount to mint to the receiver's account
+  //       let { magnitude, sgn } = receiverParty.body.balanceChange;
+  //       receiverParty.body.balanceChange = new Int64(magnitude, sgn).add(
+  //         amount
+  //       );
+  //     },
 
-      burn({ address, amount }: MintOrBurnParams) {
-        let senderParty = createChildParty(thisParty, address, {
-          caller: this.id,
-          tokenId: this.id,
-          useFullCommitment: Bool(true),
-        });
+  //     burn({ address, amount }: MintOrBurnParams) {
+  //       let senderParty = createChildParty(thisParty, address, {
+  //         caller: this.id,
+  //         tokenId: this.id,
+  //         useFullCommitment: Bool(true),
+  //       });
 
-        // Sub the amount to burn from the sender's account
-        let { magnitude, sgn } = senderParty.body.balanceChange;
-        senderParty.body.balanceChange = new Int64(magnitude, sgn).sub(amount);
+  //       // Sub the amount to burn from the sender's account
+  //       let { magnitude, sgn } = senderParty.body.balanceChange;
+  //       senderParty.body.balanceChange = new Int64(magnitude, sgn).sub(amount);
 
-        // Require signature from the sender account being deducted
-        Authorization.setLazySignature(senderParty);
-      },
+  //       // Require signature from the sender account being deducted
+  //       Authorization.setLazySignature(senderParty);
+  //     },
 
-      send({ from, to, amount }: SendParams) {
-        // Create a new party for the sender to send the amount to the receiver
-        let senderParty = createChildParty(thisParty, from, {
-          caller: this.id,
-          tokenId: this.id,
-          useFullCommitment: Bool(true),
-        });
+  //     send({ from, to, amount }: SendParams) {
+  //       // Create a new party for the sender to send the amount to the receiver
+  //       let senderParty = createChildParty(thisParty, from, {
+  //         caller: this.id,
+  //         tokenId: this.id,
+  //         useFullCommitment: Bool(true),
+  //       });
 
-        let i0 = senderParty.body.balanceChange;
-        senderParty.body.balanceChange = new Int64(i0.magnitude, i0.sgn).sub(
-          amount
-        );
+  //       let i0 = senderParty.body.balanceChange;
+  //       senderParty.body.balanceChange = new Int64(i0.magnitude, i0.sgn).sub(
+  //         amount
+  //       );
 
-        // Require signature from the sender party
-        Authorization.setLazySignature(senderParty);
+  //       // Require signature from the sender party
+  //       Authorization.setLazySignature(senderParty);
 
-        let receiverParty = createChildParty(thisParty, to, {
-          caller: this.id,
-          tokenId: this.id,
-        });
+  //       let receiverParty = createChildParty(thisParty, to, {
+  //         caller: this.id,
+  //         tokenId: this.id,
+  //       });
 
-        // Add the amount to send to the receiver's account
-        let i1 = receiverParty.body.balanceChange;
-        receiverParty.body.balanceChange = new Int64(i1.magnitude, i1.sgn).add(
-          amount
-        );
-      },
-    };
-  }
+  //       // Add the amount to send to the receiver's account
+  //       let i1 = receiverParty.body.balanceChange;
+  //       receiverParty.body.balanceChange = new Int64(i1.magnitude, i1.sgn).add(
+  //         amount
+  //       );
+  //     },
+  //   };
+  // }
 
   get tokenId() {
     return this.body.tokenId;

--- a/src/lib/party.ts
+++ b/src/lib/party.ts
@@ -596,76 +596,75 @@ class Party implements Types.Party {
     return clonedParty;
   }
 
-  // This is commented out since the API is not stable yet. Uncomment this in a non release build.
-  // token() {
-  //   let thisParty = this;
-  //   let customToken = new Token({
-  //     tokenOwner: thisParty.body.publicKey,
-  //     parentTokenId: thisParty.body.tokenId,
-  //   });
+  token() {
+    let thisParty = this;
+    let customToken = new Token({
+      tokenOwner: thisParty.body.publicKey,
+      parentTokenId: thisParty.body.tokenId,
+    });
 
-  //   return {
-  //     id: customToken.id,
-  //     parentTokenId: customToken.parentTokenId,
-  //     tokenOwner: customToken.tokenOwner,
+    return {
+      id: customToken.id,
+      parentTokenId: customToken.parentTokenId,
+      tokenOwner: customToken.tokenOwner,
 
-  //     mint({ address, amount }: MintOrBurnParams) {
-  //       let receiverParty = createChildParty(thisParty, address, {
-  //         caller: this.id,
-  //         tokenId: this.id,
-  //       });
+      mint({ address, amount }: MintOrBurnParams) {
+        let receiverParty = createChildParty(thisParty, address, {
+          caller: this.id,
+          tokenId: this.id,
+        });
 
-  //       // Add the amount to mint to the receiver's account
-  //       let { magnitude, sgn } = receiverParty.body.balanceChange;
-  //       receiverParty.body.balanceChange = new Int64(magnitude, sgn).add(
-  //         amount
-  //       );
-  //     },
+        // Add the amount to mint to the receiver's account
+        let { magnitude, sgn } = receiverParty.body.balanceChange;
+        receiverParty.body.balanceChange = new Int64(magnitude, sgn).add(
+          amount
+        );
+      },
 
-  //     burn({ address, amount }: MintOrBurnParams) {
-  //       let senderParty = createChildParty(thisParty, address, {
-  //         caller: this.id,
-  //         tokenId: this.id,
-  //         useFullCommitment: Bool(true),
-  //       });
+      burn({ address, amount }: MintOrBurnParams) {
+        let senderParty = createChildParty(thisParty, address, {
+          caller: this.id,
+          tokenId: this.id,
+          useFullCommitment: Bool(true),
+        });
 
-  //       // Sub the amount to burn from the sender's account
-  //       let { magnitude, sgn } = senderParty.body.balanceChange;
-  //       senderParty.body.balanceChange = new Int64(magnitude, sgn).sub(amount);
+        // Sub the amount to burn from the sender's account
+        let { magnitude, sgn } = senderParty.body.balanceChange;
+        senderParty.body.balanceChange = new Int64(magnitude, sgn).sub(amount);
 
-  //       // Require signature from the sender account being deducted
-  //       Authorization.setLazySignature(senderParty);
-  //     },
+        // Require signature from the sender account being deducted
+        Authorization.setLazySignature(senderParty);
+      },
 
-  //     send({ from, to, amount }: SendParams) {
-  //       // Create a new party for the sender to send the amount to the receiver
-  //       let senderParty = createChildParty(thisParty, from, {
-  //         caller: this.id,
-  //         tokenId: this.id,
-  //         useFullCommitment: Bool(true),
-  //       });
+      send({ from, to, amount }: SendParams) {
+        // Create a new party for the sender to send the amount to the receiver
+        let senderParty = createChildParty(thisParty, from, {
+          caller: this.id,
+          tokenId: this.id,
+          useFullCommitment: Bool(true),
+        });
 
-  //       let i0 = senderParty.body.balanceChange;
-  //       senderParty.body.balanceChange = new Int64(i0.magnitude, i0.sgn).sub(
-  //         amount
-  //       );
+        let i0 = senderParty.body.balanceChange;
+        senderParty.body.balanceChange = new Int64(i0.magnitude, i0.sgn).sub(
+          amount
+        );
 
-  //       // Require signature from the sender party
-  //       Authorization.setLazySignature(senderParty);
+        // Require signature from the sender party
+        Authorization.setLazySignature(senderParty);
 
-  //       let receiverParty = createChildParty(thisParty, to, {
-  //         caller: this.id,
-  //         tokenId: this.id,
-  //       });
+        let receiverParty = createChildParty(thisParty, to, {
+          caller: this.id,
+          tokenId: this.id,
+        });
 
-  //       // Add the amount to send to the receiver's account
-  //       let i1 = receiverParty.body.balanceChange;
-  //       receiverParty.body.balanceChange = new Int64(i1.magnitude, i1.sgn).add(
-  //         amount
-  //       );
-  //     },
-  //   };
-  // }
+        // Add the amount to send to the receiver's account
+        let i1 = receiverParty.body.balanceChange;
+        receiverParty.body.balanceChange = new Int64(i1.magnitude, i1.sgn).add(
+          amount
+        );
+      },
+    };
+  }
 
   get tokenId() {
     return this.body.tokenId;

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -50,7 +50,7 @@ class TokenContract extends SmartContract {
       .lte(maxAmountInCirculation.value)
       .assertTrue();
 
-    this.token().mint({
+    this.experimental.token.mint({
       address: receiverAddress,
       amount,
     });
@@ -59,7 +59,7 @@ class TokenContract extends SmartContract {
   }
 
   @method burn(receiverAddress: PublicKey, amount: UInt64) {
-    this.token().burn({
+    this.experimental.token.burn({
       address: receiverAddress,
       amount,
     });
@@ -70,7 +70,7 @@ class TokenContract extends SmartContract {
     receiverAddress: PublicKey,
     amount: UInt64
   ) {
-    this.token().send({
+    this.experimental.token.send({
       to: receiverAddress,
       from: senderAddress,
       amount,
@@ -132,7 +132,7 @@ describe('Token', () => {
     });
 
     it('should have a valid custom token id', async () => {
-      const tokenId = zkapp.token().id;
+      const tokenId = zkapp.experimental.token.id;
       const expectedTokenId = new Token({ tokenOwner: zkappAddress }).id;
       expect(tokenId).toBeDefined();
       expect(tokenId).toEqual(expectedTokenId);
@@ -145,7 +145,10 @@ describe('Token', () => {
     });
 
     it('should create a valid token with a different parentTokenId', async () => {
-      const newTokenId = Ledger.customTokenId(tokenAccount1, zkapp.token().id);
+      const newTokenId = Ledger.customTokenId(
+        tokenAccount1,
+        zkapp.experimental.token.id
+      );
       expect(newTokenId).toBeDefined();
     });
 
@@ -174,7 +177,10 @@ describe('Token', () => {
       ).send();
 
       expect(
-        Mina.getBalance(tokenAccount1, zkapp.token().id).value.toBigInt()
+        Mina.getBalance(
+          tokenAccount1,
+          zkapp.experimental.token.id
+        ).value.toBigInt()
       ).toEqual(100_000n);
     });
 
@@ -212,7 +218,10 @@ describe('Token', () => {
         .send();
 
       expect(
-        Mina.getBalance(tokenAccount1, zkapp.token().id).value.toBigInt()
+        Mina.getBalance(
+          tokenAccount1,
+          zkapp.experimental.token.id
+        ).value.toBigInt()
       ).toEqual(90_000n);
     });
 
@@ -261,10 +270,16 @@ describe('Token', () => {
         .send();
 
       expect(
-        Mina.getBalance(tokenAccount1, zkapp.token().id).value.toBigInt()
+        Mina.getBalance(
+          tokenAccount1,
+          zkapp.experimental.token.id
+        ).value.toBigInt()
       ).toEqual(90_000n);
       expect(
-        Mina.getBalance(tokenAccount2, zkapp.token().id).value.toBigInt()
+        Mina.getBalance(
+          tokenAccount2,
+          zkapp.experimental.token.id
+        ).value.toBigInt()
       ).toEqual(10_000n);
     });
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -559,10 +559,14 @@ class SmartContract {
     return this.self.network;
   }
 
-  // This is commented out since the API is not stable yet. Uncomment this in a non release build.
-  // token() {
-  //   return this.self.token();
-  // }
+  get experimental() {
+    let zkapp = this;
+    return {
+      get token() {
+        return zkapp.self.token();
+      },
+    };
+  }
 
   send(args: Omit<SendParams, 'from'>) {
     return this.self.send(args);

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -559,9 +559,10 @@ class SmartContract {
     return this.self.network;
   }
 
-  token() {
-    return this.self.token();
-  }
+  // This is commented out since the API is not stable yet. Uncomment this in a non release build.
+  // token() {
+  //   return this.self.token();
+  // }
 
   send(args: Omit<SendParams, 'from'>) {
     return this.self.send(args);


### PR DESCRIPTION
In preparation for a new SnarkyJS release, we comment on the current tokens API as there is not adequate developer documentation for the feature. Make sure to uncomment out the API in a later commit that is not being used for the current release.