### PR TITLE
Rename `authorize` to `approve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `VerificationKey`, which is a `Struct` with auxiliary data, to pass verification keys to a `@method`
   - BREAKING CHANGE: Change names related to circuit types: `AsFieldsAndAux<T>` -> `Provable<T>`, `AsFieldElement<T>` -> `ProvablePure<T>`, `circuitValue` -> `provable`
   - BREAKING CHANGE: Change all `ofFields` and `ofBits` methods on circuit types to `fromFields` and `fromBits`
-- `SmartContract.experimental.authorize()` to authorize a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428
-  - AccountUpdates are now valid `@method` arguments, and `authorize()` is intended to be used on them when passed to a method
+- `SmartContract.experimental.approve()` to approve a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428
+  - AccountUpdates are now valid `@method` arguments, and `approve()` is intended to be used on them when passed to a method
   - Also replaces `Experimental.accountUpdateFromCallback()`
 - `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()`
 - `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly.

--- a/src/examples/zkapps/dex/erc20.ts
+++ b/src/examples/zkapps/dex/erc20.ts
@@ -169,12 +169,12 @@ class TrivialCoin extends SmartContract implements Erc20 {
     from: PublicKey,
     to: PublicKey,
     value: UInt64,
-    authorize: Experimental.Callback<any>
+    approve: Experimental.Callback<any>
   ): Bool {
     // TODO: need to be able to witness a certain layout of account updates, in this case
     // tokenContract --> sender --> receiver
-    let fromUpdate = this.experimental.authorize(
-      authorize,
+    let fromUpdate = this.experimental.approve(
+      approve,
       AccountUpdate.Layout.NoChildren
     );
 
@@ -215,8 +215,8 @@ class TrivialCoin extends SmartContract implements Erc20 {
   // for letting a zkapp do whatever it wants, as long as no tokens are transfered
   // TODO: atm, we have to restrict the zkapp to have no children
   //       -> need to be able to witness a general layout of account updates
-  @method authorizeZkapp(callback: Experimental.Callback<any>) {
-    let zkappUpdate = this.experimental.authorize(
+  @method approveZkapp(callback: Experimental.Callback<any>) {
+    let zkappUpdate = this.experimental.approve(
       callback,
       AccountUpdate.Layout.NoChildren
     );

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -296,9 +296,9 @@ async function main({ withVesting }: { withVesting: boolean }) {
       send: Permissions.impossible(),
     });
     tokenXtokenAccount.sign();
-    // token X owner authorizes w/ signature so we don't need another method for this test
+    // token X owner approves w/ signature so we don't need another method for this test
     let tokenX = AccountUpdate.create(addresses.tokenX);
-    tokenX.authorize(tokenXtokenAccount);
+    tokenX.approve(tokenXtokenAccount);
     tokenX.sign();
   });
   await tx.prove();

--- a/src/examples/zkapps/token_with_proofs.ts
+++ b/src/examples/zkapps/token_with_proofs.ts
@@ -62,7 +62,7 @@ class TokenContract extends SmartContract {
     receiverAddress: PublicKey,
     callback: Experimental.Callback<any>
   ) {
-    let senderAccountUpdate = this.experimental.authorize(
+    let senderAccountUpdate = this.experimental.approve(
       callback,
       AccountUpdate.Layout.AnyChildren
     );
@@ -84,14 +84,14 @@ class TokenContract extends SmartContract {
 }
 
 class ZkAppB extends SmartContract {
-  @method authorizeSend() {
+  @method approveSend() {
     let amount = UInt64.from(1_000);
     this.balance.subInPlace(amount);
   }
 }
 
 class ZkAppC extends SmartContract {
-  @method authorizeSend() {
+  @method approveSend() {
     let amount = UInt64.from(1_000);
     this.balance.subInPlace(amount);
   }
@@ -168,17 +168,17 @@ tx = await Local.transaction(feePayer, () => {
 await tx.prove();
 await tx.send();
 
-console.log('authorize send from zkAppB');
+console.log('approve send from zkAppB');
 tx = await Local.transaction(feePayer, () => {
-  let authorizeSendingCallback = Experimental.Callback.create(
+  let approveSendingCallback = Experimental.Callback.create(
     zkAppB,
-    'authorizeSend',
+    'approveSend',
     []
   );
   // we call the token contract with the callback
-  tokenZkApp.sendTokens(zkAppBAddress, zkAppCAddress, authorizeSendingCallback);
+  tokenZkApp.sendTokens(zkAppBAddress, zkAppCAddress, approveSendingCallback);
 });
-console.log('authorize send (proof)');
+console.log('approve send (proof)');
 await tx.prove();
 console.log('send (proof)');
 await tx.send();
@@ -188,19 +188,19 @@ console.log(
   Mina.getBalance(zkAppCAddress, tokenId).value.toBigInt()
 );
 
-console.log('authorize send from zkAppC');
+console.log('approve send from zkAppC');
 tx = await Local.transaction(feePayer, () => {
   // Pay for tokenAccount1's account creation
   AccountUpdate.fundNewAccount(feePayer);
-  let authorizeSendingCallback = Experimental.Callback.create(
+  let approveSendingCallback = Experimental.Callback.create(
     zkAppC,
-    'authorizeSend',
+    'approveSend',
     []
   );
   // we call the token contract with the callback
-  tokenZkApp.sendTokens(zkAppCAddress, tokenAccount1, authorizeSendingCallback);
+  tokenZkApp.sendTokens(zkAppCAddress, tokenAccount1, approveSendingCallback);
 });
-console.log('authorize send (proof)');
+console.log('approve send (proof)');
 await tx.prove();
 console.log('send (proof)');
 await tx.send();

--- a/src/examples/zkapps/voting/demo.ts
+++ b/src/examples/zkapps/voting/demo.ts
@@ -260,14 +260,14 @@ try {
   );
 
   /*
-  if we now call authorizeVoters, which invokes publish on both membership contracts,
+  if we now call approveVoters, which invokes publish on both membership contracts,
   we will also update the committed members!
   and since we keep track of voters and candidates in our off-chain storage,
   both the on-chain committedMembers variable and the off-chain merkle tree root need to be equal
   */
 
   tx = await Mina.transaction(feePayer, () => {
-    contracts.voting.authorizeRegistrations();
+    contracts.voting.approveRegistrations();
     if (!params.doProofs) contracts.voting.sign(votingKey);
   });
 

--- a/src/examples/zkapps/voting/test.ts
+++ b/src/examples/zkapps/voting/test.ts
@@ -320,7 +320,7 @@ export async function testSet(
 
   try {
     let tx = await Mina.transaction(sequenceOverflowSet.feePayer, () => {
-      sequenceOverflowSet.voting.authorizeRegistrations();
+      sequenceOverflowSet.voting.approveRegistrations();
     });
     await tx.prove();
     await tx.send();
@@ -568,7 +568,7 @@ export async function testSet(
 
   /*
     test case description:
-      authorize registrations, invoked publish on both membership SCs
+      approve registrations, invoked publish on both membership SCs
     
     preconditions:
       - votes and candidates were registered previously
@@ -588,12 +588,12 @@ export async function testSet(
     true,
     () => {
       // register new candidate
-      voting.authorizeRegistrations();
+      voting.approveRegistrations();
     },
     feePayer
   );
 
-  // authorizeVoters updates the committed members on both contracts by invoking the publish method.
+  // approve updates the committed members on both contracts by invoking the publish method.
   // We check if offchain storage merkle roots match both on-chain committedMembers for voters and candidates
 
   if (!voting.committedVotes.get().equals(initialRoot).toBoolean()) {

--- a/src/examples/zkapps/voting/voting.ts
+++ b/src/examples/zkapps/voting/voting.ts
@@ -181,7 +181,7 @@ export class Voting_ extends SmartContract {
    * Calls the `publish()` method of the Candidate-Membership and Voter-Membership contract.
    */
   @method
-  authorizeRegistrations() {
+  approveRegistrations() {
     // Invokes the publish method of both Voter and Candidate Membership contracts.
     let VoterContract: Membership_ = new Membership_(voterAddress);
     VoterContract.publish();

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -709,7 +709,7 @@ class AccountUpdate implements Types.AccountUpdate {
         amount: number | bigint | UInt64;
       }) {
         let receiver = AccountUpdate.defaultAccountUpdate(address, this.id);
-        thisAccountUpdate.authorize(receiver);
+        thisAccountUpdate.approve(receiver);
         // Add the amount to mint to the receiver's account
         receiver.body.balanceChange = Int64.fromObject(
           receiver.body.balanceChange
@@ -725,7 +725,7 @@ class AccountUpdate implements Types.AccountUpdate {
         amount: number | bigint | UInt64;
       }) {
         let sender = AccountUpdate.defaultAccountUpdate(address, this.id);
-        thisAccountUpdate.authorize(sender);
+        thisAccountUpdate.approve(sender);
         sender.body.useFullCommitment = Bool(true);
 
         // Sub the amount to burn from the sender's account
@@ -748,7 +748,7 @@ class AccountUpdate implements Types.AccountUpdate {
       }) {
         // Create a new accountUpdate for the sender to send the amount to the receiver
         let sender = AccountUpdate.defaultAccountUpdate(from, this.id);
-        thisAccountUpdate.authorize(sender);
+        thisAccountUpdate.approve(sender);
         sender.body.useFullCommitment = Bool(true);
         sender.body.balanceChange = Int64.fromObject(
           sender.body.balanceChange
@@ -805,7 +805,7 @@ class AccountUpdate implements Types.AccountUpdate {
     } else {
       receiver = AccountUpdate.defaultAccountUpdate(to, this.body.tokenId);
     }
-    this.authorize(receiver);
+    this.approve(receiver);
 
     // Sub the amount from the sender's account
     this.body.balanceChange = Int64.fromObject(this.body.balanceChange).sub(
@@ -818,7 +818,7 @@ class AccountUpdate implements Types.AccountUpdate {
     ).add(amount);
   }
 
-  authorize(
+  approve(
     childUpdate: AccountUpdate,
     layout: AccountUpdatesLayout = AccountUpdate.Layout.NoDelegation
   ) {
@@ -1021,7 +1021,7 @@ class AccountUpdate implements Types.AccountUpdate {
   static create(publicKey: PublicKey, tokenId?: Field) {
     let accountUpdate = AccountUpdate.defaultAccountUpdate(publicKey, tokenId);
     if (smartContractContext.has()) {
-      smartContractContext.get().this.self.authorize(accountUpdate);
+      smartContractContext.get().this.self.approve(accountUpdate);
     } else {
       Mina.currentTransaction()?.accountUpdates.push(accountUpdate);
     }
@@ -1029,7 +1029,7 @@ class AccountUpdate implements Types.AccountUpdate {
   }
   static attachToTransaction(accountUpdate: AccountUpdate) {
     if (smartContractContext.has()) {
-      smartContractContext.get().this.self.authorize(accountUpdate);
+      smartContractContext.get().this.self.approve(accountUpdate);
     } else {
       if (!Mina.currentTransaction.has()) return;
       let updates = Mina.currentTransaction.get().accountUpdates;

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -957,7 +957,7 @@ async function verifyAccountUpdate(
     checkPermission(p, 'incrementNonce');
   }
 
-  // this checks for an edge case where an account update can be authorized using proofs but
+  // this checks for an edge case where an account update can be approved using proofs but
   // a) the proof is invalid (bad verification key)
   // and b) there are no state changes initiate so no permissions will be checked
   // however, if the verification key changes, the proof should still be invalid

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -759,28 +759,28 @@ class SmartContract {
         return zkapp.self.token();
       },
       /**
-       * Authorize an account update or callback. This will include the account update in the zkApp's public input,
+       * Approve an account update or callback. This will include the account update in the zkApp's public input,
        * which means it allows you to read and use its content in a proof, make assertions about it, and modify it.
        *
        * If this is called with a callback as the first parameter, it will first extract the account update produced by that callback.
        * The extracted account update is returned.
        *
        * ```ts
-       * \@method myAuthorizingMethod(callback: Callback) {
-       *   let authorizedUpdate = this.experimental.authorize(callback);
+       * \@method myApprovingMethod(callback: Callback) {
+       *   let approvedUpdate = this.experimental.approve(callback);
        * }
        * ```
        *
-       * Under the hood, "authorizing" just means that the account update is made a child of the zkApp in the
+       * Under the hood, "approving" just means that the account update is made a child of the zkApp in the
        * tree of account updates that forms the transaction.
-       * The second parameter `layout` allows you to also make assertions about the authorized update's _own_ children,
+       * The second parameter `layout` allows you to also make assertions about the approved update's _own_ children,
        * by specifying a certain expected layout of children. See {@link AccountUpdate.Layout}.
        *
        * @param updateOrCallback
        * @param layout
-       * @returns The account update that was authorized (needed when passing in a Callback)
+       * @returns The account update that was approved (needed when passing in a Callback)
        */
-      authorize(
+      approve(
         updateOrCallback: AccountUpdate | Callback<any>,
         layout?: AccountUpdatesLayout
       ) {
@@ -791,7 +791,7 @@ class SmartContract {
                 AccountUpdate,
                 () => updateOrCallback.accountUpdate
               );
-        zkapp.self.authorize(accountUpdate, layout);
+        zkapp.self.approve(accountUpdate, layout);
         return accountUpdate;
       },
     };


### PR DESCRIPTION
We rename 'authorize' to approve with the aim to take advantage of the concept of 'approve' in Ethereum. We hope that developers will intuitively understand what it means to 'approve' an AccountUpdate given that a smart contract in Ethereum must get approval to spend tokens.
