### PR TITLE
Move Reducer, token, MerkleTree off Experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,28 +25,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `VerificationKey`, which is a `Struct` with auxiliary data, to pass verification keys to a `@method`
   - BREAKING CHANGE: Change names related to circuit types: `AsFieldsAndAux<T>` -> `Provable<T>`, `AsFieldElement<T>` -> `ProvablePure<T>`, `circuitValue` -> `provable`
   - BREAKING CHANGE: Change all `ofFields` and `ofBits` methods on circuit types to `fromFields` and `fromBits`
-- `SmartContract.experimental.approve()` to approve a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428
+- New option `proofsEnabled` for `LocalBlockchain` (default value: `true`), to quickly test transaction logic with proofs disabled https://github.com/o1-labs/snarkyjs/pull/462
+  - with `proofsEnabled: true`, proofs now get verified locally https://github.com/o1-labs/snarkyjs/pull/423
+- `SmartContract.approve()` to approve a tree of child account updates https://github.com/o1-labs/snarkyjs/pull/428 https://github.com/o1-labs/snarkyjs/pull/534
   - AccountUpdates are now valid `@method` arguments, and `approve()` is intended to be used on them when passed to a method
   - Also replaces `Experimental.accountUpdateFromCallback()`
-- `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()`
-- `SmartContract.init()` is a new method on the base `SmartContract` that will be called only during the first deploy (not if you re-deploy later to upgrade the contract). Overriding `init()` is the new recommended way to add custom state initialization logic.
-- `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates
-- `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly.
+- `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()` https://github.com/o1-labs/snarkyjs/pull/484
+- `SmartContract.init()` is a new method on the base `SmartContract` that will be called only during the first deploy (not if you re-deploy later to upgrade the contract) https://github.com/o1-labs/snarkyjs/pull/543
+  - Overriding `init()` is the new recommended way to add custom state initialization logic.
+- `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates https://github.com/o1-labs/snarkyjs/pull/428
+- `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly https://github.com/o1-labs/snarkyjs/pull/484
 
 ### Changed
 
-- BREAKING CHANGE: `tx.send()` is now asynchronous: old: `send(): TransactionId` new: `send(): Promise<TransactionId>` and `tx.send()` now directly waits for the network response, as opposed to `tx.send().wait()`
-- `Circuit.witness` can now be called outside circuits, where it will just directly return the callback result
-- The `FeePayerSpec`, which is used to specify properties of the transaction via `Mina.transaction()`, now has another optional parameter to specify the nonce manually. `Mina.transaction({ feePayerKey: feePayer, nonce: 1 }, () => {})`
-- BREAKING CHANGE: Static methods of type `.fromString()`, `.fromNumber()` and `.fromBigInt()` on `Field`, `UInt64`, `UInt32` and `Int64` are not longer supported.
+- BREAKING CHANGE: `tx.send()` is now asynchronous: old: `send(): TransactionId` new: `send(): Promise<TransactionId>` and `tx.send()` now directly waits for the network response, as opposed to `tx.send().wait()` https://github.com/o1-labs/snarkyjs/pull/423
+- Sending transactions to `LocalBlockchain` now involves
+- `Circuit.witness` can now be called outside circuits, where it will just directly return the callback result https://github.com/o1-labs/snarkyjs/pull/484
+- The `FeePayerSpec`, which is used to specify properties of the transaction via `Mina.transaction()`, now has another optional parameter to specify the nonce manually. `Mina.transaction({ feePayerKey: feePayer, nonce: 1 }, () => {})` https://github.com/o1-labs/snarkyjs/pull/497
+- BREAKING CHANGE: Static methods of type `.fromString()`, `.fromNumber()` and `.fromBigInt()` on `Field`, `UInt64`, `UInt32` and `Int64` are no longer supported https://github.com/o1-labs/snarkyjs/pull/519
+  - use `Field(number | string | bigint)` and `UInt64.from(number | string | bigint)`
+- Move several features out of 'experimental' https://github.com/o1-labs/snarkyjs/pull/555
+  - `Reducer` replaces `Experimental.Reducer`
+  - `MerkleTree` and `MerkleWitness` replace `Experimental.{MerkleTree,MerkleWitness}`
+  - In a `SmartContract`, `this.token` replaces `this.experimental.token`
 
 ### Deprecated
 
 - `CircuitValue` deprecated in favor of `Struct` https://github.com/o1-labs/snarkyjs/pull/416
+- Static props `Field.zero`, `Field.one`, `Field.minusOne` deprecated in favor of `Field(number)` https://github.com/o1-labs/snarkyjs/pull/524
 
 ### Fixed
 
+- Uint comparisons and division fixed inside the prover https://github.com/o1-labs/snarkyjs/pull/503
 - Callback arguments are properly passed into method invocations https://github.com/o1-labs/snarkyjs/pull/516
