### PR TITLE
Call `init()` during `deploy()`, just once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - AccountUpdates are now valid `@method` arguments, and `approve()` is intended to be used on them when passed to a method
   - Also replaces `Experimental.accountUpdateFromCallback()`
 - `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()`
+- `SmartContract.init()` is a new method on the base `SmartContract` that will be called only during the first deploy (not if you re-deploy later to upgrade the contract). Overriding `init()` is the new recommended way to add custom state initialization logic.
+- `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates
 - `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly.
--
 
 ### Changed
 
@@ -43,12 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CircuitValue` deprecated in favor of `Struct` https://github.com/o1-labs/snarkyjs/pull/416
 
+### Fixed
+
+- Callback arguments are properly passed into method invocations https://github.com/o1-labs/snarkyjs/pull/516
+
 ## [0.6.1](https://github.com/o1-labs/snarkyjs/compare/ba688523...f0837188)
 
 ### Fixed
 
 - Proof verification on the web version https://github.com/o1-labs/snarkyjs/pull/476
-- Callback arguments are properly passed into method invocations https://github.com/o1-labs/snarkyjs/pull/516
 
 ## [0.6.0](https://github.com/o1-labs/snarkyjs/compare/f2ad423...ba688523)
 

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -36,8 +36,8 @@ class SimpleZkapp extends SmartContract {
     });
   }
 
-  @method init() {
-    super.init();
+  @method init(zkappKey: PrivateKey) {
+    super.init(zkappKey);
     this.balance.addInPlace(UInt64.from(initialBalance));
     this.x.set(initialState);
   }

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -359,6 +359,7 @@ class TokenContract extends SmartContract {
     });
   }
   @method init() {
+    super.init();
     // mint the entire supply to the token account with the same address as this contract
     /**
      * DUMB STUFF FOR TESTING (change in real app)

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -75,8 +75,6 @@ async function main({ withVesting }: { withVesting: boolean }) {
     feePayerUpdate.send({ to: addresses.tokenY, amount: accountFee.mul(2) });
     tokenX.deploy();
     tokenY.deploy();
-    tokenX.init();
-    tokenY.init();
   });
   await tx.prove();
   tx.sign([keys.tokenX, keys.tokenY]);

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1029,6 +1029,11 @@ class AccountUpdate implements Types.AccountUpdate {
   }
   static attachToTransaction(accountUpdate: AccountUpdate) {
     if (smartContractContext.has()) {
+      let selfUpdate = smartContractContext.get().this.self;
+      // avoid redundant attaching & cycle in account update structure, happens
+      // when calling attachToTransaction(this.self) inside a @method
+      // TODO avoid account update cycles more generally
+      if (selfUpdate === accountUpdate) return;
       smartContractContext.get().this.self.approve(accountUpdate);
     } else {
       if (!Mina.currentTransaction.has()) return;

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,12 +1,7 @@
 import 'isomorphic-fetch';
 import { Bool, Field, Ledger } from '../snarky.js';
 import { UInt32, UInt64 } from './int.js';
-import {
-  TokenId,
-  Permission,
-  Permissions,
-  ZkappStateLength,
-} from './account_update.js';
+import { TokenId, Permissions, ZkappStateLength } from './account_update.js';
 import { PublicKey } from './signature.js';
 import { NetworkValue } from './precondition.js';
 import { Types } from '../snarky/types.js';

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -372,7 +372,7 @@ function LocalBlockchain({
         try {
           // reverse errors so they match order of account updates
           // TODO: label updates, and try to give precise explanations about what went wrong
-          let errors = JSON.parse(err.message).reverse();
+          let errors = JSON.parse(err.message);
           err.message = invalidTransactionError(txn.transaction, errors, {
             accountCreationFee,
           });

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -134,7 +134,6 @@ function createTransaction(
       } catch (err_) {
         if ((err_ as any)?.bootstrap) err = err_;
         else {
-          currentTransaction.leave(transactionId);
           throw err_;
         }
       }

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -72,7 +72,7 @@ type CurrentTransaction = {
   accountUpdates: AccountUpdate[];
   fetchMode: FetchMode;
   isFinalRunOutsideCircuit: boolean;
-  numberOfRuns: number;
+  numberOfRuns: 0 | 1 | undefined;
 };
 
 let currentTransaction = Context.create<CurrentTransaction>();
@@ -98,7 +98,7 @@ function reportGetAccountError(publicKey: string, tokenId: string) {
 function createTransaction(
   feePayer: FeePayerSpec,
   f: () => unknown,
-  numberOfRuns: number,
+  numberOfRuns: 0 | 1 | undefined,
   {
     fetchMode = 'cached' as FetchMode,
     isFinalRunOutsideCircuit = true,
@@ -139,9 +139,7 @@ function createTransaction(
         break;
       } catch (err_) {
         if ((err_ as any)?.bootstrap) err = err_;
-        else {
-          throw err_;
-        }
+        else throw err_;
       }
     }
   } catch (err) {

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -52,6 +52,7 @@ class TokenContract extends SmartContract {
   }
 
   @method init() {
+    super.init();
     let address = this.self.body.publicKey;
     let receiver = this.experimental.token.mint({
       address,
@@ -182,7 +183,6 @@ async function setupLocal() {
       amount: Mina.accountCreationFee(),
     });
     tokenZkapp.deploy();
-    tokenZkapp.init();
   });
   await tx.prove();
   tx.sign([tokenZkappKey]);
@@ -200,7 +200,6 @@ async function setupLocalProofs() {
       amount: Mina.accountCreationFee(),
     });
     tokenZkapp.deploy();
-    tokenZkapp.init();
     tokenZkapp.deployZkapp(zkAppBAddress, ZkAppB._verificationKey!);
     tokenZkapp.deployZkapp(zkAppCAddress, ZkAppC._verificationKey!);
   });

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -33,6 +33,7 @@ import {
   AccountUpdatesLayout,
   smartContractContext,
   zkAppProver,
+  ZkappStateLength,
 } from './account_update.js';
 import { PrivateKey, PublicKey } from './signature.js';
 import * as Mina from './mina.js';
@@ -178,6 +179,7 @@ function wrapMethod(
                 accountUpdates: [],
                 fetchMode: inProver() ? 'cached' : 'test',
                 isFinalRunOutsideCircuit: false,
+                numberOfRuns: Infinity,
               },
               () => {
                 // inside prover / compile, the method is always called with the public input as first argument
@@ -693,15 +695,52 @@ class SmartContract {
     verificationKey?: { data: string; hash: Field | string };
     zkappKey?: PrivateKey;
   } = {}) {
+    let accountUpdate = this.newSelf();
     verificationKey ??= (this.constructor as any)._verificationKey;
     if (verificationKey !== undefined) {
       let { hash: hash_, data } = verificationKey;
       let hash = typeof hash_ === 'string' ? Field(hash_) : hash_;
-      this.setValue(this.self.update.verificationKey, { hash, data });
+      this.setValue(accountUpdate.update.verificationKey, { hash, data });
     }
-    this.setValue(this.self.update.permissions, Permissions.default());
-    this.sign(zkappKey);
-    AccountUpdate.attachToTransaction(this.self);
+    this.setValue(accountUpdate.update.permissions, Permissions.default());
+    accountUpdate.sign(zkappKey);
+    AccountUpdate.attachToTransaction(accountUpdate);
+
+    // init if this account is not yet deployed or has no verification key on it
+    let shouldInit =
+      !Mina.hasAccount(this.address) ||
+      Mina.getAccount(this.address).verificationKey !== undefined;
+    if (!shouldInit) return;
+    this.init();
+    let initUpdate = this.self;
+    // switch back to the deploy account update so the user can make modifications to it
+    this.#executionState = {
+      transactionId: this.#executionState!.transactionId,
+      accountUpdate,
+    };
+    // check if the entire state was overwritten, show a warning if not
+    let isFirstRun = Mina.currentTransaction()?.numberOfRuns === 0;
+    if (!isFirstRun) return;
+    Circuit.asProver(() => {
+      if (
+        initUpdate.update.appState.some(({ isSome }) => !isSome.toBoolean())
+      ) {
+        console.warn(`WARNING: the \`init()\` method was called without overwriting the entire state. This means that your zkApp will lack
+the \`isProved\` status which certifies that the current state was verifiably produced by proofs (and not arbitrarily set by the zkApp developer).
+To make sure the entire state is wiped, consider adding this line to your \`init()\` method:
+super.init();
+`);
+      }
+    });
+  }
+  // TODO make this a @method and create a proof during `zk deploy` (+ add mechanism to skip this)
+  init() {
+    // let accountUpdate = this.newSelf(); // this would emulate the behaviour of init() being a @method
+    let accountUpdate = this.self;
+    for (let i = 0; i < ZkappStateLength; i++) {
+      AccountUpdate.setValue(accountUpdate.body.update.appState[i], Field(0));
+    }
+    AccountUpdate.attachToTransaction(accountUpdate);
   }
 
   sign(zkappKey?: PrivateKey) {
@@ -738,6 +777,14 @@ class SmartContract {
     }
     // if in a transaction, but outside a @method call, we implicitly create an account update
     // which is stable during the current transaction -- as long as it doesn't get overridden by a method call
+    let accountUpdate = selfAccountUpdate(this);
+    this.#executionState = { transactionId, accountUpdate };
+    return accountUpdate;
+  }
+  // same as this.self, but explicitly creates a _new_ account update
+  newSelf(): AccountUpdate {
+    let inTransaction = Mina.currentTransaction.has();
+    let transactionId = inTransaction ? Mina.currentTransaction.id() : NaN;
     let accountUpdate = selfAccountUpdate(this);
     this.#executionState = { transactionId, accountUpdate };
     return accountUpdate;

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -711,7 +711,8 @@ class SmartContract {
       !Mina.hasAccount(this.address) ||
       Mina.getAccount(this.address).verificationKey !== undefined;
     if (!shouldInit) return;
-    this.init();
+    if (zkappKey) this.init(zkappKey);
+    else this.init();
     let initUpdate = this.self;
     // switch back to the deploy account update so the user can make modifications to it
     this.#executionState = {
@@ -734,8 +735,11 @@ super.init();
     });
   }
   // TODO make this a @method and create a proof during `zk deploy` (+ add mechanism to skip this)
