### PR TITLE
Don't increment nonces on accounts that are the fee payer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/d880bd6e...HEAD)
 
+### Changed
+
+- BREAKING CHANGE: Constraint changes in `sign()`, `requireSignature()` and `createSigned()` on `AccountUpdate` / `SmartContract`. _This means that smart contracts using these methods in their proofs won't be able to create valid proofs against old deployed verification keys._
+- New option `enforceTransactionLimits` for `LocalBlockchain` (default value: `true`), to disable the enforcement of protocol transaction limits (maximum events, maximum sequence events and enforcing certain layout of `AccountUpdate`s depending on their authorization) https://github.com/o1-labs/snarkyjs/pull/620
+
+### Deprecated
+
+- `AccountUpdate.createSigned(privateKey: PrivateKey)` in favor of new signature `AccountUpdate.createSigned(publicKey: PublicKey)`
+
 ### Fixed
 
 - Type inference for Structs with instance methods https://github.com/o1-labs/snarkyjs/pull/567
   - also fixes `Struct.fromJSON`
 - `SmartContract.fetchEvents` fixed when multiple event types existed https://github.com/o1-labs/snarkyjs/issues/627
-
-### Changed
-
-- New option `enforceTransactionLimits` for `LocalBlockchain` (default value: `true`), to disable the enforcement of protocol transaction limits (maximum events, maximum sequence events and enforcing certain layout of `AccountUpdate`s depending on their authorization) https://github.com/o1-labs/snarkyjs/pull/620
 
 ## [0.7.3](https://github.com/o1-labs/snarkyjs/compare/5f20f496...d880bd6e)
 

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -929,7 +929,7 @@ class AccountUpdate implements Types.AccountUpdate {
    */
   sign(privateKey?: PrivateKey) {
     let { nonce, isSameAsFeePayer } = AccountUpdate.getSigningInfo(this);
-    // if this account is the same as the fee payer, we use the "full commitment" for relay protection
+    // if this account is the same as the fee payer, we use the "full commitment" for replay protection
     this.body.useFullCommitment = isSameAsFeePayer;
     // otherwise, we increment the nonce
     let doIncrementNonce = isSameAsFeePayer.not();


### PR DESCRIPTION
- closes #271
- tweak the implementation of `AccountUpdate.createSigned`, to use `create` and `requireSignature()`. Deprecate the API where a private key is passed to `createSigned()` -- we want to move away from private keys in transactions. Instead, add another function signature that takes a public key.
- breaking change to the circuit used in `requireSignature()` -- this will break many deployed contracts and thus require a minor version bump