### PR TITLE
add enableProofs

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1473,7 +1473,10 @@ let ZkappPublicInput = provablePure(
   { customObjectKeys: ['accountUpdate', 'calls'] }
 );
 
-async function addMissingProofs(zkappCommand: ZkappCommand): Promise<{
+async function addMissingProofs(
+  zkappCommand: ZkappCommand,
+  { proofsEnabled = true }
+): Promise<{
   zkappCommand: ZkappCommandProved;
   proofs: (Proof<ZkappPublicInput> | undefined)[];
 }> {
@@ -1483,6 +1486,14 @@ async function addMissingProofs(zkappCommand: ZkappCommand): Promise<{
 
   async function addProof(accountUpdate: AccountUpdate) {
     accountUpdate = AccountUpdate.clone(accountUpdate);
+
+    if (!proofsEnabled) {
+      Authorization.setProof(accountUpdate, Pickles.dummyBase64Proof());
+      return {
+        accountUpdateProved: accountUpdate as AccountUpdateProved,
+        proof: undefined,
+      };
+    }
     if (accountUpdate.lazyAuthorization?.kind !== 'lazy-proof') {
       return {
         accountUpdateProved: accountUpdate as AccountUpdateProved,

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -92,7 +92,11 @@ function reportGetAccountError(publicKey: string, tokenId: string) {
 function createTransaction(
   feePayer: FeePayerSpec,
   f: () => unknown,
-  { fetchMode = 'cached' as FetchMode, isFinalRunOutsideCircuit = true } = {}
+  {
+    fetchMode = 'cached' as FetchMode,
+    isFinalRunOutsideCircuit = true,
+    proofsEnabled = true,
+  } = {}
 ): Transaction {
   if (currentTransaction.has()) {
     throw new Error('Cannot start new transaction within another transaction');
@@ -181,7 +185,9 @@ function createTransaction(
     },
 
     async prove() {
-      let { zkappCommand, proofs } = await addMissingProofs(self.transaction);
+      let { zkappCommand, proofs } = await addMissingProofs(self.transaction, {
+        proofsEnabled,
+      });
       self.transaction = zkappCommand;
       return proofs;
     },
@@ -434,12 +440,14 @@ function LocalBlockchain({
       // and hopefully with upcoming work by Matt we can just run everything in the prover, and nowhere else
       let tx = createTransaction(sender, f, {
         isFinalRunOutsideCircuit: false,
+        proofsEnabled,
       });
       let hasProofs = tx.transaction.accountUpdates.some(
         Authorization.hasLazyProof
       );
       return createTransaction(sender, f, {
         isFinalRunOutsideCircuit: !hasProofs,
+        proofsEnabled,
       });
     },
     applyJsonTransaction(json: string) {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -934,6 +934,8 @@ declare const Pickles: {
     verificationKey: string
   ): Promise<boolean>;
 
+  dummyBase64Proof: () => string;
+
   proofToBase64: (proof: [0 | 1 | 2, Pickles.Proof]) => string;
   proofOfBase64: (
     base64: string,

--- a/src/snarky/snarky-class-spec.js
+++ b/src/snarky/snarky-class-spec.js
@@ -495,6 +495,10 @@ export default [
         type: 'function',
       },
       {
+        name: 'dummyBase64Proof',
+        type: 'function',
+      },
+      {
         name: 'proofToBase64',
         type: 'function',
       },


### PR DESCRIPTION
Missing piece to https://github.com/o1-labs/snarkyjs/issues/150

- if `enableProofs == false`,
	- `tx.prove()` will be "skipped" and a dummy proof will be inserted instead 
	- proofs wont be verified  