+- Removed internal type `JSONValue` from public interfaces https://github.com/o1-labs/snarkyjs/pull/536
+- Returning values from a zkApp https://github.com/o1-labs/snarkyjs/pull/461
 
 ## [0.6.1](https://github.com/o1-labs/snarkyjs/compare/ba688523...f0837188)
 
@@ -112,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `this.account.isNew` to assert that an account did not (or did) exist before the transaction https://github.com/MinaProtocol/mina/pull/11524
 - `LocalBlockchain.setTimestamp` and other setters for network state, to test network preconditions locally https://github.com/o1-labs/snarkyjs/pull/329
 - **Experimental APIs** are now collected under the `Experimental` import, or on `this.experimental` in a smart contract.
-- Custom tokens (_experimental_), via `this.experimental.token`. RFC: https://github.com/o1-labs/snarkyjs/issues/233, PR: https://github.com/o1-labs/snarkyjs/pull/273,
+- Custom tokens (_experimental_), via `this.token`. RFC: https://github.com/o1-labs/snarkyjs/issues/233, PR: https://github.com/o1-labs/snarkyjs/pull/273,
 - Actions / sequence events support (_experimental_), via `Experimental.Reducer`. RFC: https://github.com/o1-labs/snarkyjs/issues/265, PR: https://github.com/o1-labs/snarkyjs/pull/274
 - Merkle tree implementation (_experimental_) via `Experimental.MerkleTree` https://github.com/o1-labs/snarkyjs/pull/343
 

