### PR TITLE
enforce protocol limits on account updates and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type inference for Structs with instance methods https://github.com/o1-labs/snarkyjs/pull/567
   - also fixes `Struct.fromJSON`
 
+### Changed
+
+- New option `enforceTransactionLimits` for `LocalBlockchain` (default value: `true`), to disable the enforcement of protocol transaction limits (maximum events, maximum sequence events and enforcing certain layout of `AccountUpdate`s depending on their authorization) https://github.com/o1-labs/snarkyjs/pull/620
+
 ## [0.7.3](https://github.com/o1-labs/snarkyjs/compare/5f20f496...d880bd6e)
 
 ### Fixed

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -13,7 +13,10 @@ import { expect } from 'expect';
 await isReady;
 let doProofs = false;
 
-let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
+let Local = Mina.LocalBlockchain({
+  proofsEnabled: doProofs,
+  enforceTransactionLimits: false,
+});
 Mina.setActiveInstance(Local);
 let accountFee = Mina.accountCreationFee();
 let [{ privateKey: feePayerKey }] = Local.testAccounts;
@@ -37,7 +40,10 @@ await TokenContract.compile();
 await main({ withVesting: false });
 
 // swap out ledger so we can start fresh
-Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
+Local = Mina.LocalBlockchain({
+  proofsEnabled: doProofs,
+  enforceTransactionLimits: false,
+});
 Mina.setActiveInstance(Local);
 [{ privateKey: feePayerKey }] = Local.testAccounts;
 feePayerAddress = feePayerKey.toPublicKey();

