### PR TITLE
Dex happy path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AccountUpdates are now valid `@method` arguments, and `authorize()` is intended to be used on them when passed to a method
   - Also replaces `Experimental.accountUpdateFromCallback()`
 - `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()`
+- `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `VerificationKey`, which is a `Struct` with auxiliary data, to pass verification keys to a `@method`
   - BREAKING CHANGE: Change names related to circuit types: `AsFieldsAndAux<T>` -> `Provable<T>`, `AsFieldElement<T>` -> `ProvablePure<T>`, `circuitValue` -> `provable`
   - BREAKING CHANGE: Change all `ofFields` and `ofBits` methods on circuit types to `fromFields` and `fromBits`
-- `SmartContract.experimental.authorize` to authorize a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428
-  - AccountUpdates are now valid `@method` arguments, and `authorize` is intended to be used on them when passed to a method
-  - Also replaces `Experimental.accountUpdateFromCallback`
+- `SmartContract.experimental.authorize()` to authorize a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428
+  - AccountUpdates are now valid `@method` arguments, and `authorize()` is intended to be used on them when passed to a method
+  - Also replaces `Experimental.accountUpdateFromCallback()`
+- `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()`
 
 ### Changed
 
 - BREAKING CHANGE: `tx.send()` is now asynchronous: old: `send(): TransactionId` new: `send(): Promise<TransactionId>` and `tx.send()` now directly waits for the network response, as opposed to `tx.send().wait()`
+- `Circuit.witness` can now be called outside circuits, where it will just directly return the callback result
 
 ### Deprecated
 

--- a/src/examples/zkapps/dex/arbitrary_token_interaction.ts
+++ b/src/examples/zkapps/dex/arbitrary_token_interaction.ts
@@ -1,0 +1,65 @@
+import {
+  isReady,
+  Mina,
+  AccountUpdate,
+  UInt64,
+  shutdown,
+  Token,
+} from 'snarkyjs';
+import { TokenContract, addresses, keys, tokenIds } from './dex.js';
+
+await isReady;
+let doProofs = true;
+
+let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
+Mina.setActiveInstance(Local);
+let accountFee = Mina.accountCreationFee();
+
+let [{ privateKey: userKey, publicKey: userAddress }] = Local.testAccounts;
+let tx;
+
+console.log('-------------------------------------------------');
+console.log('TOKEN X ADDRESS\t', addresses.tokenX.toBase58());
+console.log('USER ADDRESS\t', userAddress.toBase58());
+console.log('-------------------------------------------------');
+console.log('TOKEN X ID\t', Token.Id.toBase58(tokenIds.X));
+console.log('-------------------------------------------------');
+
+// compile & deploy all 5 zkApps
+console.log('compile (token)...');
+await TokenContract.compile();
+
+let tokenX = new TokenContract(addresses.tokenX);
+
+console.log('deploy & init token contracts...');
+tx = await Mina.transaction(userKey, () => {
+  // pay fees for creating 2 token contract accounts, and fund them so each can create 1 account themselves
+  let feePayerUpdate = AccountUpdate.createSigned(userKey);
+  feePayerUpdate.balance.subInPlace(accountFee.mul(1));
+  tokenX.deploy();
+});
+await tx.prove();
+tx.sign([keys.tokenX]);
+await tx.send();
+
+console.log('arbitrary token minting...');
+tx = await Mina.transaction(userKey, () => {
+  // pay fees for creating user's token X account
+  AccountUpdate.createSigned(userKey).balance.subInPlace(accountFee.mul(1));
+  // 😈😈😈 mint any number of tokens to our account 😈😈😈
+  let tokenContract = new TokenContract(addresses.tokenX);
+  tokenContract.experimental.token.mint({
+    address: userAddress,
+    amount: UInt64.from(1e18),
+  });
+});
+await tx.prove();
+console.log(tx.toPretty());
+await tx.send();
+
+console.log(
+  'User tokens: ',
+  Mina.getBalance(userAddress, tokenIds.X).value.toBigInt()
+);
+
+shutdown();

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -308,14 +308,8 @@ class TokenContract extends SmartContract {
   @method authorizeUpdate(zkappUpdate: AccountUpdate) {
     // adopt this account update as a child, allowing a certain layout for its own children
     // we allow 10 child account updates, in a left-biased tree of width 3
-    let { NoChildren, StaticChildren } = AccountUpdate.Layout;
-    let layout = StaticChildren(
-      StaticChildren(
-        StaticChildren(StaticChildren(NoChildren), NoChildren),
-        NoChildren
-      ),
-      NoChildren
-    );
+    let { NoChildren, StaticChildren, AnyChildren } = AccountUpdate.Layout;
+    let layout = AnyChildren;
     this.experimental.authorize(zkappUpdate, layout);
 
     // walk account updates to see if balances for this token cancel
@@ -331,14 +325,8 @@ class TokenContract extends SmartContract {
   ) {
     // adopt this account update as a child, allowing a certain layout for its own children
     // we allow 10 child account updates, in a left-biased tree of width 3
-    let { NoChildren, StaticChildren } = AccountUpdate.Layout;
-    let layout = StaticChildren(
-      StaticChildren(
-        StaticChildren(StaticChildren(NoChildren), NoChildren),
-        NoChildren
-      ),
-      NoChildren
-    );
+    let { NoChildren, StaticChildren, AnyChildren } = AccountUpdate.Layout;
+    let layout = AnyChildren;
     this.experimental.authorize(zkappUpdate, layout);
 
     // walk account updates to see if balances cancel the amount sent

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -310,8 +310,10 @@ class TokenContract extends SmartContract {
     // we allow 10 child account updates, in a left-biased tree of width 3
     let { NoChildren, StaticChildren } = AccountUpdate.Layout;
     let layout = StaticChildren(
-      StaticChildren(StaticChildren(3), NoChildren, NoChildren),
-      NoChildren,
+      StaticChildren(
+        StaticChildren(StaticChildren(NoChildren), NoChildren),
+        NoChildren
+      ),
       NoChildren
     );
     this.experimental.authorize(zkappUpdate, layout);
@@ -331,8 +333,10 @@ class TokenContract extends SmartContract {
     // we allow 10 child account updates, in a left-biased tree of width 3
     let { NoChildren, StaticChildren } = AccountUpdate.Layout;
     let layout = StaticChildren(
-      StaticChildren(StaticChildren(3), NoChildren, NoChildren),
-      NoChildren,
+      StaticChildren(
+        StaticChildren(StaticChildren(NoChildren), NoChildren),
+        NoChildren
+      ),
       NoChildren
     );
     this.experimental.authorize(zkappUpdate, layout);

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -240,12 +240,12 @@ class DexTokenHolder extends SmartContract {
     // we're writing this as if our token == y and other token == x
     let dx = otherTokenAmount;
     let tokenX = new TokenContract(otherTokenAddress);
-    // send x from user to us (i.e., to the same address as this but with the other token)
-    tokenX.transfer(user, this.address, dx);
     // get balances
     let x = tokenX.getBalance(this.address);
     let y = this.account.balance.get();
     this.account.balance.assertEquals(y);
+    // send x from user to us (i.e., to the same address as this but with the other token)
+    tokenX.transfer(user, this.address, dx);
     // compute and send dy
     let dy = y.mul(dx).div(x.add(dx));
     // just subtract dy balance and let adding balance be handled one level higher

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -196,7 +196,7 @@ class DexTokenHolder extends SmartContract {
     this.send({ to: user, amount: dy });
 
     // TODO: something's still off here
-    // this has to be a delegate call, to make it authoritable by the token owner
+    // this has to be a delegate call, to make it authorizable by the token owner
     this.self.isDelegateCall = Bool(true);
 
     // return l, dy so callers don't have to walk their child account updates to get it
@@ -224,7 +224,7 @@ class DexTokenHolder extends SmartContract {
     this.send({ to: user, amount: dx });
 
     // TODO: something's still off here
-    // this has to be a delegate call, to make it authoritable by the token owner
+    // this has to be a delegate call, to make it authorizable by the token owner
     this.self.isDelegateCall = Bool(true);
 
     return [dx, dy];

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -195,6 +195,10 @@ class DexTokenHolder extends SmartContract {
     let dy = y.mul(dl).div(l);
     this.send({ to: user, amount: dy });
 
+    // TODO: something's still off here
+    // this has to be a delegate call, to make it authoritable by the token owner
+    this.self.isDelegateCall = Bool(true);
+
     // return l, dy so callers don't have to walk their child account updates to get it
     return [l, dy];
   }
@@ -218,6 +222,10 @@ class DexTokenHolder extends SmartContract {
     this.account.balance.assertEquals(x);
     let dx = x.mul(dl).div(l);
     this.send({ to: user, amount: dx });
+
+    // TODO: something's still off here
+    // this has to be a delegate call, to make it authoritable by the token owner
+    this.self.isDelegateCall = Bool(true);
 
     return [dx, dy];
   }

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -331,17 +331,10 @@ class TokenContract extends SmartContract {
 }
 
 await isReady;
-let { keys, addresses } = randomAccounts(
-  'tokenX',
-  'tokenY',
-  'dex',
-  'user',
-  'tokenZ'
-);
+let { keys, addresses } = randomAccounts('tokenX', 'tokenY', 'dex', 'user');
 let tokenIds = {
   X: Token.getId(addresses.tokenX),
   Y: Token.getId(addresses.tokenY),
-  Z: Token.getId(addresses.tokenZ),
   lqXY: Token.getId(addresses.dex),
 };
 

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -289,11 +289,6 @@ class TokenContract extends SmartContract {
   // => need callbacks for signatures
   @method deployZkapp(address: PublicKey, verificationKey: VerificationKey) {
     let tokenId = this.experimental.token.id;
-    // let zkapp = Experimental.createChildAccountUpdate(
-    //   this.self,
-    //   address,
-    //   tokenId
-    // );
     let zkapp = AccountUpdate.defaultAccountUpdate(address, tokenId);
     this.experimental.authorize(zkapp);
     AccountUpdate.setValue(zkapp.update.permissions, {
@@ -306,11 +301,7 @@ class TokenContract extends SmartContract {
 
   // let a zkapp do whatever it wants, as long as the token supply stays constant
   @method authorizeUpdate(zkappUpdate: AccountUpdate) {
-    // adopt this account update as a child, allowing a certain layout for its own children
-    // we allow 10 child account updates, in a left-biased tree of width 3
-    let { NoChildren, StaticChildren, AnyChildren } = AccountUpdate.Layout;
-    let layout = AnyChildren;
-    this.experimental.authorize(zkappUpdate, layout);
+    this.experimental.authorize(zkappUpdate);
 
     // walk account updates to see if balances for this token cancel
     let balance = balanceSum(zkappUpdate, this.experimental.token.id);
@@ -323,11 +314,7 @@ class TokenContract extends SmartContract {
     to: PublicKey,
     amount: UInt64
   ) {
-    // adopt this account update as a child, allowing a certain layout for its own children
-    // we allow 10 child account updates, in a left-biased tree of width 3
-    let { NoChildren, StaticChildren, AnyChildren } = AccountUpdate.Layout;
-    let layout = AnyChildren;
-    this.experimental.authorize(zkappUpdate, layout);
+    this.experimental.authorize(zkappUpdate);
 
     // walk account updates to see if balances cancel the amount sent
     let balance = balanceSum(zkappUpdate, this.experimental.token.id);

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -31,20 +31,17 @@ TokenContract.analyzeMethods();
 DexTokenHolder.analyzeMethods();
 Dex.analyzeMethods();
 
-if (true) {
-  // compile & deploy all 5 zkApps
-  console.log('compile (token)...');
-  await TokenContract.compile();
-  console.log('compile (dex token holder)...');
-  await DexTokenHolder.compile();
-  console.log('compile (dex main contract)...');
-  await Dex.compile();
-}
+// compile & deploy all 5 zkApps
+console.log('compile (token)...');
+await TokenContract.compile();
+console.log('compile (dex token holder)...');
+await DexTokenHolder.compile();
+console.log('compile (dex main contract)...');
+await Dex.compile();
+
 let tokenX = new TokenContract(addresses.tokenX);
 let tokenY = new TokenContract(addresses.tokenY);
 let dex = new Dex(addresses.dex);
-let dexX = new DexTokenHolder(addresses.dex, tokenIds.X);
-let dexY = new DexTokenHolder(addresses.dex, tokenIds.Y);
 
 console.log('deploy & init token contracts...');
 tx = await Mina.transaction({ feePayerKey }, () => {
@@ -146,9 +143,11 @@ console.log(
 );
 
 console.log('user redeem liquidity');
+Local.setProofsEnabled(true);
 tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
   dex.redeemLiquidity(addresses.user, UInt64.from(100));
 });
+console.log(tx.toPretty());
 
 await tx.prove();
 tx.sign([keys.user]);

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -183,7 +183,6 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 await tx.prove();
 tx.sign([keys.user]);
-console.log(tx.toPretty());
 await tx.send();
 
 console.log(

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -9,9 +9,9 @@ import {
 } from './dex.js';
 
 await isReady;
-let doProofs = true;
+let doProofs = false;
 
-let Local = Mina.LocalBlockchain();
+let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
 Mina.setActiveInstance(Local);
 let accountFee = Mina.accountCreationFee();
 
@@ -31,7 +31,7 @@ TokenContract.analyzeMethods();
 DexTokenHolder.analyzeMethods();
 Dex.analyzeMethods();
 
-if (doProofs) {
+if (true) {
   // compile & deploy all 5 zkApps
   console.log('compile (token)...');
   await TokenContract.compile();
@@ -82,7 +82,7 @@ await tx.prove();
 tx.sign([keys.dex]);
 await tx.send();
 
-console.log('transfer to a user');
+console.log('transfer tokens to user');
 tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
   AccountUpdate.createSigned(feePayerKey).balance.subInPlace(
     Mina.accountCreationFee().mul(2)
@@ -104,6 +104,7 @@ console.log(
 
 console.log('user supply liquidity -- base');
 tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
+  // needed because the user account for the liquidity token is created
   AccountUpdate.createSigned(feePayerKey).balance.subInPlace(
     Mina.accountCreationFee().mul(1)
   );
@@ -111,7 +112,7 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 
 await tx.prove();
-tx.sign([keys.dex, keys.user, keys.tokenX]);
+tx.sign([keys.user]);
 await tx.send();
 
 console.log(
@@ -130,19 +131,13 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 
 await tx.prove();
-tx.sign([keys.dex, keys.user, keys.tokenX]);
+tx.sign([keys.user]);
 await tx.send();
 
 console.log(
   'DEX liquidity (X, Y): ',
   Mina.getBalance(addresses.dex, tokenIds.X).value.toBigInt(),
   Mina.getBalance(addresses.dex, tokenIds.Y).value.toBigInt()
-);
-
-console.log(
-  'DEBUG DEX tokenholder liquidity (X, Y): ',
-  Mina.getBalance(dexX.address, tokenIds.X).value.toBigInt(),
-  Mina.getBalance(dexY.address, tokenIds.Y).value.toBigInt()
 );
 
 console.log(
@@ -160,7 +155,7 @@ console.log(tx.toPretty());
 await tx.prove();
 console.log('goes the dynamite');
 
-tx.sign([keys.dex, keys.user, keys.tokenX]);
+tx.sign([keys.user]);
 await tx.send();
 
 console.log(

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -61,7 +61,6 @@ tx = await Mina.transaction({ feePayerKey }, () => {
 });
 await tx.prove();
 tx.sign([keys.tokenX, keys.tokenY]);
-console.log(tx.toPretty());
 await tx.send();
 
 console.log(
@@ -81,10 +80,9 @@ tx = await Mina.transaction(feePayerKey, () => {
 });
 await tx.prove();
 tx.sign([keys.dex]);
-console.log(tx.toPretty());
 await tx.send();
 
-console.log('transfer X and Y tokens to a user...');
+console.log('transfer to a user');
 tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
   AccountUpdate.createSigned(feePayerKey).balance.subInPlace(
     Mina.accountCreationFee().mul(2)
@@ -113,7 +111,6 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 
 await tx.prove();
-
 tx.sign([keys.dex, keys.user, keys.tokenX]);
 await tx.send();
 
@@ -133,6 +130,35 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 
 await tx.prove();
+tx.sign([keys.dex, keys.user, keys.tokenX]);
+await tx.send();
+
+console.log(
+  'DEX liquidity (X, Y): ',
+  Mina.getBalance(addresses.dex, tokenIds.X).value.toBigInt(),
+  Mina.getBalance(addresses.dex, tokenIds.Y).value.toBigInt()
+);
+
+console.log(
+  'DEBUG DEX tokenholder liquidity (X, Y): ',
+  Mina.getBalance(dexX.address, tokenIds.X).value.toBigInt(),
+  Mina.getBalance(dexY.address, tokenIds.Y).value.toBigInt()
+);
+
+console.log(
+  'user DEX tokens: ',
+  Mina.getBalance(addresses.user, tokenIds.lqXY).value.toBigInt()
+);
+
+console.log('user redeem liquidity');
+tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
+  dex.redeemLiquidity(addresses.user, UInt64.from(100));
+});
+
+console.log('boom');
+console.log(tx.toPretty());
+await tx.prove();
+console.log('goes the dynamite');
 
 tx.sign([keys.dex, keys.user, keys.tokenX]);
 await tx.send();

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -151,11 +151,10 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
 });
 
 console.log('boom');
-console.log(tx.toPretty());
 await tx.prove();
-console.log('goes the dynamite');
-
 tx.sign([keys.user]);
+console.log(tx.toPretty());
+console.log('goes the dynamite');
 await tx.send();
 
 console.log(

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -1,4 +1,11 @@
-import { isReady, Mina, AccountUpdate, UInt64, shutdown } from 'snarkyjs';
+import {
+  isReady,
+  Mina,
+  AccountUpdate,
+  UInt64,
+  shutdown,
+  Token,
+} from 'snarkyjs';
 import {
   Dex,
   DexTokenHolder,
@@ -24,6 +31,9 @@ console.log('TOKEN X ADDRESS\t', addresses.tokenX.toBase58());
 console.log('TOKEN Y ADDRESS\t', addresses.tokenY.toBase58());
 console.log('DEX ADDRESS\t', addresses.dex.toBase58());
 console.log('USER ADDRESS\t', addresses.user.toBase58());
+console.log('-------------------------------------------------');
+console.log('TOKEN X ID\t', Token.Id.toBase58(tokenIds.X));
+console.log('TOKEN Y ID\t', Token.Id.toBase58(tokenIds.Y));
 console.log('-------------------------------------------------');
 
 // analyze methods for quick error feedback
@@ -143,15 +153,11 @@ console.log(
 );
 
 console.log('user redeem liquidity');
-Local.setProofsEnabled(true);
 tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
   dex.redeemLiquidity(addresses.user, UInt64.from(100));
 });
-console.log(tx.toPretty());
-
 await tx.prove();
 tx.sign([keys.user]);
-console.log(tx.toPretty());
 await tx.send();
 
 console.log(
@@ -163,6 +169,28 @@ console.log(
 console.log(
   'user DEX tokens: ',
   Mina.getBalance(addresses.user, tokenIds.lqXY).value.toBigInt()
+);
+console.log(
+  'User tokens X: ',
+  Mina.getBalance(addresses.user, tokenIds.X).value.toBigInt(),
+  '\nUser tokens Y: ',
+  Mina.getBalance(addresses.user, tokenIds.Y).value.toBigInt()
+);
+
+console.log('swap 10 X for Y');
+tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
+  dex.swapX(addresses.user, UInt64.from(10));
+});
+await tx.prove();
+tx.sign([keys.user]);
+console.log(tx.toPretty());
+await tx.send();
+
+console.log(
+  'User tokens X: ',
+  Mina.getBalance(addresses.user, tokenIds.X).value.toBigInt(),
+  '\nUser tokens Y: ',
+  Mina.getBalance(addresses.user, tokenIds.Y).value.toBigInt()
 );
 
 shutdown();

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -150,11 +150,9 @@ tx = await Mina.transaction({ feePayerKey, fee: accountFee.mul(1) }, () => {
   dex.redeemLiquidity(addresses.user, UInt64.from(100));
 });
 
-console.log('boom');
 await tx.prove();
 tx.sign([keys.user]);
 console.log(tx.toPretty());
-console.log('goes the dynamite');
 await tx.send();
 
 console.log(

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -678,9 +678,7 @@ class AccountUpdate implements Types.AccountUpdate {
       authorization,
       accountUpdate.isSelf
     );
-    cloned.lazyAuthorization = cloneCircuitValue(
-      accountUpdate.lazyAuthorization
-    );
+    cloned.lazyAuthorization = accountUpdate.lazyAuthorization;
     cloned.children.callsType = accountUpdate.children.callsType;
     cloned.children.accountUpdates = accountUpdate.children.accountUpdates.map(
       AccountUpdate.clone
@@ -1092,7 +1090,7 @@ class AccountUpdate implements Types.AccountUpdate {
       callsType: { type: 'None' },
       accountUpdates: [],
     };
-    let lazyAuthorization = a && cloneCircuitValue(a.lazyAuthorization);
+    let lazyAuthorization = a && a.lazyAuthorization;
     if (a) {
       children.callsType = a.children.callsType;
       children.accountUpdates = a.children.accountUpdates.map(

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1030,7 +1030,11 @@ class AccountUpdate implements Types.AccountUpdate {
     if (smartContractContext.has()) {
       smartContractContext.get().this.self.authorize(accountUpdate);
     } else {
-      Mina.currentTransaction()?.accountUpdates.push(accountUpdate);
+      if (!Mina.currentTransaction.has()) return;
+      let updates = Mina.currentTransaction.get().accountUpdates;
+      if (!updates.find((update) => update.id === accountUpdate.id)) {
+        updates.push(accountUpdate);
+      }
     }
   }
 

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1027,6 +1027,13 @@ class AccountUpdate implements Types.AccountUpdate {
     }
     return accountUpdate;
   }
+  static attachToTransaction(accountUpdate: AccountUpdate) {
+    if (smartContractContext.has()) {
+      smartContractContext.get().this.self.authorize(accountUpdate);
+    } else {
+      Mina.currentTransaction()?.accountUpdates.push(accountUpdate);
+    }
+  }
 
   static createSigned(signer: PrivateKey) {
     let publicKey = signer.toPublicKey();

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -4,7 +4,6 @@ import {
   cloneCircuitValue,
   memoizationContext,
   memoizeWitness,
-  witness,
 } from './circuit_value.js';
 import { Field, Bool, Ledger, Circuit, Pickles, Provable } from '../snarky.js';
 import { jsLayout, Types } from '../snarky/types.js';
@@ -1357,7 +1356,7 @@ const CallForest = {
     // compute hash outside the circuit if callsType is "Witness"
     // i.e., allowing accountUpdates with arbitrary children
     if (callsType.type === 'Witness') {
-      return witness(Field, () => CallForest.hashChildrenBase(update));
+      return Circuit.witness(Field, () => CallForest.hashChildrenBase(update));
     }
     let calls = CallForest.hashChildrenBase(update);
     if (callsType.type === 'Equals' && inCheckedComputation()) {

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1459,6 +1459,12 @@ function makeChildAccountUpdate(parent: AccountUpdate, child: AccountUpdate) {
     if (i !== undefined && i !== -1) {
       topLevelUpdates!.splice(i, 1);
     }
+  } else {
+    let siblings = child.parent.children.accountUpdates;
+    let i = siblings?.findIndex((update) => update.id === child.id);
+    if (i !== undefined && i !== -1) {
+      siblings!.splice(i, 1);
+    }
   }
   child.parent = parent;
 }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1627,14 +1627,14 @@ async function addMissingProofs(
   async function addProof(index: number, accountUpdate: AccountUpdate) {
     accountUpdate = AccountUpdate.clone(accountUpdate);
 
-    if (!proofsEnabled) {
-      Authorization.setProof(accountUpdate, Pickles.dummyBase64Proof());
+    if (accountUpdate.lazyAuthorization?.kind !== 'lazy-proof') {
       return {
         accountUpdateProved: accountUpdate as AccountUpdateProved,
         proof: undefined,
       };
     }
-    if (accountUpdate.lazyAuthorization?.kind !== 'lazy-proof') {
+    if (!proofsEnabled) {
+      Authorization.setProof(accountUpdate, Pickles.dummyBase64Proof());
       return {
         accountUpdateProved: accountUpdate as AccountUpdateProved,
         proof: undefined,

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1209,7 +1209,7 @@ class AccountUpdate implements Types.AccountUpdate {
    * ```ts
    * let { NoChildren, AnyChildren, StaticChildren } = AccounUpdate.Layout;
    *
