### PR TITLE
Get rid of extra argument passed to zkApp compilation method.

### DIFF
--- a/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
+++ b/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
@@ -45,7 +45,7 @@ deployButton.addEventListener('click', async () => {
   logEvents('Deploying zkApp...', eventsContainer);
 
   try {
-    const { verificationKey } = await HelloWorld.compile(zkAppAddress);
+    const { verificationKey } = await HelloWorld.compile();
     const deploymentTransaction = await Mina.transaction(feePayer, () => {
       if (!eventsContainer.innerHTML.includes('zkApp Deployed successfully')) {
         AccountUpdate.fundNewAccount(feePayer);


### PR DESCRIPTION
We have this [PR](https://github.com/o1-labs/snarkyjs/pull/406) which removed required argument for methods like `compile` but tests still use it.
It works because, well, JS is in use.