### PR TITLE
Replace .sign() with .requireSignature()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Overriding `init()` is the new recommended way to add custom state initialization logic.
 - `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates https://github.com/o1-labs/snarkyjs/pull/428
 - `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly https://github.com/o1-labs/snarkyjs/pull/484
+- `SmartContract.requireSignature()` and `AccountUpdate.requireSignature()` as a simpler, better-named replacement for `.sign()` https://github.com/o1-labs/snarkyjs/pull/556
 
 ### Changed
 
@@ -53,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CircuitValue` deprecated in favor of `Struct` https://github.com/o1-labs/snarkyjs/pull/416
 - Static props `Field.zero`, `Field.one`, `Field.minusOne` deprecated in favor of `Field(number)` https://github.com/o1-labs/snarkyjs/pull/524
+- `SmartContract.sign()` and `AccountUpdate.sign()` in favor of `.requireSignature()` https://github.com/o1-labs/snarkyjs/pull/556
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Overriding `init()` is the new recommended way to add custom state initialization logic.
 - `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates https://github.com/o1-labs/snarkyjs/pull/428
 - `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly https://github.com/o1-labs/snarkyjs/pull/484
-- `SmartContract.requireSignature()` and `AccountUpdate.requireSignature()` as a simpler, better-named replacement for `.sign()` https://github.com/o1-labs/snarkyjs/pull/556
+- `SmartContract.requireSignature()` and `AccountUpdate.requireSignature()` as a simpler, better-named replacement for `.sign()` https://github.com/o1-labs/snarkyjs/pull/558
 
 ### Changed
 
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CircuitValue` deprecated in favor of `Struct` https://github.com/o1-labs/snarkyjs/pull/416
 - Static props `Field.zero`, `Field.one`, `Field.minusOne` deprecated in favor of `Field(number)` https://github.com/o1-labs/snarkyjs/pull/524
-- `SmartContract.sign()` and `AccountUpdate.sign()` in favor of `.requireSignature()` https://github.com/o1-labs/snarkyjs/pull/556
+- `SmartContract.sign()` and `AccountUpdate.sign()` in favor of `.requireSignature()` https://github.com/o1-labs/snarkyjs/pull/558
 
 ### Fixed
 

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -907,6 +907,29 @@ class AccountUpdate implements Types.AccountUpdate {
     return this.body.publicKey;
   }
 
+  /**
+   * Use this command if this account update should be signed by the account owner,
+   * instead of not having any authorization.
+   *
+   * If you use this and are not relying on a wallet to sign your transaction, then you should use the following code
+   * before sending your transaction:
+   *
+   * ```ts
+   * let tx = Mina.transaction(...); // create transaction as usual, using `requireSignature()` somewhere
+   * tx.sign([privateKey]); // pass the private key of this account to `sign()`!
+   * ```
+   *
+   * Note that an account's {@link Permissions} determine which updates have to be (can be) authorized by a signature.
+   */
+  requireSignature() {
+    let nonce = AccountUpdate.getNonce(this);
+    this.account.nonce.assertEquals(nonce);
+    this.body.incrementNonce = Bool(true);
+    Authorization.setLazySignature(this, {});
+  }
+  /**
+   * @deprecated `.sign()` is deprecated in favor of `.requireSignature()`
+   */
   sign(privateKey?: PrivateKey) {
     let nonce = AccountUpdate.getNonce(this);
     this.account.nonce.assertEquals(nonce);

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -747,9 +747,34 @@ super.init();
     AccountUpdate.attachToTransaction(accountUpdate);
   }
 
+  /**
+   * Use this command if the account update created by this SmartContract should be signed by the account owner,
+   * instead of authorized with a proof.
+   *
+   * Note that the smart contract's {@link Permissions} determine which updates have to be (can be) authorized by a signature.
+   *
+   * If you only want to avoid creating proofs for quicker testing, we advise you to
+   * use `LocalBlockchain({ proofsEnabled: false })` instead of `requireSignature()`. Setting
+   * `proofsEnabled` to `false` allows you to test your transactions with the same authorization flow as in production,
+   * with the only difference being that quick mock proofs are filled in instead of real proofs.
+   */
+  requireSignature() {
+    this.self.requireSignature();
+  }
+  /**
+   * @deprecated `this.sign()` is deprecated in favor of `this.requireSignature()`
+   */
   sign(zkappKey?: PrivateKey) {
     this.self.sign(zkappKey);
   }
+  /**
+   * Use this command if the account update created by this SmartContract should have no authorization on it,
+   * instead of being authorized with a proof.
+   *
+   * WARNING: This is a method that should rarely be useful. If you want to disable proofs for quicker testing, take a look
+   * at `LocalBlockchain({ proofsEnabled: false })`, which causes mock proofs to be created and doesn't require changing the
+   * authorization flow.
+   */
   skipAuthorization() {
     Authorization.setLazyNone(this.self);
   }


### PR DESCRIPTION
closes #441

This PR deprecates `.sign()` on SmartContract as well as AccountUpdate in favor of `.requireSignature()`.

`requireSignature()` is different in that it doesn't take an optional private key as input. The idea is to move to a default flow where all private keys are passed into `tx.sign([...])` after constructing the tx. This is already possible with `this.sign()` but we now want to make this the only supported flow of signing transactions. The reason is that only with this flow, it's possible to have the tx signed by a wallet, and it's confusing to have two different ways of doing it.

We also add doc-comments to sign / requireSignature!