-  init() {
+  init(zkappKey?: PrivateKey) {
     // let accountUpdate = this.newSelf(); // this would emulate the behaviour of init() being a @method
+    // TODO: enable this if provedState is available, to make this callable only once
+    // this.account.provedState.assertEquals(Bool(false));
+    zkappKey?.toPublicKey().assertEquals(this.address);
     let accountUpdate = this.self;
     for (let i = 0; i < ZkappStateLength; i++) {
       AccountUpdate.setValue(accountUpdate.body.update.appState[i], Field(0));

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -179,7 +179,7 @@ function wrapMethod(
                 accountUpdates: [],
                 fetchMode: inProver() ? 'cached' : 'test',
                 isFinalRunOutsideCircuit: false,
-                numberOfRuns: Infinity,
+                numberOfRuns: undefined,
               },
               () => {
                 // inside prover / compile, the method is always called with the public input as first argument

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -727,8 +727,8 @@ class SmartContract {
         initUpdate.update.appState.some(({ isSome }) => !isSome.toBoolean())
       ) {
         console.warn(`WARNING: the \`init()\` method was called without overwriting the entire state. This means that your zkApp will lack
-the \`isProved\` status which certifies that the current state was verifiably produced by proofs (and not arbitrarily set by the zkApp developer).
-To make sure the entire state is wiped, consider adding this line to your \`init()\` method:
+the \`provedState === true\` status which certifies that the current state was verifiably produced by proofs (and not arbitrarily set by the zkApp developer).
+To make sure the entire state is reset, consider adding this line to the beginning of your \`init()\` method:
 super.init();
 `);
       }


### PR DESCRIPTION
## `init()` RFC

This proposes a simple, incremental change which is intended to
* solve the pain point of ensuring that state is initialized only once
* give users an opt-in, easy-to-use way of showing that their state was entirely set by proofs
* give users a default where they can re-init the state multiple times

(with users I mean zkApp developers)

The logic that I propose is as follows:
* there is a new method on the base SmartContract: `init()`. It is, by default, not a `@method`
* inside deploy, we check whether the zkApp account either does not exist yet, or doesn't have a verification key on it (indicating first-time deployment)
* if this is the case, deploy calls init.
* inside the base init, we set the entire state to 0. we also set a precondition on `provedState` to be `false`.

The `init` method can be overridden by the user, to define custom state initialization logic. It's suitable for that because init will only run on the first deploy, and not on subsequent deploys. A typical smart contract could look like this:

```ts
class MyContract extends SmartContract {
  @state(Field) x = State<Field>();
  
  init() {
    super.init();
    this.setPermissions(...); // custom permissions
    this.x.set(Field(1));
  }
}
```

Note that this contract doesn't have a custom deploy method. There's no need for it, because we can set custom permissions in `init` as well (there's no reason to set their value again in re-deployments). I expect this to be the default pattern used for smart contracts going forward: no deploy, but a custom init method.

With the defaults, init is not a `@method`, and doesn't create a proof. Not being a method also has the side effect that init will not create its own account update, but will reuse the deploy account update. This is actually very important! Because, by default, zkApps have the `editState` permission set to `proof`. That means that init, without a proof, could not change the state if it were a separate account update after deploy.

Another nice side effect of having both in one update is that the user could still have state initialization logic in _deploy_. This pattern has been used in many examples so we can't expect it to immediately go away:

```ts
  deploy(args: deployArgs) {
    super.deploy(args);
    this.setPermissions(...); // custom permissions
    this.x.set(Field(1));
  }
```

Note that here, the base init is called during `super.deploy()`. Luckily, the usual pattern when overriding deploy is to put your logic _after_ `super.deploy()`. This means that your changes to the state will come after init (which here sets the state to zero; if it came after, it would wipe out your initialization). This is why I don't expect major disruption from this change for users who continue to use the old pattern and don't override init.

Some users will want to use `init()` slightly differently and make it a method:

```ts
@method init() {
    super.init();
    this.x.set(Field(1));
  }
```

Because methods always create their own account update (otherwise they couldn't create a proof about it), the effect of the decorator is that there is now a second account update, _separate_ from deploy, which just exercises the init logic. It will have a proof created for it, and after running this, the `provedState` attribute on the account is true.

### How do we ensure that malicious end users don't use init to wipe out the state?

If there is no `@method` decorator, normal users won't be able to run init because state updates without proof or signature will not be allowed to them.

If there is a method decorator, then the `provedState` attribute will become true after the first deployment. In this state, nobody can run init, because of the precondition it has that provedState = false.

Minor qualification: Since `provedState` is not available yet from graphQL, as a temp solution I actually don't set that precondition. (It's commented out.) The temp solution is that init takes an optional `privateKey` argument, and if this argument is provided, the base init checks that this private key belongs to the zkApp public key. Therefore, a developer can easily ensure, already with this PR, that no-one else can run init, by passing the private key to the base init. (See the `simple_zkapp.ts` example in this PR. It's fine to ignore this paragraph, because there's already a PR up for exposing `provedState` on graphQL.

### Can a developer change their mind and init the state a second time, with different state?

It depends: If the `editState` permission is set to `proof`, then the state can't be changed after deployment. However, with our current defaults, the permission itself can be rolled back, and so can the state. The same is true if a developer is using a `@method` for init. In fact, the question of when a developer can change the state later has nothing to do with init.

### What if we forget to call `super`?

If we don't call `super.init()`, then the base logic which sets the whole state to zero doesn't run. This is not ideal, because in the proving case, we won't get `provedState=true`. This is why I implemented a warning: After init was run, deploy will look if the entire state was updated, and if not, print the following:
```
WARNING: the `init()` method was called without overwriting the entire state. This means that your zkApp will lack
the `provedState === true` status which certifies that the current state was verifiably produced by proofs (and not arbitrarily set by the zkApp developer).
To make sure the entire state is reset, consider adding this line to the beginning of your `init()` method:
super.init();
```

### Shouldn't `init()` be a `@method`, and make a proof, by default?

I think it should eventually, but having it opt-in is fine as an incremental step. Note that, when the base init is a `@method`, then the state is silently wiped after `deploy()` even for developers who aren't aware of init and are still using the old pattern of initializing state in deploy. Therefore, it feels better to ramp up developers slowly on init so that it becomes wide-spread, before we make such a change which makes the old pattern obsolete.