-   * NoChildren                 // an account updates with no children
+   * NoChildren                 // an account update with no children
    * AnyChildren                // an account update with arbitrary children
    * StaticChildren(NoChildren) // an account update with 1 child, which doesn't have children itself
    * StaticChildren(1)          // shortcut for StaticChildren(NoChildren)
@@ -1287,6 +1287,9 @@ class AccountUpdate implements Types.AccountUpdate {
     }
     if (body.update?.permissions) {
       body.update.permissions = JSON.stringify(body.update.permissions) as any;
+    }
+    if (body.update?.appState) {
+      body.update.appState = JSON.stringify(body.update.appState) as any;
     }
     if (
       jsonUpdate.authorization !== undefined ||

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -824,6 +824,9 @@ class AccountUpdate implements Types.AccountUpdate {
     this.isDelegateCall = Bool(false);
     if (layout !== undefined) {
       AccountUpdate.witnessChildren(childUpdate, layout, { skipCheck: true });
+    } else {
+      // if there is no explicit child layout, then we don't allow the child to delegate our authority to their children
+      childUpdate.isDelegateCall.assertFalse();
     }
   }
 
@@ -1342,7 +1345,7 @@ const CallForest = {
       return witness(Field, () => CallForest.hashChildrenBase(update));
     }
     let calls = CallForest.hashChildrenBase(update);
-    if (callsType.type === 'Equals') {
+    if (callsType.type === 'Equals' && inCheckedComputation()) {
       calls.assertEquals(callsType.value);
     }
     return calls;

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -942,16 +942,13 @@ Circuit.witness = function <T, S extends Provable<T> = Provable<T>>(
     // }
     return fields;
   };
-
-  let fields = inCheckedComputation()
-    ? snarkContext.runWith(
-        {
-          proverData: snarkContext()?.proverData,
-          witnesses: snarkContext()?.witnesses,
-        },
-        () => Circuit._witness(type, createFields)
-      )[1]
-    : createFields();
+  let ctx = snarkContext.get();
+  let fields =
+    inCheckedComputation() && !ctx.inWitnessBlock
+      ? snarkContext.runWith({ ...ctx, inWitnessBlock: true }, () =>
+          Circuit._witness(type, createFields)
+        )[1]
+      : createFields();
   let aux = type.toAuxiliary(proverValue);
   let value = type.fromFields(fields, aux);
   type.check(value);

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -29,7 +29,6 @@ export {
   memoizeWitness,
   getBlindingValue,
   toConstant,
-  witness,
   InferCircuitValue,
   Provables,
   HashInput,
@@ -1034,11 +1033,6 @@ function auxiliary<T>(type: Provable<T>, compute: () => any[]) {
   return aux ?? type.toAuxiliary();
 }
 
-// TODO: very likely, this is how Circuit.witness should behave
-function witness<T>(type: Provable<T>, compute: () => T) {
-  return inCheckedComputation() ? Circuit.witness(type, compute) : compute();
-}
-
 let memoizationContext = Context.create<{
   memoized: { fields: Field[]; aux: any[] }[];
   currentIndex: number;
@@ -1050,7 +1044,7 @@ let memoizationContext = Context.create<{
  * for reuse by the prover. This is needed to witness non-deterministic values.
  */
 function memoizeWitness<T>(type: Provable<T>, compute: () => T) {
-  return witness(type, () => {
+  return Circuit.witness(type, () => {
     if (!memoizationContext.has()) return compute();
     let context = memoizationContext.get();
     let { memoized, currentIndex } = context;

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -928,7 +928,7 @@ Circuit.witness = function <T, S extends Provable<T> = Provable<T>>(
   compute: () => T
 ) {
   let proverValue: T | undefined;
-  let fields = Circuit._witness(type, () => {
+  let createFields = () => {
     proverValue = compute();
     let fields = type.toFields(proverValue);
     // TODO: enable this check
@@ -941,7 +941,17 @@ Circuit.witness = function <T, S extends Provable<T> = Provable<T>>(
     //   );
     // }
     return fields;
-  });
+  };
+
+  let fields = inCheckedComputation()
+    ? snarkContext.runWith(
+        {
+          proverData: snarkContext()?.proverData,
+          witnesses: snarkContext()?.witnesses,
+        },
+        () => Circuit._witness(type, createFields)
+      )[1]
+    : createFields();
   let aux = type.toAuxiliary(proverValue);
   let value = type.fromFields(fields, aux);
   type.check(value);

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -1010,6 +1010,23 @@ Circuit.constraintSystem = function <T>(f: () => T) {
   return result;
 };
 
+Circuit.log = function (...args: any) {
+  Circuit.asProver(() => {
+    let prettyArgs = [];
+    for (let arg of args) {
+      if (arg?.toPretty !== undefined) prettyArgs.push(arg.toPretty());
+      else {
+        try {
+          prettyArgs.push(JSON.parse(JSON.stringify(arg)));
+        } catch {
+          prettyArgs.push(arg);
+        }
+      }
+    }
+    console.log(...prettyArgs);
+  });
+};
+
 function auxiliary<T>(type: Provable<T>, compute: () => any[]) {
   let aux;
   if (inCheckedComputation()) Circuit.asProver(() => (aux = compute()));

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -11,9 +11,7 @@ type CipherText = {
 
 function encrypt(message: Field[], otherPublicKey: PublicKey) {
   // key exchange
-  let privateKey = Circuit.inCheckedComputation()
-    ? Circuit.witness(Scalar, () => Scalar.random())
-    : Scalar.random();
+  let privateKey = Circuit.witness(Scalar, () => Scalar.random());
   let publicKey = Group.generator.scale(privateKey);
   let sharedSecret = otherPublicKey.toGroup().scale(privateKey);
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -227,21 +227,6 @@ interface Mina {
   ) => { hash: string; actions: string[][] }[];
 }
 
-interface MockMina extends Mina {
-  addAccount(publicKey: PublicKey, balance: string): void;
-  /**
-   * An array of 10 test accounts that have been pre-filled with
-   * 30000000000 units of currency.
-   */
-  testAccounts: Array<{ publicKey: PublicKey; privateKey: PrivateKey }>;
-  applyJsonTransaction: (tx: string) => void;
-  setTimestamp: (ms: UInt64) => void;
-  setGlobalSlot: (slot: UInt32) => void;
-  setGlobalSlotSinceHardfork: (slot: UInt32) => void;
-  setBlockchainLength: (height: UInt32) => void;
-  setTotalCurrency: (currency: UInt64) => void;
-}
-
 const defaultAccountCreationFee = 1_000_000_000;
 
 /**
@@ -250,7 +235,7 @@ const defaultAccountCreationFee = 1_000_000_000;
 function LocalBlockchain({
   accountCreationFee = defaultAccountCreationFee as string | number,
   proofsEnabled = true,
-} = {}): MockMina {
+} = {}) {
   const msPerSlot = 3 * 60 * 1000;
   const startTime = new Date().valueOf();
 
@@ -466,6 +451,10 @@ function LocalBlockchain({
       );
     },
     addAccount,
+    /**
+     * An array of 10 test accounts that have been pre-filled with
+     * 30000000000 units of currency.
+     */
     testAccounts,
     setTimestamp(ms: UInt64) {
       networkState.timestamp = ms;
@@ -481,6 +470,9 @@ function LocalBlockchain({
     },
     setTotalCurrency(currency: UInt64) {
       networkState.totalCurrency = currency;
+    },
+    setProofsEnabled(newProofsEnabled: boolean) {
+      proofsEnabled = newProofsEnabled;
     },
   };
 }

--- a/src/lib/precondition.test.ts
+++ b/src/lib/precondition.test.ts
@@ -48,6 +48,7 @@ describe('preconditions', () => {
       await expect(
         Mina.transaction(feePayer, () => {
           precondition().get();
+          AccountUpdate.attachToTransaction(zkapp.self);
         })
       ).rejects.toThrow(/precondition/);
     }
@@ -69,6 +70,7 @@ describe('preconditions', () => {
         let p = precondition().get();
         precondition().assertEquals(p as any);
       }
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     await tx.send();
     // check that tx was applied, by checking nonce was incremented
@@ -81,6 +83,7 @@ describe('preconditions', () => {
         Mina.transaction(feePayer, () => {
           let p = precondition();
           p.assertEquals(p.get() as any);
+          AccountUpdate.attachToTransaction(zkapp.self);
         })
       ).rejects.toThrow(/not implemented/);
     }
@@ -94,6 +97,7 @@ describe('preconditions', () => {
         precondition().assertBetween(p.constructor.zero, p);
       }
       zkapp.sign(zkappKey);
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     await tx.send();
     // check that tx was applied, by checking nonce was incremented
@@ -108,6 +112,7 @@ describe('preconditions', () => {
         precondition().assertNothing();
       }
       zkapp.sign(zkappKey);
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     await tx.send();
     // check that tx was applied, by checking nonce was incremented
@@ -134,6 +139,7 @@ describe('preconditions', () => {
       zkapp.self.body.preconditions.network.totalCurrency.value.upper =
         UInt64.from(1e9 * 1e9);
       zkapp.sign(zkappKey);
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     await tx.send();
     // check that tx was applied, by checking nonce was incremented
@@ -146,6 +152,7 @@ describe('preconditions', () => {
       let tx = await Mina.transaction(feePayer, () => {
         let p = precondition().get();
         precondition().assertEquals(p.add(1) as any);
+        AccountUpdate.attachToTransaction(zkapp.self);
       });
 
       await expect(tx.send()).rejects.toThrow(/unsatisfied/);
@@ -157,6 +164,7 @@ describe('preconditions', () => {
       let tx = await Mina.transaction(feePayer, () => {
         let p = precondition().get();
         precondition().assertEquals(p.not());
+        AccountUpdate.attachToTransaction(zkapp.self);
       });
       await expect(tx.send()).rejects.toThrow(/unsatisfied/);
     }
@@ -165,6 +173,7 @@ describe('preconditions', () => {
   it('unsatisfied assertEquals should be rejected (public key)', async () => {
     let tx = await Mina.transaction(feePayer, () => {
       zkapp.account.delegate.assertEquals(PublicKey.empty());
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     await expect(tx.send()).rejects.toThrow(/unsatisfied/);
   });
@@ -174,6 +183,7 @@ describe('preconditions', () => {
       let tx = await Mina.transaction(feePayer, () => {
         let p: any = precondition().get();
         precondition().assertBetween(p.add(20), p.add(30));
+        AccountUpdate.attachToTransaction(zkapp.self);
       });
       await expect(tx.send()).rejects.toThrow(/unsatisfied/);
     }
@@ -186,6 +196,7 @@ describe('preconditions', () => {
     let tx = await Mina.transaction(feePayer, () => {
       zkapp.account.nonce.assertEquals(UInt32.from(1e8));
       zkapp.sign(zkappKey);
+      AccountUpdate.attachToTransaction(zkapp.self);
     });
     expect(() => tx.send()).toThrow();
   });

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -54,8 +54,8 @@ let unimplementedPreconditions: LongKey[] = [
   'account.provedState',
 ];
 
-type BaseType = 'UInt64' | 'UInt32' | 'Field' | 'Bool';
-let baseMap = { UInt64, UInt32, Field, Bool };
+type BaseType = 'UInt64' | 'UInt32' | 'Field' | 'Bool' | 'PublicKey';
+let baseMap = { UInt64, UInt32, Field, Bool, PublicKey };
 
 function preconditionClass(
   layout: Layout,
@@ -126,6 +126,9 @@ function preconditionSubclass<
   fieldType: Provable<U>,
   context: PreconditionContext
 ) {
+  if (fieldType === undefined) {
+    throw Error(`this.${longKey}: fieldType undefined`);
+  }
   return {
     get() {
       if (unimplementedPreconditions.includes(longKey)) {

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -1,5 +1,5 @@
 import { Provable, Bool, Field } from '../snarky.js';
-import { circuitValueEquals, witness } from './circuit_value.js';
+import { circuitValueEquals, Circuit } from './circuit_value.js';
 import * as Mina from './mina.js';
 import {
   SequenceEvents,
@@ -169,7 +169,7 @@ function getVariable<K extends LongKey, U extends FlatPreconditionValue[K]>(
   longKey: K,
   fieldType: Provable<U>
 ): U {
-  return witness(fieldType, () => {
+  return Circuit.witness(fieldType, () => {
     let [accountOrNetwork, ...rest] = longKey.split('.');
     let key = rest.join('.');
     let value: U;

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -47,6 +47,7 @@ type SnarkContext = {
   inCheckedComputation?: boolean;
   inAnalyze?: boolean;
   inRunAndCheck?: boolean;
+  inWitnessBlock?: boolean;
 };
 let snarkContext = Context.create<SnarkContext>({ default: {} });
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -1,5 +1,5 @@
 import { Field, ProvablePure } from '../snarky.js';
-import { circuitArray, witness } from './circuit_value.js';
+import { circuitArray, Circuit } from './circuit_value.js';
 import { AccountUpdate, TokenId } from './account_update.js';
 import { PublicKey } from './signature.js';
 import * as Mina from './mina.js';
@@ -201,7 +201,7 @@ function createState<T>(): InternalStateType<T> {
       let contract = this._contract;
       let inProver_ = inProver();
       let stateFieldsType = circuitArray(Field, layout.length);
-      let stateAsFields = witness(stateFieldsType, () => {
+      let stateAsFields = Circuit.witness(stateFieldsType, () => {
         let account: Account;
         try {
           account = Mina.getAccount(
@@ -215,10 +215,10 @@ function createState<T>(): InternalStateType<T> {
           }
           throw Error(
             `${contract.key}.get() failed, either:\n` +
-            `1. We can't find this zkapp account in the ledger\n` +
-            `2. Because the zkapp account was not found in the cache. ` +
+              `1. We can't find this zkapp account in the ledger\n` +
+              `2. Because the zkapp account was not found in the cache. ` +
               `Try calling \`await fetchAccount(zkappAddress)\` first.\n` +
-            `If none of these are the case, then please reach out on Discord at #zkapp-developers and/or open an issue to tell us!`
+              `If none of these are the case, then please reach out on Discord at #zkapp-developers and/or open an issue to tell us!`
           );
         }
         if (account.appState === undefined) {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -702,6 +702,7 @@ class SmartContract {
     }
     this.setValue(this.self.update.permissions, Permissions.default());
     this.sign(zkappKey);
+    AccountUpdate.attachToTransaction(this.self);
   }
 
   sign(zkappKey?: PrivateKey) {
@@ -736,13 +737,9 @@ class SmartContract {
     ) {
       return executionState.accountUpdate;
     }
-    // TODO: here, we are creating a new account update & attaching it implicitly
-    // we should refactor some methods which rely on that, such as `deploy()`,
-    // to do at least the attaching explicitly, and remove implicit attaching
-    // also, implicit creation is questionable
-    let transaction = Mina.currentTransaction.get();
+    // if in a transaction, but outside a @method call, we implicitly create an account update
+    // which is stable during the current transaction -- as long as it doesn't get overridden by a method call
     let accountUpdate = selfAccountUpdate(this);
-    transaction.accountUpdates.push(accountUpdate);
     this._executionState = { transactionId, accountUpdate };
     return accountUpdate;
   }

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -587,6 +587,8 @@ declare class Circuit {
   static inProver(): boolean;
 
   static inCheckedComputation(): boolean;
+
+  static log(...args: any): void;
 }
 
 declare class Scalar {


### PR DESCRIPTION
This PR finishes the happy path of the first DEX version, without proofs. Proofs currently run into an exotic Pickles error when executing "redeemLiquidity". We checked that the account update structures created by the DEX methods make sense and are as expected.

This also
* makes some changes to how Circuit.witness works,
* adds a `Circuit.log` function (use like console.log) to remove `Circuit.asProver` boilerplate when debugging,
* makes adding account updates to the tx more explicit in some cases where it happened in a very hidden way, causing bugs
* Closes #482
* Closes #403 
* Closes #445