### PR TITLE
fix `fetchAccount`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snarkyjs",
   "description": "JavaScript bindings for SnarkyJS",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "main": "./dist/web/index.js",
   "exports": {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -181,7 +181,7 @@ type FlexibleAccount = {
 
 // TODO provedState
 const accountQuery = (publicKey: string, tokenId: string) => `{
-  account(publicKey: "${publicKey}", tokenId: "${tokenId}") {
+  account(publicKey: "${publicKey}", token: "${tokenId}") {
     publicKey
     nonce
     zkappUri


### PR DESCRIPTION
Seems like the GraphQL schema account field now takes a `token` instead of a `tokenid`

```
{
  account(publicKey: "B62qpkPHkmoG73CdpDxHzNVkYse7vRH13jwNjcM3sgCVcJt5az64Aru", tokenId: "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf") {
    publicKey
  }
}
```

to 

```
{
  account(publicKey: "B62qpkPHkmoG73CdpDxHzNVkYse7vRH13jwNjcM3sgCVcJt5az64Aru", token: "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf") {
    publicKey
  }
}
```

https://proxy.berkeley.minaexplorer.com/graphql