### PR TITLE
Added prev_challenges to plonk_index_create bindings

### DIFF
--- a/src/chrome_bindings/worker_run.js
+++ b/src/chrome_bindings/worker_run.js
@@ -19,6 +19,7 @@ export default function workerRun() {
         args: [
           plonk_wasm.WasmFpGateVector,
           undefined /* number */,
+          undefined,
           plonk_wasm.WasmFpSrs,
         ],
         res: plonk_wasm.WasmPastaFpPlonkIndex,
@@ -27,6 +28,7 @@ export default function workerRun() {
         args: [
           plonk_wasm.WasmFqGateVector,
           undefined /* number */,
+          undefined,
           plonk_wasm.WasmFqSrs,
         ],
         res: plonk_wasm.WasmPastaFqPlonkIndex,


### PR DESCRIPTION
This PR fixes issue #379 by adding missing arguments (`prev_challenges`) to the following bindings:
- `caml_pasta_fp_plonk_index_create`
- `caml_pasta_fq_plonk_index_create`

This binding update is required due to the following changes in [bindings.js](https://github.com/MinaProtocol/mina/blob/develop/src/lib/crypto/kimchi_bindings/js/bindings.js):
- https://github.com/MinaProtocol/mina/commit/99dc99ea479ab2b22eb3a5568757c3f62e3f22b4#diff-c2c0ff175c607b726ab7857e08ab0d7389d6c6f2b2fb1039583a0505c47b28e9R1217
- https://github.com/MinaProtocol/mina/commit/99dc99ea479ab2b22eb3a5568757c3f62e3f22b4#diff-c2c0ff175c607b726ab7857e08ab0d7389d6c6f2b2fb1039583a0505c47b28e9R1270
