### PR TITLE
Add args to the callback method invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Proof verification on the web version https://github.com/o1-labs/snarkyjs/pull/476
+- Callback arguments are properly passed into method invocations https://github.com/o1-labs/snarkyjs/pull/516
 
 ## [0.6.0](https://github.com/o1-labs/snarkyjs/compare/f2ad423...ba688523)
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -558,7 +558,7 @@ class Callback<Result> extends GenericArgument {
 
     // call the callback, leveraging composability (if this is inside a smart contract method)
     // to prove to the outer circuit that we called it
-    let result = (instance[methodName] as Function)();
+    let result = (instance[methodName] as Function)(...args);
     let accountUpdate = instance.self;
 
     let callback = new Callback<any>({


### PR DESCRIPTION
# Description
Fixes https://github.com/o1-labs/snarkyjs/issues/515 
This PR adds a spread operation of the arguments into the called method on a callback. This properly passes all argument values into the method invocation.

# Tested:
Manual testing