### PR TITLE
Add shutdown to end of primitive unit test

### DIFF
--- a/src/lib/primitives.unit-test.ts
+++ b/src/lib/primitives.unit-test.ts
@@ -1,5 +1,5 @@
 import { Circuit, circuitMain } from './circuit_value.js';
-import { isReady } from '../snarky.js';
+import { isReady, shutdown } from '../snarky.js';
 import { UInt64, UInt32 } from './int.js';
 import { expect } from 'expect';
 
@@ -19,5 +19,5 @@ let keypair = Primitives.generateKeypair();
 let proof = Primitives.prove([], [], keypair);
 let ok = Primitives.verify([], keypair.verificationKey(), proof);
 expect(ok).toEqual(true);
-
 console.log('primitive operations in the circuit are working! 🎉');
+shutdown();


### PR DESCRIPTION
This issue currently is breaking CI by letting jobs run for their extended execution time (6 hours). Fixes it by calling `shutdown` to end the primitive test process.