### PR TITLE
Fix Struct

### DIFF
--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -757,7 +757,9 @@ function Struct<
      * @param aux the raw non-field element data
      */
     static fromFields(fields: Field[], aux: any[]) {
-      return new this(this.type.fromFields(fields, aux) as T);
+      let value = this.type.fromFields(fields, aux) as T;
+      let struct = Object.create(this.prototype);
+      return Object.assign(struct, value);
     }
   }
   return Struct_ as any;

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -757,7 +757,7 @@ function Struct<
      * @param aux the raw non-field element data
      */
     static fromFields(fields: Field[], aux: any[]) {
-      return new Struct_(this.type.fromFields(fields, aux) as T);
+      return new this(this.type.fromFields(fields, aux) as T);
     }
   }
   return Struct_ as any;


### PR DESCRIPTION
Fix to `Struct`, to enable actually adding custom instance functions and custom constructors

* fixes all errors that were introduced by replacing `CircuitValue` with `Struct` in a user project (https://github.com/gretzke/zkApp-data-types)