### PR TITLE
fix analyzeMethods in composed reducers

### DIFF
--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -596,6 +596,8 @@ class SmartContract {
         return getReducer(this);
       },
     });
+
+    (this.constructor as typeof SmartContract).analyzeMethods();
   }
 
   /**


### PR DESCRIPTION
`analyzeMethods` was only invoked when the contract was compiled, however, there might be situations where you still might want to access the information that `analyzeMethods` returns in contracts that were not compiled. Solution: invoke `analyzeMethods` in the constructor 


closes https://github.com/o1-labs/snarkyjs/issues/359