### PR TITLE
0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/4e8f94fa...HEAD)
+## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/4f0dd40...HEAD)
 
 ### Added
 
 - `reducer.getActions` partially implemented for local testing https://github.com/o1-labs/snarkyjs/pull/327
 - `gte` and `assertGte` methods on `UInt32`, `UInt64` https://github.com/o1-labs/snarkyjs/pull/349
 
-## [0.5.2](https://github.com/o1-labs/snarkyjs/compare/55c8ea0...4e8f94fa)
+## [0.5.2](https://github.com/o1-labs/snarkyjs/compare/55c8ea0...4f0dd40)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snarkyjs",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snarkyjs",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "env": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snarkyjs",
   "description": "JavaScript bindings for SnarkyJS",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "main": "./dist/web/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prepublishOnly": "npm run prepublish:web && npm run prepublish:node",
     "bootstrap": "npm run build && node src/build/extractJsooMethods.js && npm run build",
     "format": "prettier --write --ignore-unknown **/*",
-    "test": "node --experimental-wasm-modules --experimental-modules --experimental-wasm-threads --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test": "for f in ./src/**/*.test.ts; do NODE_OPTIONS=--experimental-vm-modules npx jest $f; done",
     "clean": "rimraf ./dist",
     "test:integration": "./run src/examples/zkapps/hello_world/run.ts && ./run src/examples/zkapps/voting/run.ts"
   },

--- a/src/lib/group.test.ts
+++ b/src/lib/group.test.ts
@@ -200,8 +200,9 @@ describe('group', () => {
     describe('toJSON', () => {
       it("fromJSON('1','1') should be the same as Group(1,1)", () => {
         Circuit.runAndCheck(() => {
-          const x = Circuit.witness(Group, () =>
-            Group.fromJSON({ x: 1, y: 1 })
+          const x = Circuit.witness(
+            Group,
+            () => Group.fromJSON({ x: 1, y: 1 })!
           );
           expect(x).toEqual(new Group(1, 1));
         });


### PR DESCRIPTION
This just contains various cherry-picks on top of the 0.5 release to stay true to the fixes proclaimed in the changelog on `main`, while not breaking compatibility with QAnet.

BEFORE merging this (the version upgrade), we have to publish from this branch
