### PR TITLE
marke BaseMerkleWitness as export

### DIFF
--- a/src/lib/merkle_tree.ts
+++ b/src/lib/merkle_tree.ts
@@ -3,7 +3,7 @@ import { Poseidon } from './hash';
 import { Bool, Field } from './core';
 
 // external API
-export { Witness, MerkleTree, MerkleWitness };
+export { Witness, MerkleTree, MerkleWitness, BaseMerkleWitness };
 
 type Witness = { isLeft: boolean; sibling: Field }[];
 


### PR DESCRIPTION
marking the BaseMerkleWitness class as export allows us (and users) to export child classes that extend BaseMerkleWitness as well

`export class MerkleWitness extends Experimental.MerkleWitness(n) {}`

fixes

`'extends' clause of exported class 'MerkleWitness' has or is using private name 'BaseMerkleWitness'`