--- a/src/examples/zkapps/voting/demo.ts
+++ b/src/examples/zkapps/voting/demo.ts
@@ -20,6 +20,7 @@ import {
 
 let Local = Mina.LocalBlockchain({
   proofsEnabled: false,
+  enforceTransactionLimits: false,
 });
 Mina.setActiveInstance(Local);
 

--- a/src/examples/zkapps/voting/deployContracts.ts
+++ b/src/examples/zkapps/voting/deployContracts.ts
@@ -55,6 +55,7 @@ export async function deployContracts(
 }> {
   let Local = Mina.LocalBlockchain({
     proofsEnabled,
+    enforceTransactionLimits: false,
   });
   Mina.setActiveInstance(Local);
 
@@ -119,6 +120,7 @@ export async function deployInvalidContracts(
 }> {
   let Local = Mina.LocalBlockchain({
     proofsEnabled: false,
+    enforceTransactionLimits: false,
   });
   Mina.setActiveInstance(Local);
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1153,6 +1153,7 @@ function verifyTransactionLimits(accountUpdates: AccountUpdate[]) {
   let error = '';
 
   if (!isWithinCostLimit) {
+    // TODO: we should add a link to the docs explaining the reasoning behind it once we have such an explainer
     error += `Error sending transaction: The transaction is too expensive, try reducing the number of AccountUpdates that are attached to the transaction.
 Each transaction needs to be processed by the snark workers on the network.
 Certain layouts of AccountUpdates require more proving time than others, and therefore are too expensive.\n\n`;

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1160,7 +1160,8 @@ function verifyTransactionLimits(accountUpdates: AccountUpdate[]) {
     error += `Error: The transaction is too expensive, try reducing the number of AccountUpdates that are attached to the transaction.
 Each transaction needs to be processed by the snark workers on the network.
 Certain layouts of AccountUpdates require more proving time than others, and therefore are too expensive.
-${authTypes.proof}
+
+${JSON.stringify(authTypes)}
 \n\n`;
   }
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1151,8 +1151,6 @@ function verifyTransactionLimits(accountUpdates: AccountUpdate[]) {
     eventElements['sequence'] <= maxSequenceEventElements;
 
   let error = '';
-  console.log(eventElements);
-  console.log(authTypes);
 
   if (!isWithinCostLimit) {
     error += `Error sending transaction: The transaction is too expensive, try reducing the number of AccountUpdates that are attached to the transaction.

--- a/src/lib/mina.unit-test.ts
+++ b/src/lib/mina.unit-test.ts
@@ -1,0 +1,102 @@
+import { filterGroups } from './mina.js';
+import { expect } from 'expect';
+
+let S = 'Signature';
+let N = 'None_given';
+let P = 'Proof';
+
+expect(filterGroups([S, S, S, S, S, S])).toEqual({
+  proof: 0,
+  signedPair: 3,
+  signedSingle: 0,
+});
+
+expect(filterGroups([N, N, N, N, N, N])).toEqual({
+  proof: 0,
+  signedPair: 3,
+  signedSingle: 0,
+});
+
+expect(filterGroups([N, S, S, N, N, S])).toEqual({
+  proof: 0,
+  signedPair: 3,
+  signedSingle: 0,
+});
+
+expect(filterGroups([S, P, S, S, S, S])).toEqual({
+  proof: 1,
+  signedPair: 2,
+  signedSingle: 1,
+});
+
+expect(filterGroups([N, P, N, P, N, P])).toEqual({
+  proof: 3,
+  signedPair: 0,
+  signedSingle: 3,
+});
+
+expect(filterGroups([N, P])).toEqual({
+  proof: 1,
+  signedPair: 0,
+  signedSingle: 1,
+});
+
+expect(filterGroups([N, S])).toEqual({
+  proof: 0,
+  signedPair: 1,
+  signedSingle: 0,
+});
+
+expect(filterGroups([P, P])).toEqual({
+  proof: 2,
+  signedPair: 0,
+  signedSingle: 0,
+});
+
+expect(filterGroups([P, P, S, N, N])).toEqual({
+  proof: 2,
+  signedPair: 1,
+  signedSingle: 1,
+});
+
+expect(filterGroups([P])).toEqual({
+  proof: 1,
+  signedPair: 0,
+  signedSingle: 0,
+});
+
+expect(filterGroups([S])).toEqual({
+  proof: 0,
+  signedPair: 0,
+  signedSingle: 1,
+});
+
+expect(filterGroups([N])).toEqual({
+  proof: 0,
+  signedPair: 0,
+  signedSingle: 1,
+});
+
+expect(filterGroups([N, N])).toEqual({
+  proof: 0,
+  signedPair: 1,
+  signedSingle: 0,
+});
+
+expect(filterGroups([N, S])).toEqual({
+  proof: 0,
+  signedPair: 1,
+  signedSingle: 0,
+});
+
+expect(filterGroups([S, N])).toEqual({
+  proof: 0,
+  signedPair: 1,
+  signedSingle: 0,
+});
+
+expect(filterGroups([S, S])).toEqual({
+  proof: 0,
+  signedPair: 1,
+  signedSingle: 0,
+});

--- a/src/lib/mina.unit-test.ts
+++ b/src/lib/mina.unit-test.ts
@@ -1,5 +1,6 @@
 import { filterGroups } from './mina.js';
 import { expect } from 'expect';
+import { shutdown } from '../index.js';
 
 let S = 'Signature';
 let N = 'None_given';
@@ -100,3 +101,4 @@ expect(filterGroups([S, S])).toEqual({
   signedPair: 1,
   signedSingle: 0,
 });
+shutdown();

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -154,7 +154,10 @@ let zkAppCAddress: PublicKey;
 let zkAppC: ZkAppC;
 
 function setupAccounts() {
-  let Local = Mina.LocalBlockchain({ proofsEnabled: true });
+  let Local = Mina.LocalBlockchain({
+    proofsEnabled: true,
+    enforceTransactionLimits: false,
+  });
   Mina.setActiveInstance(Local);
   feePayerKey = Local.testAccounts[0].privateKey;
 


### PR DESCRIPTION
enforces limits on the layout of account updates, sequence events and events, as defined on the protocol side

~~TODO: fix token tests, since they exceed the newly defined limits~~

closes https://github.com/o1-labs/snarkyjs/issues/276