### PR TITLE
add more static Ledger helpers

### DIFF
--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -810,9 +810,15 @@ declare class Ledger {
   static privateKeyOfString(privateKeyBase58: string): Scalar;
   static fieldToBase58(field: Field): string;
   static fieldOfBase58(fieldBase58: string): Field;
+
   static memoToBase58(memoString: string): string;
 
   static verificationKeyToBase58(vr: unknown): string;
+
+  static checkAccountUpdateSignature(
+    updateJson: string,
+    commitment: Field
+  ): boolean;
 
   static fieldsOfJson(json: string): Field[];
   static hashAccountUpdateFromFields(fields: Field[]): Field;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -743,7 +743,7 @@ interface Account {
   votingFor: Field;
   zkapp?: {
     appState: Field[];
-    verificationKey?: string; // base58 string
+    verificationKey?: { data: string; hash: string };
     zkappVersion: number;
     sequenceState: Field[];
     lastSequenceSlot: number;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -812,6 +812,8 @@ declare class Ledger {
   static fieldOfBase58(fieldBase58: string): Field;
   static memoToBase58(memoString: string): string;
 
+  static verificationKeyToBase58(vr: unknown): string;
+
   static fieldsOfJson(json: string): Field[];
   static hashAccountUpdateFromFields(fields: Field[]): Field;
   static hashAccountUpdateFromJson(json: string): Field;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -743,7 +743,7 @@ interface Account {
   votingFor: Field;
   zkapp?: {
     appState: Field[];
-    verificationKey?: { hash: Field; data: unknown };
+    verificationKey?: string; // base58 string
     zkappVersion: number;
     sequenceState: Field[];
     lastSequenceSlot: number;
@@ -812,8 +812,6 @@ declare class Ledger {
   static fieldOfBase58(fieldBase58: string): Field;
 
   static memoToBase58(memoString: string): string;
-
-  static verificationKeyToBase58(vr: unknown): string;
 
   static checkAccountUpdateSignature(
     updateJson: string,

--- a/src/snarky/snarky-class-spec.js
+++ b/src/snarky/snarky-class-spec.js
@@ -457,6 +457,10 @@ export default [
         type: 'function',
       },
       {
+        name: 'verificationKeyToBase58',
+        type: 'function',
+      },
+      {
         name: 'fieldsOfJson',
         type: 'function',
       },

--- a/src/snarky/snarky-class-spec.js
+++ b/src/snarky/snarky-class-spec.js
@@ -457,10 +457,6 @@ export default [
         type: 'function',
       },
       {
-        name: 'verificationKeyToBase58',
-        type: 'function',
-      },
-      {
         name: 'checkAccountUpdateSignature',
         type: 'function',
       },

--- a/src/snarky/snarky-class-spec.js
+++ b/src/snarky/snarky-class-spec.js
@@ -461,6 +461,10 @@ export default [
         type: 'function',
       },
       {
+        name: 'checkAccountUpdateSignature',
+        type: 'function',
+      },
+      {
         name: 'fieldsOfJson',
         type: 'function',
       },


### PR DESCRIPTION
- export verificationKey as ~~base58~~ base64 instead of a structure https://github.com/o1-labs/snarkyjs/issues/150
- implements and exposes a method to verify specific account update signatures to check if tx authorizations are valid 

Companion of https://github.com/MinaProtocol/mina/pull/11842

closes https://github.com/o1-labs/snarkyjs/issues/433