### PR TITLE
fix(examples): added missing await isReady stmts

### DIFF
--- a/src/examples/api_exploration.ts
+++ b/src/examples/api_exploration.ts
@@ -1,4 +1,5 @@
 import {
+  isReady,
   Field,
   Bool,
   Group,
@@ -11,6 +12,9 @@ import {
 } from 'snarkyjs';
 
 /* This file demonstrates the classes and functions available in snarkyjs */
+
+// Wait for SnarkyJS to load
+await isReady;
 
 /* # Field */
 

--- a/src/examples/constraint_system.ts
+++ b/src/examples/constraint_system.ts
@@ -1,5 +1,6 @@
-import { Field, Circuit, Poseidon } from 'snarkyjs';
+import { isReady, Field, Circuit, Poseidon } from 'snarkyjs';
 
+await isReady;
 let hash = Poseidon.hash([Field(1), Field(-1)]);
 
 let { rows, digest } = Circuit.constraintSystem(() => {

--- a/src/examples/ex01_small_preimage.ts
+++ b/src/examples/ex01_small_preimage.ts
@@ -1,4 +1,6 @@
-import { Poseidon, Field, Circuit, circuitMain, public_ } from 'snarkyjs';
+import { Poseidon, Field, Circuit, circuitMain, public_, isReady } from 'snarkyjs';
+
+await isReady;
 
 /* Exercise 1:
 

--- a/src/examples/matrix_mul.ts
+++ b/src/examples/matrix_mul.ts
@@ -1,4 +1,6 @@
-import { Field, provable, Circuit } from 'snarkyjs';
+import { Field, provable, Circuit, isReady } from 'snarkyjs';
+
+await isReady;
 
 // there are two ways of specifying an n*m matrix
 

--- a/src/examples/program.ts
+++ b/src/examples/program.ts
@@ -1,4 +1,6 @@
-import { SelfProof, Field, Experimental, verify } from 'snarkyjs';
+import { SelfProof, Field, Experimental, verify, isReady } from 'snarkyjs';
+
+await isReady;
 
 let MyProgram = Experimental.ZkProgram({
   publicInput: Field,

--- a/src/examples/schnorr_sign.ts
+++ b/src/examples/schnorr_sign.ts
@@ -8,7 +8,11 @@ import {
   prop,
   CircuitValue,
   Signature,
+  isReady,
 } from 'snarkyjs';
+
+await isReady;
+
 class Witness extends CircuitValue {
   @prop signature: Signature;
   @prop acc: Group;


### PR DESCRIPTION
Fix missing `await isReady;` statements in some examples
```
⋊> ~/t/z/snarkyjs on main ◦ ./run src/examples/api_exploration.ts                                                    20:38:51
running /Users/lhoste/tmp/zk/snarkyjs/dist/node/examples/api_exploration.js
/Users/lhoste/tmp/zk/snarkyjs/dist/node/_node_bindings/snarky_js_node.bc.cjs:7565
         throw err;
         ^

Error: Cannot call class constructor because snarkyjs has not finished loading.
Try calling `await isReady` before `new Field()`
    at new Class (file:///Users/lhoste/tmp/zk/snarkyjs/dist/node/snarky/proxy.js:9:23)
    at file:///Users/lhoste/tmp/zk/snarkyjs/dist/node/examples/api_exploration.js:2:12
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:409:24)
    at async file:///Users/lhoste/tmp/zk/snarkyjs/src/build/run.js:21:16

Node.js v18.4.0
