### PR TITLE
Make SequenceEvents exportable for external use

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -635,6 +635,8 @@ class AccountUpdate implements Types.AccountUpdate {
 
   private isSelf: boolean;
 
+  static SequenceEvents = SequenceEvents;
+
   constructor(body: Body, authorization?: Control);
   constructor(body: Body, authorization = {} as Control, isSelf = false) {
     this.id = Math.random();


### PR DESCRIPTION
Put SequenceEvents as a static member on AccountUpdate for easy export to external use, which allows developers to process and calculate actions hash (sequence state) outside the contract.