--- a/src/examples/zkapps/dex/arbitrary_token_interaction.ts
+++ b/src/examples/zkapps/dex/arbitrary_token_interaction.ts
@@ -48,7 +48,7 @@ tx = await Mina.transaction(userKey, () => {
   AccountUpdate.createSigned(userKey).balance.subInPlace(accountFee.mul(1));
   // 😈😈😈 mint any number of tokens to our account 😈😈😈
   let tokenContract = new TokenContract(addresses.tokenX);
-  tokenContract.experimental.token.mint({
+  tokenContract.token.mint({
     address: userAddress,
     amount: UInt64.from(1e18),
   });

--- a/src/examples/zkapps/merkle_tree/merkle_zkapp.ts
+++ b/src/examples/zkapps/merkle_tree/merkle_zkapp.ts
@@ -13,15 +13,12 @@ Merkle Trees give developers the power of storing large amounts of data off-chai
 import {
   SmartContract,
   isReady,
-  shutdown,
   Poseidon,
   Field,
-  Experimental,
   Permissions,
   DeployArgs,
   State,
   state,
-  Circuit,
   CircuitValue,
   PublicKey,
   UInt64,
@@ -31,13 +28,15 @@ import {
   UInt32,
   PrivateKey,
   AccountUpdate,
+  MerkleTree,
+  MerkleWitness,
 } from 'snarkyjs';
 
 await isReady;
 
 const doProofs = true;
 
-class MerkleWitness extends Experimental.MerkleWitness(8) {}
+class MyMerkleWitness extends MerkleWitness(8) {}
 
 class Account extends CircuitValue {
   @prop publicKey: PublicKey;
@@ -81,7 +80,7 @@ class Leaderboard extends SmartContract {
   }
 
   @method
-  guessPreimage(guess: Field, account: Account, path: MerkleWitness) {
+  guessPreimage(guess: Field, account: Account, path: MyMerkleWitness) {
     // this is our hash! its the hash of the preimage "22", but keep it a secret!
     let target = Field(
       '17057234437185175411792943285768571642343179330449434169483610110583519635705'
@@ -133,7 +132,7 @@ Accounts.set('Olivia', olivia);
 
 // we now need "wrap" the Merkle tree around our off-chain storage
 // we initialize a new Merkle Tree with height 8
-const Tree = new Experimental.MerkleTree(8);
+const Tree = new MerkleTree(8);
 
 Tree.setLeaf(0n, bob.hash());
 Tree.setLeaf(1n, alice.hash());
@@ -164,7 +163,7 @@ console.log('Final points: ' + Accounts.get('Bob')?.points);
 async function makeGuess(name: Names, index: bigint, guess: number) {
   let account = Accounts.get(name)!;
   let w = Tree.getWitness(index);
-  let witness = new MerkleWitness(w);
+  let witness = new MyMerkleWitness(w);
 
   let tx = await Mina.transaction(feePayer, () => {
     leaderboardZkApp.guessPreimage(Field(guess), account, witness);

--- a/src/examples/zkapps/reducer/reducer.ts
+++ b/src/examples/zkapps/reducer/reducer.ts
@@ -5,11 +5,11 @@ import {
   method,
   PrivateKey,
   SmartContract,
-  Experimental,
   Mina,
   AccountUpdate,
   isReady,
   Permissions,
+  Reducer,
 } from 'snarkyjs';
 
 await isReady;
@@ -18,7 +18,7 @@ const INCREMENT = Field(1);
 
 class CounterZkapp extends SmartContract {
   // the "reducer" field describes a type of action that we can dispatch, and reduce later
-  reducer = Experimental.Reducer({ actionType: Field });
+  reducer = Reducer({ actionType: Field });
 
   // on-chain version of our state. it will typically lag behind the
   // version that's implicitly represented by the list of actions
@@ -92,7 +92,7 @@ let tx = await Mina.transaction(feePayer, () => {
     });
   }
   zkapp.counter.set(initialCounter);
-  zkapp.actionsHash.set(Experimental.Reducer.initialActionsHash);
+  zkapp.actionsHash.set(Reducer.initialActionsHash);
 });
 await tx.send();
 

--- a/src/examples/zkapps/reducer/reducer_composite.ts
+++ b/src/examples/zkapps/reducer/reducer_composite.ts
@@ -5,7 +5,6 @@ import {
   method,
   PrivateKey,
   SmartContract,
-  Experimental,
   Mina,
   AccountUpdate,
   isReady,
@@ -13,6 +12,7 @@ import {
   Bool,
   Circuit,
   Struct,
+  Reducer,
 } from 'snarkyjs';
 import assert from 'node:assert/strict';
 
@@ -26,7 +26,7 @@ const INCREMENT = { isIncrement: Bool(true), otherData: Field(0) };
 
 class CounterZkapp extends SmartContract {
   // the "reducer" field describes a type of action that we can dispatch, and reduce later
-  reducer = Experimental.Reducer({ actionType: MaybeIncrement });
+  reducer = Reducer({ actionType: MaybeIncrement });
 
   // on-chain version of our state. it will typically lag behind the
   // version that's implicitly represented by the list of actions
@@ -103,7 +103,7 @@ let tx = await Mina.transaction(feePayer, () => {
     });
   }
   zkapp.counter.set(initialCounter);
-  zkapp.actionsHash.set(Experimental.Reducer.initialActionsHash);
+  zkapp.actionsHash.set(Reducer.initialActionsHash);
 });
 await tx.send();
 

--- a/src/examples/zkapps/simple_and_counter_zkapp.ts
+++ b/src/examples/zkapps/simple_and_counter_zkapp.ts
@@ -21,8 +21,8 @@ import {
   UInt32,
   Bool,
   PublicKey,
-  Circuit,
   Experimental,
+  Reducer,
 } from 'snarkyjs';
 
 const doProofs = true;
@@ -37,7 +37,7 @@ let offchainStorage = {
 
 class CounterZkapp extends SmartContract {
   // the "reducer" field describes a type of action that we can dispatch, and reduce later
-  reducer = Experimental.Reducer({ actionType: Field });
+  reducer = Reducer({ actionType: Field });
 
   // on-chain version of our state. it will typically lag behind the
   // version that's implicitly represented by the list of actions
@@ -52,7 +52,7 @@ class CounterZkapp extends SmartContract {
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),
     });
-    this.actionsHash.set(Experimental.Reducer.initialActionsHash);
+    this.actionsHash.set(Reducer.initialActionsHash);
   }
 
   @method incrementCounter() {

--- a/src/examples/zkapps/token_with_proofs.ts
+++ b/src/examples/zkapps/token_with_proofs.ts
@@ -30,7 +30,7 @@ class TokenContract extends SmartContract {
 
   @method tokenDeploy(deployer: PrivateKey, verificationKey: VerificationKey) {
     let address = deployer.toPublicKey();
-    let tokenId = this.experimental.token.id;
+    let tokenId = this.token.id;
     let deployUpdate = Experimental.createChildAccountUpdate(
       this.self,
       address,
@@ -49,12 +49,12 @@ class TokenContract extends SmartContract {
 
   @method mint(receiverAddress: PublicKey) {
     let amount = UInt64.from(1_000_000);
-    this.experimental.token.mint({ address: receiverAddress, amount });
+    this.token.mint({ address: receiverAddress, amount });
   }
 
   @method burn(receiverAddress: PublicKey) {
     let amount = UInt64.from(1_000);
-    this.experimental.token.burn({ address: receiverAddress, amount });
+    this.token.burn({ address: receiverAddress, amount });
   }
 
   @method sendTokens(
@@ -62,7 +62,7 @@ class TokenContract extends SmartContract {
     receiverAddress: PublicKey,
     callback: Experimental.Callback<any>
   ) {
-    let senderAccountUpdate = this.experimental.approve(
+    let senderAccountUpdate = this.approve(
       callback,
       AccountUpdate.Layout.AnyChildren
     );
@@ -71,7 +71,7 @@ class TokenContract extends SmartContract {
       senderAccountUpdate.body.balanceChange
     );
     negativeAmount.assertEquals(Int64.from(amount).neg());
-    let tokenId = this.experimental.token.id;
+    let tokenId = this.token.id;
     senderAccountUpdate.body.tokenId.assertEquals(tokenId);
     senderAccountUpdate.body.publicKey.assertEquals(senderAddress);
     let receiverAccountUpdate = Experimental.createChildAccountUpdate(
@@ -116,7 +116,7 @@ let tokenAccount1Key = Local.testAccounts[1].privateKey;
 let tokenAccount1 = tokenAccount1Key.toPublicKey();
 
 let tokenZkApp = new TokenContract(tokenZkAppAddress);
-let tokenId = tokenZkApp.experimental.token.id;
+let tokenId = tokenZkApp.token.id;
 
 let zkAppB = new ZkAppB(zkAppBAddress, tokenId);
 let zkAppC = new ZkAppC(zkAppCAddress, tokenId);

--- a/src/examples/zkapps/voting/demo.ts
+++ b/src/examples/zkapps/voting/demo.ts
@@ -6,13 +6,12 @@ import {
   Mina,
   AccountUpdate,
   PrivateKey,
-  Permissions,
   UInt64,
-  Experimental,
-  UInt32,
+  SmartContract,
+  Reducer,
 } from 'snarkyjs';
 import { VotingApp, VotingAppParams } from './factory.js';
-import { Member, MerkleWitness } from './member.js';
+import { Member, MyMerkleWitness } from './member.js';
 import { OffchainStorage } from './off_chain_storage.js';
 import {
   ParticipantPreconditions,
@@ -72,21 +71,17 @@ try {
 
     contracts.voting.deploy({ zkappKey: votingKey });
     contracts.voting.committedVotes.set(votesStore.getRoot());
-    contracts.voting.accumulatedVotes.set(
-      Experimental.Reducer.initialActionsHash
-    );
+    contracts.voting.accumulatedVotes.set(Reducer.initialActionsHash);
 
     contracts.candidateContract.deploy({ zkappKey: candidateKey });
     contracts.candidateContract.committedMembers.set(candidateStore.getRoot());
     contracts.candidateContract.accumulatedMembers.set(
-      Experimental.Reducer.initialActionsHash
+      Reducer.initialActionsHash
     );
 
     contracts.voterContract.deploy({ zkappKey: voterKey });
     contracts.voterContract.committedMembers.set(voterStore.getRoot());
-    contracts.voterContract.accumulatedMembers.set(
-      Experimental.Reducer.initialActionsHash
-    );
+    contracts.voterContract.accumulatedMembers.set(Reducer.initialActionsHash);
   });
   await tx.send();
 
@@ -300,8 +295,8 @@ try {
   Local.incrementGlobalSlot(5);
   tx = await Mina.transaction(feePayer, () => {
     let c = candidateStore.get(0n)!;
-    c.witness = new MerkleWitness(candidateStore.getWitness(0n));
-    c.votesWitness = new MerkleWitness(votesStore.getWitness(0n));
+    c.witness = new MyMerkleWitness(candidateStore.getWitness(0n));
+    c.votesWitness = new MyMerkleWitness(votesStore.getWitness(0n));
     // we are voting for candidate c, 0n, with voter 2n
     contracts.voting.vote(c, voterStore.get(2n)!);
     if (!params.doProofs) contracts.voting.sign(votingKey);
@@ -355,7 +350,7 @@ function registerMember(
   // we will also have to keep track of new voters and candidates within our off-chain merkle tree
   store.set(i, m); // setting voter 0n
   // setting the merkle witness
-  m.witness = new MerkleWitness(store.getWitness(i));
+  m.witness = new MyMerkleWitness(store.getWitness(i));
   return m;
 }
 

--- a/src/examples/zkapps/voting/deployContracts.ts
+++ b/src/examples/zkapps/voting/deployContracts.ts
@@ -7,6 +7,7 @@ import {
   AccountUpdate,
   PrivateKey,
   SmartContract,
+  Reducer,
 } from 'snarkyjs';
 import { VotingAppParams } from './factory.js';
 
@@ -71,19 +72,15 @@ export async function deployContracts(
 
       voting.deploy({ zkappKey: params.votingKey });
       voting.committedVotes.set(votesRoot);
-      voting.accumulatedVotes.set(Experimental.Reducer.initialActionsHash);
+      voting.accumulatedVotes.set(Reducer.initialActionsHash);
 
       candidateContract.deploy({ zkappKey: params.candidateKey });
       candidateContract.committedMembers.set(candidateRoot);
-      candidateContract.accumulatedMembers.set(
-        Experimental.Reducer.initialActionsHash
-      );
+      candidateContract.accumulatedMembers.set(Reducer.initialActionsHash);
 
       voterContract.deploy({ zkappKey: params.voterKey });
       voterContract.committedMembers.set(voterRoot);
-      voterContract.accumulatedMembers.set(
-        Experimental.Reducer.initialActionsHash
-      );
+      voterContract.accumulatedMembers.set(Reducer.initialActionsHash);
     });
     await tx.send();
   } catch (err: any) {
@@ -139,7 +136,7 @@ export async function deployInvalidContracts(
 
       voting.deploy({ zkappKey: params.votingKey });
       voting.committedVotes.set(votesRoot);
-      voting.accumulatedVotes.set(Experimental.Reducer.initialActionsHash);
+      voting.accumulatedVotes.set(Reducer.initialActionsHash);
 
       // invalid contracts
 

--- a/src/examples/zkapps/voting/member.ts
+++ b/src/examples/zkapps/voting/member.ts
@@ -5,17 +5,16 @@ import {
   prop,
   PublicKey,
   UInt64,
-  Experimental,
-  Token,
   Poseidon,
+  MerkleWitness,
 } from 'snarkyjs';
 
-export class MerkleWitness extends Experimental.MerkleWitness(8) {}
+export class MyMerkleWitness extends MerkleWitness(8) {}
 let w = {
   isLeft: false,
   sibling: Field(0),
 };
-let dummyWitness = Array.from(Array(MerkleWitness.height - 1).keys()).map(
+let dummyWitness = Array.from(Array(MyMerkleWitness.height - 1).keys()).map(
   () => w
 );
 
@@ -34,8 +33,8 @@ export class Member extends CircuitValue {
   // just to avoid double voting, but we can also ignore this for now
   @prop hashVoted: Bool;
 
-  @prop witness: MerkleWitness;
-  @prop votesWitness: MerkleWitness;
+  @prop witness: MyMerkleWitness;
+  @prop votesWitness: MyMerkleWitness;
 
   constructor(
     publicKey: PublicKey,
@@ -52,8 +51,8 @@ export class Member extends CircuitValue {
     this.isCandidate = Bool(false);
     this.votes = Field(0);
 
-    this.witness = new MerkleWitness(dummyWitness);
-    this.votesWitness = new MerkleWitness(dummyWitness);
+    this.witness = new MyMerkleWitness(dummyWitness);
+    this.votesWitness = new MyMerkleWitness(dummyWitness);
   }
 
   getHash(): Field {

--- a/src/examples/zkapps/voting/membership.ts
+++ b/src/examples/zkapps/voting/membership.ts
@@ -10,6 +10,7 @@ import {
   PublicKey,
   Experimental,
   Circuit,
+  Reducer,
 } from 'snarkyjs';
 import { Member } from './member.js';
 import { ParticipantPreconditions } from './preconditions.js';
@@ -56,7 +57,7 @@ export class Membership_ extends SmartContract {
    */
   @state(Field) accumulatedMembers = State<Field>();
 
-  reducer = Experimental.Reducer({ actionType: Member });
+  reducer = Reducer({ actionType: Member });
 
   deploy(args: DeployArgs) {
     super.deploy(args);

--- a/src/examples/zkapps/voting/off_chain_storage.ts
+++ b/src/examples/zkapps/voting/off_chain_storage.ts
@@ -1,6 +1,6 @@
 // Merkle Tree and off chain storage
 
-import { Experimental, Field, Poseidon } from 'snarkyjs';
+import { Field, MerkleTree } from 'snarkyjs';
 
 export { OffchainStorage };
 
@@ -13,7 +13,7 @@ class OffchainStorage<
 
   constructor(public readonly height: number) {
     super();
-    this.merkleTree = new Experimental.MerkleTree(height);
+    this.merkleTree = new MerkleTree(height);
   }
 
   set(key: bigint, value: V): this {

--- a/src/examples/zkapps/voting/test.ts
+++ b/src/examples/zkapps/voting/test.ts
@@ -13,7 +13,7 @@ import {
 import { deployContracts, deployInvalidContracts } from './deployContracts.js';
 import { DummyContract } from './dummyContract.js';
 import { VotingAppParams } from './factory.js';
-import { Member, MerkleWitness } from './member.js';
+import { Member, MyMerkleWitness } from './member.js';
 import { Membership_ } from './membership.js';
 import { OffchainStorage } from './off_chain_storage.js';
 import { Voting_ } from './voting.js';
@@ -768,15 +768,15 @@ export async function testSet(
     () => {
       // attempting to vote for the registered candidate
       currentCandidate = candidatesStore.get(0n)!;
-      currentCandidate.witness = new MerkleWitness(
+      currentCandidate.witness = new MyMerkleWitness(
         candidatesStore.getWitness(0n)
       );
-      currentCandidate.votesWitness = new MerkleWitness(
+      currentCandidate.votesWitness = new MyMerkleWitness(
         votesStore.getWitness(0n)
       );
 
       let v = votersStore.get(0n)!;
-      v.witness = new MerkleWitness(votersStore.getWitness(0n));
+      v.witness = new MyMerkleWitness(votersStore.getWitness(0n));
 
       voting.vote(currentCandidate, v);
     },

--- a/src/examples/zkapps/voting/voting.ts
+++ b/src/examples/zkapps/voting/voting.ts
@@ -10,6 +10,7 @@ import {
   PublicKey,
   Circuit,
   Bool,
+  Reducer,
 } from 'snarkyjs';
 
 import { Member } from './member.js';
@@ -84,7 +85,7 @@ export class Voting_ extends SmartContract {
    */
   @state(Field) accumulatedVotes = State<Field>();
 
-  reducer = Experimental.Reducer({ actionType: Member });
+  reducer = Reducer({ actionType: Member });
 
   deploy(args: DeployArgs) {
     super.deploy(args);
@@ -96,7 +97,7 @@ export class Voting_ extends SmartContract {
       setVerificationKey: Permissions.none(),
       setPermissions: Permissions.proofOrSignature(),
     });
-    this.accumulatedVotes.set(Experimental.Reducer.initialActionsHash);
+    this.accumulatedVotes.set(Reducer.initialActionsHash);
   }
 
   /**

--- a/src/examples/zkapps/voting/voting_lib.ts
+++ b/src/examples/zkapps/voting/voting_lib.ts
@@ -1,4 +1,4 @@
-import { Member, MerkleWitness } from './member.js';
+import { Member, MyMerkleWitness } from './member.js';
 import { OffchainStorage } from './off_chain_storage.js';
 import { Voting_ } from './voting.js';
 import { Mina, PrivateKey } from 'snarkyjs';
@@ -21,7 +21,7 @@ export function registerMember(
   // we will also have to keep track of new voters and candidates within our off-chain merkle tree
   store.set(i, m); // setting voter 0n
   // setting the merkle witness
-  m.witness = new MerkleWitness(store.getWitness(i));
+  m.witness = new MyMerkleWitness(store.getWitness(i));
 
   return m;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export {
   declareMethods,
   Account,
   VerificationKey,
+  Reducer,
 } from './lib/zkapp.js';
 export { state, State, declareState } from './lib/state.js';
 export { Proof, SelfProof, verify } from './lib/proof_system.js';
@@ -60,22 +61,19 @@ export {
 export * as Encryption from './lib/encryption.js';
 export * as Encoding from './lib/encoding.js';
 export { Character, CircuitString } from './lib/string.js';
+export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
 
 // experimental APIs
 import { ZkProgram } from './lib/proof_system.js';
-import { Reducer, Callback } from './lib/zkapp.js';
+import { Callback } from './lib/zkapp.js';
 import { createChildAccountUpdate } from './lib/account_update.js';
 import { memoizeWitness } from './lib/circuit_value.js';
-import { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
 export { Experimental };
 
 const Experimental_ = {
-  Reducer,
   Callback,
   createChildAccountUpdate,
   memoizeWitness,
-  MerkleTree,
-  MerkleWitness,
   ZkProgram,
 };
 
@@ -87,11 +85,8 @@ type Callback_<Result> = Callback<Result>;
  */
 namespace Experimental {
   export let ZkProgram = Experimental_.ZkProgram;
-  export let Reducer = Experimental_.Reducer;
   export let createChildAccountUpdate = Experimental_.createChildAccountUpdate;
   export let memoizeWitness = Experimental_.memoizeWitness;
-  export let MerkleTree = Experimental_.MerkleTree;
-  export let MerkleWitness = Experimental_.MerkleWitness;
   export let Callback = Experimental_.Callback;
   export type Callback<Result> = Callback_<Result>;
 }

--- a/src/lib/merkle_tree.test.ts
+++ b/src/lib/merkle_tree.test.ts
@@ -1,4 +1,11 @@
-import { isReady, shutdown, Poseidon, Field, Experimental } from 'snarkyjs';
+import {
+  isReady,
+  shutdown,
+  Poseidon,
+  Field,
+  MerkleTree,
+  MerkleWitness,
+} from 'snarkyjs';
 
 describe('Merkle Tree', () => {
   beforeAll(async () => {
@@ -9,12 +16,12 @@ describe('Merkle Tree', () => {
   });
 
   it('root of empty tree of size 1', () => {
-    const tree = new Experimental.MerkleTree(1);
+    const tree = new MerkleTree(1);
     expect(tree.getRoot().toString()).toEqual(Field(0).toString());
   });
 
   it('root is correct', () => {
-    const tree = new Experimental.MerkleTree(2);
+    const tree = new MerkleTree(2);
     tree.setLeaf(0n, Field(1));
     tree.setLeaf(1n, Field(2));
     expect(tree.getRoot().toString()).toEqual(
@@ -23,7 +30,7 @@ describe('Merkle Tree', () => {
   });
 
   it('builds correct tree', () => {
-    const tree = new Experimental.MerkleTree(4);
+    const tree = new MerkleTree(4);
     tree.setLeaf(0n, Field(1));
     tree.setLeaf(1n, Field(2));
     tree.setLeaf(2n, Field(3));
@@ -34,7 +41,7 @@ describe('Merkle Tree', () => {
   });
 
   it('tree of height 128', () => {
-    const tree = new Experimental.MerkleTree(128);
+    const tree = new MerkleTree(128);
 
     const index = 2n ** 64n;
     expect(tree.validate(index)).toBe(true);
@@ -44,7 +51,7 @@ describe('Merkle Tree', () => {
   });
 
   it('tree of height 256', () => {
-    const tree = new Experimental.MerkleTree(256);
+    const tree = new MerkleTree(256);
 
     const index = 2n ** 128n;
     expect(tree.validate(index)).toBe(true);
@@ -56,14 +63,14 @@ describe('Merkle Tree', () => {
   it('works with MerkleWitness', () => {
     // tree with height 3 (4 leaves)
     const HEIGHT = 3;
-    let tree = new Experimental.MerkleTree(HEIGHT);
-    class MerkleWitness extends Experimental.MerkleWitness(HEIGHT) {}
+    let tree = new MerkleTree(HEIGHT);
+    class MyMerkleWitness extends MerkleWitness(HEIGHT) {}
 
     // tree with the leaves [15, 16, 17, 18]
     tree.fill([15, 16, 17, 18].map(Field));
 
     // witness for the leaf '17', at index 2
-    let witness = new MerkleWitness(tree.getWitness(2n));
+    let witness = new MyMerkleWitness(tree.getWitness(2n));
 
     // calculate index
     expect(witness.calculateIndex().toString()).toEqual('2');

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -122,13 +122,13 @@ class TokenContract extends SmartContract {
 }
 
 class ZkAppB extends SmartContract {
-  @method approve(amount: UInt64) {
+  @method approveZkapp(amount: UInt64) {
     this.balance.subInPlace(amount);
   }
 }
 
 class ZkAppC extends SmartContract {
-  @method approve(amount: UInt64) {
+  @method approveZkapp(amount: UInt64) {
     this.balance.subInPlace(amount);
   }
 
@@ -543,7 +543,7 @@ describe('Token', () => {
         let tx = await Mina.transaction(feePayerKey, () => {
           let approveSendingCallback = Experimental.Callback.create(
             zkAppB,
-            'approve',
+            'approveZkapp',
             [UInt64.from(10_000)]
           );
           tokenZkapp.approveTransferCallback(

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -40,9 +40,9 @@ class TokenContract extends SmartContract {
    * This is important since we want the native token id of the deployed zkApp to be the token id of the token contract.
    */
   @method deployZkapp(address: PublicKey, verificationKey: VerificationKey) {
-    let tokenId = this.experimental.token.id;
+    let tokenId = this.token.id;
     let zkapp = AccountUpdate.defaultAccountUpdate(address, tokenId);
-    this.experimental.approve(zkapp);
+    this.approve(zkapp);
     AccountUpdate.setValue(zkapp.update.permissions, {
       ...Permissions.default(),
       send: Permissions.proof(),
@@ -54,7 +54,7 @@ class TokenContract extends SmartContract {
   @method init() {
     super.init();
     let address = this.self.body.publicKey;
-    let receiver = this.experimental.token.mint({
+    let receiver = this.token.mint({
       address,
       amount: this.SUPPLY,
     });
@@ -71,7 +71,7 @@ class TokenContract extends SmartContract {
       this.SUPPLY.value,
       "Can't mint more than the total supply"
     );
-    this.experimental.token.mint({
+    this.token.mint({
       address: receiverAddress,
       amount,
     });
@@ -86,7 +86,7 @@ class TokenContract extends SmartContract {
       UInt64.from(0).value,
       "Can't burn less than 0"
     );
-    this.experimental.token.burn({
+    this.token.burn({
       address: receiverAddress,
       amount,
     });
@@ -100,12 +100,12 @@ class TokenContract extends SmartContract {
     callback: Experimental.Callback<any>
   ) {
     let layout = AccountUpdate.Layout.NoChildren; // Allow only 1 accountUpdate with no children
-    let senderAccountUpdate = this.experimental.approve(callback, layout);
+    let senderAccountUpdate = this.approve(callback, layout);
     let negativeAmount = Int64.fromObject(
       senderAccountUpdate.body.balanceChange
     );
     negativeAmount.assertEquals(Int64.from(amount).neg());
-    let tokenId = this.experimental.token.id;
+    let tokenId = this.token.id;
     senderAccountUpdate.body.tokenId.assertEquals(tokenId);
     senderAccountUpdate.body.publicKey.assertEquals(senderAddress);
     let receiverAccountUpdate = Experimental.createChildAccountUpdate(
@@ -162,7 +162,7 @@ function setupAccounts() {
   tokenZkappAddress = tokenZkappKey.toPublicKey();
 
   tokenZkapp = new TokenContract(tokenZkappAddress);
-  tokenId = tokenZkapp.experimental.token.id;
+  tokenId = tokenZkapp.token.id;
 
   zkAppBKey = Local.testAccounts[1].privateKey;
   zkAppBAddress = zkAppBKey.toPublicKey();
@@ -371,7 +371,7 @@ describe('Token', () => {
 
         tx = await Mina.transaction(feePayerKey, () => {
           AccountUpdate.fundNewAccount(feePayerKey);
-          tokenZkapp.experimental.token.send({
+          tokenZkapp.token.send({
             from: zkAppBAddress,
             to: zkAppCAddress,
             amount: UInt64.from(10_000),
@@ -400,7 +400,7 @@ describe('Token', () => {
         ).send();
         let tx = (
           await Mina.transaction(feePayerKey, () => {
-            tokenZkapp.experimental.token.send({
+            tokenZkapp.token.send({
               from: zkAppBAddress,
               to: zkAppCAddress,
               amount: UInt64.from(10_000),
@@ -424,7 +424,7 @@ describe('Token', () => {
         ).send();
         let tx = (
           await Mina.transaction(feePayerKey, () => {
-            tokenZkapp.experimental.token.send({
+            tokenZkapp.token.send({
               from: zkAppBAddress,
               to: zkAppCAddress,
               amount: UInt64.from(100_000),
@@ -592,7 +592,7 @@ describe('Token', () => {
       test.skip('should reject tx if user bypasses the token contract by using an empty account update', async () => {
         let tx = await Mina.transaction(feePayerKey, () => {
           AccountUpdate.fundNewAccount(feePayerKey);
-          tokenZkapp.experimental.token.mint({
+          tokenZkapp.token.mint({
             address: zkAppBAddress,
             amount: UInt64.from(100_000),
           });

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -800,49 +800,42 @@ super.init();
     return this.self.network;
   }
 
-  get experimental() {
-    let zkapp = this;
-    return {
-      get token() {
-        return zkapp.self.token();
-      },
-      /**
-       * Approve an account update or callback. This will include the account update in the zkApp's public input,
-       * which means it allows you to read and use its content in a proof, make assertions about it, and modify it.
-       *
-       * If this is called with a callback as the first parameter, it will first extract the account update produced by that callback.
-       * The extracted account update is returned.
-       *
-       * ```ts
-       * \@method myApprovingMethod(callback: Callback) {
-       *   let approvedUpdate = this.experimental.approve(callback);
-       * }
-       * ```
-       *
-       * Under the hood, "approving" just means that the account update is made a child of the zkApp in the
-       * tree of account updates that forms the transaction.
-       * The second parameter `layout` allows you to also make assertions about the approved update's _own_ children,
-       * by specifying a certain expected layout of children. See {@link AccountUpdate.Layout}.
-       *
-       * @param updateOrCallback
-       * @param layout
-       * @returns The account update that was approved (needed when passing in a Callback)
-       */
-      approve(
-        updateOrCallback: AccountUpdate | Callback<any>,
-        layout?: AccountUpdatesLayout
-      ) {
-        let accountUpdate =
-          updateOrCallback instanceof AccountUpdate
-            ? updateOrCallback
-            : Circuit.witness(
-                AccountUpdate,
-                () => updateOrCallback.accountUpdate
-              );
-        zkapp.self.approve(accountUpdate, layout);
-        return accountUpdate;
-      },
-    };
+  get token() {
+    return this.self.token();
+  }
+
+  /**
+   * Approve an account update or callback. This will include the account update in the zkApp's public input,
+   * which means it allows you to read and use its content in a proof, make assertions about it, and modify it.
+   *
+   * If this is called with a callback as the first parameter, it will first extract the account update produced by that callback.
+   * The extracted account update is returned.
+   *
+   * ```ts
+   * \@method myApprovingMethod(callback: Callback) {
+   *   let approvedUpdate = this.approve(callback);
+   * }
+   * ```
+   *
+   * Under the hood, "approving" just means that the account update is made a child of the zkApp in the
+   * tree of account updates that forms the transaction.
+   * The second parameter `layout` allows you to also make assertions about the approved update's _own_ children,
+   * by specifying a certain expected layout of children. See {@link AccountUpdate.Layout}.
+   *
+   * @param updateOrCallback
+   * @param layout
+   * @returns The account update that was approved (needed when passing in a Callback)
+   */
+  approve(
+    updateOrCallback: AccountUpdate | Callback<any>,
+    layout?: AccountUpdatesLayout
+  ) {
+    let accountUpdate =
+      updateOrCallback instanceof AccountUpdate
+        ? updateOrCallback
+        : Circuit.witness(AccountUpdate, () => updateOrCallback.accountUpdate);
+    this.self.approve(accountUpdate, layout);
+    return accountUpdate;
   }
 
   send(args: {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -75,10 +75,8 @@ export {
   Callback,
   Account,
   VerificationKey,
+  Reducer,
 };
-
-// internal API
-export { Reducer };
 
 const reservedPropNames = new Set(['_methods', '_']);
 


### PR DESCRIPTION
- closes #532 
- moves the following off Experimental: MerkleTree, MerkleWitness, Reducer
- moves the following off this.experimental: token, approve 
- thoroughly updates the changelog
