### PR TITLE
Set Update fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `this.account.<field>.set()` as a unified API to update fields on the account https://github.com/o1-labs/snarkyjs/pull/643
+  - covers `permissions`, `verificationKey`, `zkappUri`, `tokenSymbol`, `delegate`, `votingFor`
+  - exists on `SmartContract.account` and `AccountUpdate.account`
 - `Circuit.constraintSystemFromKeypair(keypair)` to inspect the circuit at a low level https://github.com/o1-labs/snarkyjs/pull/529
   - Works with a `keypair` (prover + verifier key) generated with the `Circuit` API
 
 ### Changed
 
-- BREAKING CHANGE: Constraint changes in `sign()`, `requireSignature()` and `createSigned()` on `AccountUpdate` / `SmartContract`. _This means that smart contracts using these methods in their proofs won't be able to create valid proofs against old deployed verification keys._
+- BREAKING CHANGE: Constraint changes in `sign()`, `requireSignature()` and `createSigned()` on `AccountUpdate` / `SmartContract`. _This means that smart contracts using these methods in their proofs won't be able to create valid proofs against old deployed verification keys._ https://github.com/o1-labs/snarkyjs/pull/637
 - New option `enforceTransactionLimits` for `LocalBlockchain` (default value: `true`), to disable the enforcement of protocol transaction limits (maximum events, maximum sequence events and enforcing certain layout of `AccountUpdate`s depending on their authorization) https://github.com/o1-labs/snarkyjs/pull/620
 
 ### Deprecated
 
-- `AccountUpdate.createSigned(privateKey: PrivateKey)` in favor of new signature `AccountUpdate.createSigned(publicKey: PublicKey)`
+- `this.setPermissions()` in favor of `this.account.permissions.set()` https://github.com/o1-labs/snarkyjs/pull/643
+  - `this.tokenSymbol.set()` in favor of `this.account.tokenSymbol.set()`
+  - `this.setValue()` in favor of `this.account.<field>.set()`
+- `AccountUpdate.createSigned(privateKey: PrivateKey)` in favor of new signature `AccountUpdate.createSigned(publicKey: PublicKey)` https://github.com/o1-labs/snarkyjs/pull/637
 
 ### Fixed
 

--- a/MINA_COMMIT
+++ b/MINA_COMMIT
@@ -1,2 +1,2 @@
 The mina commit used to generate the backends for node and chrome is
-cb8fa95ef27ab92ddbecb0bd925f78d9fcce3d38
+11eef6848acc011aaba2c8b1740e4b70f8d94a8a

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -30,7 +30,7 @@ class SimpleZkapp extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -393,7 +393,7 @@ function createDex({
 class TokenContract extends SmartContract {
   deploy(args?: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
       receive: Permissions.proof(),
@@ -437,14 +437,13 @@ class TokenContract extends SmartContract {
   // => need callbacks for signatures
   @method deployZkapp(address: PublicKey, verificationKey: VerificationKey) {
     let tokenId = this.token.id;
-    let zkapp = AccountUpdate.defaultAccountUpdate(address, tokenId);
-    this.approve(zkapp);
-    AccountUpdate.setValue(zkapp.update.permissions, {
+    let zkapp = AccountUpdate.create(address, tokenId);
+    zkapp.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });
-    AccountUpdate.setValue(zkapp.update.verificationKey, verificationKey);
-    zkapp.sign();
+    zkapp.account.verificationKey.set(verificationKey);
+    zkapp.requireSignature();
   }
 
   // let a zkapp send tokens to someone, provided the token supply stays constant

--- a/src/examples/zkapps/dex/erc20.ts
+++ b/src/examples/zkapps/dex/erc20.ts
@@ -16,6 +16,7 @@ import {
   Mina,
   Int64,
   PrivateKey,
+  VerificationKey,
 } from 'snarkyjs';
 
 /**
@@ -75,8 +76,8 @@ class TrivialCoin extends SmartContract implements Erc20 {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.tokenSymbol.set('SOM');
-    this.setPermissions({
+    this.account.tokenSymbol.set('SOM');
+    this.account.permissions.set({
       ...Permissions.default(),
       setPermissions: Permissions.proof(),
       send: Permissions.proof(),
@@ -105,7 +106,7 @@ class TrivialCoin extends SmartContract implements Erc20 {
     // that this function was run. Since it can be run only once, this implies it was run exactly once
 
     // make account non-upgradable forever
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       setVerificationKey: Permissions.impossible(),
       setPermissions: Permissions.impossible(),
@@ -145,7 +146,7 @@ class TrivialCoin extends SmartContract implements Erc20 {
     // we don't have to check the balance of the sender -- this is done by the zkApp protocol
     return Bool(true);
   }
-  @method approve(spender: PublicKey, value: UInt64): Bool {
+  @method approveSpend(spender: PublicKey, value: UInt64): Bool {
     // TODO: implement allowances
     return Bool(false);
   }
@@ -192,7 +193,7 @@ class TrivialCoin extends SmartContract implements Erc20 {
   }
 
   // this is a very standardized deploy method. instead, we could also take the account update from a callback
-  @method deployZkapp(zkappKey: PrivateKey) {
+  @method deployZkapp(zkappKey: PrivateKey, verificationKey: VerificationKey) {
     let address = zkappKey.toPublicKey();
     let tokenId = this.token.id;
     let zkapp = Experimental.createChildAccountUpdate(
@@ -200,12 +201,11 @@ class TrivialCoin extends SmartContract implements Erc20 {
       address,
       tokenId
     );
-    AccountUpdate.setValue(zkapp.update.permissions, {
+    zkapp.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });
-    // TODO pass in verification key
-    // AccountUpdate.setValue(zkapp.update.verificationKey, verificationKey);
+    zkapp.account.verificationKey.set(verificationKey);
     zkapp.sign(zkappKey);
   }
 

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -296,15 +296,15 @@ async function main({ withVesting }: { withVesting: boolean }) {
   console.log('prepare test with forbidden send');
   tx = await Mina.transaction(keys.tokenX, () => {
     let tokenXtokenAccount = AccountUpdate.create(addresses.tokenX, tokenIds.X);
-    AccountUpdate.setValue(tokenXtokenAccount.update.permissions, {
+    tokenXtokenAccount.account.permissions.set({
       ...Permissions.initial(),
       send: Permissions.impossible(),
     });
-    tokenXtokenAccount.sign();
+    tokenXtokenAccount.requireSignature();
     // token X owner approves w/ signature so we don't need another method for this test
     let tokenX = AccountUpdate.create(addresses.tokenX);
     tokenX.approve(tokenXtokenAccount);
-    tokenX.sign();
+    tokenX.requireSignature();
   });
   await tx.prove();
   await tx.sign([keys.tokenX]).send();

--- a/src/examples/zkapps/dex/upgradability.ts
+++ b/src/examples/zkapps/dex/upgradability.ts
@@ -104,11 +104,11 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
     console.log('manipulating setDelegate field to impossible...');
     // setting the setDelegate permission field to impossible
     let dexAccount = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(dexAccount.update.permissions, {
+    dexAccount.account.permissions.set({
       ...Permissions.initial(),
       setDelegate: Permissions.impossible(),
     });
-    dexAccount.sign();
+    dexAccount.requireSignature();
   });
   await tx.prove();
   tx.sign([keys.dex]);
@@ -120,11 +120,8 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
   tx = await Mina.transaction(feePayerKey, () => {
     // setting the delegate field to something, although permissions forbid it
     let dexAccount = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(
-      dexAccount.update.delegate,
-      PrivateKey.random().toPublicKey()
-    );
-    dexAccount.sign();
+    dexAccount.account.delegate.set(PrivateKey.random().toPublicKey());
+    dexAccount.requireSignature();
   });
   await tx.prove();
 
@@ -136,11 +133,11 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
 
   tx = await Mina.transaction(feePayerKey, () => {
     let dexAccount = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(dexAccount.update.permissions, {
+    dexAccount.account.permissions.set({
       ...Permissions.initial(),
       setDelegate: Permissions.proofOrSignature(),
     });
-    dexAccount.sign();
+    dexAccount.requireSignature();
   });
   await tx.prove();
   await tx.sign([keys.dex]).send();
@@ -150,8 +147,8 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
   let newDelegate = PrivateKey.random().toPublicKey();
   tx = await Mina.transaction(feePayerKey, () => {
     let dexAccount = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(dexAccount.update.delegate, newDelegate);
-    dexAccount.sign();
+    dexAccount.account.delegate.set(newDelegate);
+    dexAccount.requireSignature();
   });
   await tx.prove();
   await tx.sign([keys.dex]).send();
@@ -179,19 +176,15 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
     // changing the permission to impossible and then trying to change the delegate field
 
     let permissionUpdate = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(permissionUpdate.update.permissions, {
+    permissionUpdate.account.permissions.set({
       ...Permissions.initial(),
       setDelegate: Permissions.impossible(),
     });
-    permissionUpdate.sign();
+    permissionUpdate.requireSignature();
 
     let fieldUpdate = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(
-      fieldUpdate.update.delegate,
-      PrivateKey.random().toPublicKey()
-    );
-
-    fieldUpdate.sign();
+    fieldUpdate.account.delegate.set(PrivateKey.random().toPublicKey());
+    fieldUpdate.requireSignature();
   });
   await tx.prove();
   await expect(tx.sign([keys.dex]).send()).rejects.toThrow(
@@ -218,16 +211,16 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
   tx = await Mina.transaction(feePayerKey, () => {
     // changing field
     let fieldUpdate = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(fieldUpdate.update.delegate, newDelegate);
-    fieldUpdate.sign();
+    fieldUpdate.account.delegate.set(newDelegate);
+    fieldUpdate.requireSignature();
 
     // changing permissions back to impossible
     let permissionUpdate2 = AccountUpdate.create(addresses.dex);
-    AccountUpdate.setValue(permissionUpdate2.update.permissions, {
+    permissionUpdate2.account.permissions.set({
       ...Permissions.initial(),
       setDelegate: Permissions.impossible(),
     });
-    permissionUpdate2.sign();
+    permissionUpdate2.requireSignature();
   });
   await tx.prove();
   await tx.sign([keys.dex]).send();
@@ -425,7 +418,7 @@ async function upgradeabilityTests({ withVesting }: { withVesting: boolean }) {
   tx = await Mina.transaction(feePayerKey, () => {
     // pay fees for creating 3 dex accounts
     let update = AccountUpdate.createSigned(keys.dex);
-    AccountUpdate.setValue(update.update.permissions, {
+    update.account.permissions.set({
       ...Permissions.initial(),
       setVerificationKey: Permissions.impossible(),
     });

--- a/src/examples/zkapps/escrow/escrow.ts
+++ b/src/examples/zkapps/escrow/escrow.ts
@@ -14,7 +14,7 @@ import {
 export class Escrow extends SmartContract {
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proof(),
       send: Permissions.proof(),

--- a/src/examples/zkapps/hello_world/hello_world.ts
+++ b/src/examples/zkapps/hello_world/hello_world.ts
@@ -3,7 +3,6 @@ import {
   SmartContract,
   state,
   State,
-  AccountUpdate,
   method,
   DeployArgs,
   PrivateKey,

--- a/src/examples/zkapps/hello_world/hello_world.ts
+++ b/src/examples/zkapps/hello_world/hello_world.ts
@@ -21,13 +21,13 @@ export class HelloWorld extends SmartContract {
 
   deploy(input: DeployArgs) {
     super.deploy(input);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
     });
     this.x.set(Field(2));
 
-    AccountUpdate.setValue(this.self.update.delegate, adminPublicKey);
+    this.account.delegate.set(adminPublicKey);
   }
 
   @method update(squared: Field, admin: PrivateKey) {

--- a/src/examples/zkapps/local_events_zkapp.ts
+++ b/src/examples/zkapps/local_events_zkapp.ts
@@ -43,7 +43,7 @@ class SimpleZkapp extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       send: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/merkle_tree/merkle_zkapp.ts
+++ b/src/examples/zkapps/merkle_tree/merkle_zkapp.ts
@@ -71,7 +71,7 @@ class Leaderboard extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
     });

--- a/src/examples/zkapps/set_local_preconditions_zkapp.ts
+++ b/src/examples/zkapps/set_local_preconditions_zkapp.ts
@@ -26,7 +26,7 @@ await isReady;
 class SimpleZkapp extends SmartContract {
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       send: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/simple_and_counter_zkapp.ts
+++ b/src/examples/zkapps/simple_and_counter_zkapp.ts
@@ -47,7 +47,7 @@ class CounterZkapp extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),
@@ -97,7 +97,7 @@ class SimpleZkapp extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       send: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/simple_zkapp_payment.ts
+++ b/src/examples/zkapps/simple_zkapp_payment.ts
@@ -17,7 +17,7 @@ await isReady;
 class SendMINAExample extends SmartContract {
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/token_with_proofs.ts
+++ b/src/examples/zkapps/token_with_proofs.ts
@@ -21,7 +21,7 @@ await isReady;
 class TokenContract extends SmartContract {
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });
@@ -36,14 +36,11 @@ class TokenContract extends SmartContract {
       address,
       tokenId
     );
-    AccountUpdate.setValue(deployUpdate.update.permissions, {
+    deployUpdate.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });
-    AccountUpdate.setValue(
-      deployUpdate.update.verificationKey,
-      verificationKey
-    );
+    deployUpdate.account.verificationKey.set(verificationKey);
     deployUpdate.sign(deployer);
   }
 

--- a/src/examples/zkapps/voting/deployContracts.ts
+++ b/src/examples/zkapps/voting/deployContracts.ts
@@ -18,7 +18,7 @@ import { Voting_ } from './voting.js';
 class InvalidContract extends SmartContract {
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.none(),
       editSequenceState: Permissions.none(),

--- a/src/examples/zkapps/voting/dummyContract.ts
+++ b/src/examples/zkapps/voting/dummyContract.ts
@@ -13,7 +13,7 @@ export class DummyContract extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/voting/membership.ts
+++ b/src/examples/zkapps/voting/membership.ts
@@ -61,7 +61,7 @@ export class Membership_ extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),

--- a/src/examples/zkapps/voting/test.ts
+++ b/src/examples/zkapps/voting/test.ts
@@ -101,8 +101,7 @@ export async function testSet(
     true,
     () => {
       let vkUpdate = AccountUpdate.createSigned(params.votingKey);
-
-      AccountUpdate.setValue(vkUpdate.update.verificationKey, {
+      vkUpdate.account.verificationKey.set({
         ...verificationKey,
         hash: Field(verificationKey.hash),
       });
@@ -180,7 +179,7 @@ export async function testSet(
     () => {
       let permUpdate = AccountUpdate.createSigned(params.voterKey);
 
-      AccountUpdate.setValue(permUpdate.update.permissions, {
+      permUpdate.account.permissions.set({
         ...Permissions.default(),
         setPermissions: Permissions.none(),
         editSequenceState: Permissions.impossible(),

--- a/src/examples/zkapps/voting/voting.ts
+++ b/src/examples/zkapps/voting/voting.ts
@@ -89,7 +89,7 @@ export class Voting_ extends SmartContract {
 
   deploy(args: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       editSequenceState: Permissions.proofOrSignature(),

--- a/src/js_crypto/constants.ts
+++ b/src/js_crypto/constants.ts
@@ -10,7 +10,8 @@ let prefixes = {
   "accountUpdateNode": "MinaAcctUpdateNode**",
   "zkappMemo": "MinaZkappMemo*******",
   "signatureMainnet": "MinaSignatureMainnet",
-  "signatureTestnet": "CodaSignature*******"
+  "signatureTestnet": "CodaSignature*******",
+  "zkappUri": "MinaZkappUri********"
 };
 let versionBytes = {
   "tokenIdKey": 28,

--- a/src/lib/account_update.test.ts
+++ b/src/lib/account_update.test.ts
@@ -18,7 +18,7 @@ import {
 let address: PublicKey;
 let accountUpdate: AccountUpdate;
 
-describe('accountUpdate', () => {
+describe('AccountUpdate', () => {
   beforeAll(async () => {
     await isReady;
     address = PrivateKey.random().toPublicKey();
@@ -27,7 +27,7 @@ describe('accountUpdate', () => {
   });
   afterAll(() => setTimeout(shutdown, 0));
 
-  it('can convert accountUpdate to fields consistently', () => {
+  it('can convert account update to fields consistently', () => {
     // convert accountUpdate to fields in OCaml, going via AccountUpdate.of_json
     let json = JSON.stringify(accountUpdate.toJSON().body);
     let fields1 = Ledger.fieldsOfJson(json);
@@ -52,7 +52,7 @@ describe('accountUpdate', () => {
     expect(fields1).toEqual(fields2);
   });
 
-  it('can hash a accountUpdate', () => {
+  it('can hash an account update', () => {
     // TODO remove restriction "This function can't be run outside of a checked computation."
     Circuit.runAndCheck(() => {
       let hash = accountUpdate.hash();
@@ -68,7 +68,7 @@ describe('accountUpdate', () => {
     });
   });
 
-  it("converts accountUpdate to a public input that's consistent with the ocaml implementation", async () => {
+  it("converts account update to a public input that's consistent with the ocaml implementation", async () => {
     let otherAddress = PrivateKey.random().toPublicKey();
 
     let accountUpdate = AccountUpdate.create(address);

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -774,15 +774,15 @@ class AccountUpdate implements Types.AccountUpdate {
     return this.body.tokenId;
   }
 
+  /**
+   * @deprecated use `this.account.tokenSymbol`
+   */
   get tokenSymbol() {
     let accountUpdate = this;
 
     return {
       set(tokenSymbol: string) {
-        AccountUpdate.setValue(
-          accountUpdate.update.tokenSymbol,
-          TokenSymbol.from(tokenSymbol)
-        );
+        accountUpdate.account.tokenSymbol.set(tokenSymbol);
       },
     };
   }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -652,7 +652,7 @@ class AccountUpdate implements Types.AccountUpdate {
   static SequenceEvents = SequenceEvents;
 
   constructor(body: Body, authorization?: Control);
-  constructor(body: Body, authorization = {} as Control, isSelf = false) {
+  constructor(body: Body, authorization: Control = {}, isSelf = false) {
     this.id = Math.random();
     this.body = body;
     this.authorization = authorization;

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -893,7 +893,10 @@ class AccountUpdate implements Types.AccountUpdate {
    * }
    * ```
    */
-  static assertEquals<T>(property: OrIgnore<ClosedInterval<T> | T>, value: T) {
+  static assertEquals<T extends object>(
+    property: OrIgnore<ClosedInterval<T> | T>,
+    value: T
+  ) {
     property.isSome = Bool(true);
     if ('lower' in property.value && 'upper' in property.value) {
       property.value.lower = value;

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -866,7 +866,13 @@ function cloneCircuitValue<T>(obj: T): T {
 
 function circuitValueEquals<T>(a: T, b: T): boolean {
   // primitive JS types and functions are checked for exact equality
-  if (typeof a !== 'object' || a === null) return a === b;
+  if (
+    typeof a !== 'object' ||
+    a === null ||
+    typeof b !== 'object' ||
+    b === null
+  )
+    return a === b;
 
   // built-in JS datatypes with custom equality checks
   if (Array.isArray(a)) {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -133,7 +133,9 @@ function dataAsHash<T, J, Field>({
   emptyValue: () => { data: T; hash: Field };
   toJSON: (value: T) => J;
   fromJSON: (json: J) => { data: T; hash: Field };
-}): GenericProvableExtended<{ data: T; hash: Field }, J, Field> {
+}): GenericProvableExtended<{ data: T; hash: Field }, J, Field> & {
+  emptyValue(): { data: T; hash: Field };
+} {
   return {
     emptyValue,
     sizeInFields() {

--- a/src/lib/hash-generic.ts
+++ b/src/lib/hash-generic.ts
@@ -1,0 +1,70 @@
+import { GenericField, GenericHashInput } from '../provable/generic.js';
+import { prefixToField } from '../provable/binable.js';
+
+export { createHashHelpers, HashHelpers };
+
+type Hash<Field> = {
+  initialState(): Field[];
+  update(state: Field[], input: Field[]): Field[];
+};
+
+type HashHelpers<Field> = ReturnType<typeof createHashHelpers<Field>>
+
+function createHashHelpers<Field>(
+  Field: GenericField<Field>,
+  Hash: Hash<Field>
+) {
+  function toBigInt(x: Field): bigint {
+    if (typeof x === 'bigint') return x;
+    if ((x as any).toBigInt) return (x as any).toBigInt();
+    throw Error(`toBigInt: not implemented for ${x}`);
+  }
+
+  function salt(prefix: string) {
+    return Hash.update(Hash.initialState(), [prefixToField(Field, prefix)]);
+  }
+  function emptyHashWithPrefix(prefix: string) {
+    return salt(prefix)[0];
+  }
+  function hashWithPrefix(prefix: string, input: Field[]) {
+    let init = salt(prefix);
+    return Hash.update(init, input)[0];
+  }
+
+  type HashInput = GenericHashInput<Field>;
+
+  /**
+   * Convert the {fields, packed} hash input representation to a list of field elements
+   * Random_oracle_input.Chunked.pack_to_fields
+   */
+  function packToFields({ fields = [], packed = [] }: HashInput) {
+    if (packed.length === 0) return fields;
+    let packedBits = [];
+    let currentPackedField = 0n;
+    let currentSize = 0;
+    for (let [field_, size] of packed) {
+      let field = toBigInt(field_);
+      currentSize += size;
+      if (currentSize < 255) {
+        currentPackedField = currentPackedField * (1n << BigInt(size)) + field;
+      } else {
+        packedBits.push(currentPackedField);
+        currentSize = size;
+        currentPackedField = field;
+      }
+    }
+    packedBits.push(currentPackedField);
+    return fields.concat(packedBits.map(Field));
+  }
+
+  return {
+    salt,
+    emptyHashWithPrefix,
+    hashWithPrefix,
+    /**
+     * Convert the {fields, packed} hash input representation to a list of field elements
+     * Random_oracle_input.Chunked.pack_to_fields
+     */
+    packToFields,
+  };
+}

--- a/src/lib/hash-generic.ts
+++ b/src/lib/hash-generic.ts
@@ -15,12 +15,6 @@ function createHashHelpers<Field>(
   Hash: Hash<Field>,
   packToFields: (input: GenericHashInput<Field>) => Field[]
 ) {
-  function toBigInt(x: Field): bigint {
-    if (typeof x === 'bigint') return x;
-    if ((x as any).toBigInt) return (x as any).toBigInt();
-    throw Error(`toBigInt: not implemented for ${x}`);
-  }
-
   function salt(prefix: string) {
     return Hash.update(Hash.initialState(), [prefixToField(Field, prefix)]);
   }

--- a/src/lib/hash-input.unit-test.ts
+++ b/src/lib/hash-input.unit-test.ts
@@ -71,11 +71,11 @@ let update = accountUpdate.body.update;
 update.timing.isSome = Bool(true);
 update.appState[0].isSome = Bool(true);
 update.appState[0].value = Field(9);
-update.delegate.isSome = Bool(true);
-let delegate = PrivateKey.random().toPublicKey();
-update.delegate.value = delegate;
 
-accountUpdate.tokenSymbol.set('BLABLA');
+let delegate = PrivateKey.random().toPublicKey();
+accountUpdate.account.delegate.set(delegate);
+accountUpdate.account.tokenSymbol.set('BLABLA');
+accountUpdate.account.zkappUri.set('https://example.com');
 testInput(Update, Ledger.hashInputFromJson.update, update);
 
 // account precondition

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,6 +1,7 @@
 import { HashInput, ProvableExtended, Struct } from './circuit_value.js';
 import { Poseidon as Poseidon_, Field } from '../snarky.js';
 import { inCheckedComputation } from './proof_system.js';
+import { createHashHelpers } from './hash-generic.js';
 
 // external API
 export { Poseidon, TokenSymbol };
@@ -8,6 +9,7 @@ export { Poseidon, TokenSymbol };
 // internal API
 export {
   HashInput,
+  Hash,
   prefixes,
   emptyHashWithPrefix,
   hashWithPrefix,
@@ -48,21 +50,15 @@ const Poseidon = {
     return Poseidon_.update(state, input, isChecked);
   },
 
-  get initialState(): [Field, Field, Field] {
+  initialState(): [Field, Field, Field] {
     return [Field(0), Field(0), Field(0)];
   },
 
   Sponge,
 };
 
-function emptyHashWithPrefix(prefix: string) {
-  return salt(prefix)[0];
-}
-
-function hashWithPrefix(prefix: string, input: Field[]) {
-  let init = salt(prefix);
-  return Poseidon.update(init, input)[0];
-}
+let Hash = createHashHelpers(Field, Poseidon);
+let { packToFields, salt, emptyHashWithPrefix, hashWithPrefix } = Hash;
 
 const prefixes: typeof Poseidon_.prefixes = new Proxy({} as any, {
   // hack bc Poseidon_.prefixes is not available at start-up
@@ -72,10 +68,6 @@ const prefixes: typeof Poseidon_.prefixes = new Proxy({} as any, {
     ] as string;
   },
 });
-
-function salt(prefix: string) {
-  return Poseidon.update(Poseidon.initialState, [prefixToField(prefix)]);
-}
 
 // same as Random_oracle.prefix_to_field in OCaml
 function prefixToField(prefix: string) {
@@ -91,31 +83,6 @@ function prefixToField(prefix: string) {
     })
     .flat();
   return Field.fromBits(bits);
-}
-
-/**
- * Convert the {fields, packed} hash input representation to a list of field elements
- * Random_oracle_input.Chunked.pack_to_fields
- */
-function packToFields({ fields = [], packed = [] }: HashInput) {
-  if (packed.length === 0) return fields;
-  let packedBits = [];
-  let currentPackedField = Field(0);
-  let currentSize = 0;
-  for (let [field, size] of packed) {
-    currentSize += size;
-    if (currentSize < 255) {
-      currentPackedField = currentPackedField
-        .mul(Field(1n << BigInt(size)))
-        .add(field);
-    } else {
-      packedBits.push(currentPackedField);
-      currentSize = size;
-      currentPackedField = field;
-    }
-  }
-  packedBits.push(currentPackedField);
-  return fields.concat(packedBits);
 }
 
 const TokenSymbolPure: ProvableExtended<

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -348,7 +348,7 @@ type RangeCondition<T> = { isSome: Bool; value: { lower: T; upper: T } };
 type FlaggedOptionCondition<T> = { isSome: Bool; value: T };
 type AnyCondition<T> = RangeCondition<T> | FlaggedOptionCondition<T>;
 
-function isRangeCondition<T>(
+function isRangeCondition<T extends object>(
   condition: AnyCondition<T>
 ): condition is RangeCondition<T> {
   return 'isSome' in condition && 'lower' in condition.value;

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -11,6 +11,7 @@ import { Layout } from '../provable/gen/transaction.js';
 import { jsLayout } from '../provable/gen/js-layout.js';
 import { emptyReceiptChainHash, TokenSymbol } from './hash.js';
 import { PublicKey } from './signature.js';
+import { ZkappUri } from '../provable/transaction-leaves.js';
 
 export {
   preconditions,
@@ -55,9 +56,7 @@ function Account(accountUpdate: AccountUpdate): Account {
     },
     verificationKey: updateSubclass(accountUpdate, 'verificationKey', identity),
     permissions: updateSubclass(accountUpdate, 'permissions', identity),
-    zkappUri: updateSubclass(accountUpdate, 'zkappUri', () => {
-      throw Error('zkappUri.set is not implemented');
-    }),
+    zkappUri: updateSubclass(accountUpdate, 'zkappUri', ZkappUri.fromJSON),
     tokenSymbol: updateSubclass(accountUpdate, 'tokenSymbol', TokenSymbol.from),
     timing: updateSubclass(accountUpdate, 'timing', identity),
     votingFor: updateSubclass(accountUpdate, 'votingFor', identity),

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -28,7 +28,7 @@ class TokenContract extends SmartContract {
 
   deploy(args?: DeployArgs) {
     super.deploy(args);
-    this.setPermissions({
+    this.account.permissions.set({
       ...Permissions.default(),
       editState: Permissions.proofOrSignature(),
       send: Permissions.proof(),
@@ -43,12 +43,12 @@ class TokenContract extends SmartContract {
     let tokenId = this.token.id;
     let zkapp = AccountUpdate.defaultAccountUpdate(address, tokenId);
     this.approve(zkapp);
-    AccountUpdate.setValue(zkapp.update.permissions, {
+    zkapp.account.permissions.set({
       ...Permissions.default(),
       send: Permissions.proof(),
     });
-    AccountUpdate.setValue(zkapp.update.verificationKey, verificationKey);
-    zkapp.sign();
+    zkapp.account.verificationKey.set(verificationKey);
+    zkapp.requireSignature();
   }
 
   @method init() {
@@ -117,7 +117,7 @@ class TokenContract extends SmartContract {
   }
 
   @method setValidTokenSymbol() {
-    this.tokenSymbol.set(tokenSymbol);
+    this.account.tokenSymbol.set(tokenSymbol);
   }
 }
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -724,9 +724,9 @@ class SmartContract {
     if (verificationKey !== undefined) {
       let { hash: hash_, data } = verificationKey;
       let hash = typeof hash_ === 'string' ? Field(hash_) : hash_;
-      this.setValue(accountUpdate.update.verificationKey, { hash, data });
+      accountUpdate.account.verificationKey.set({ hash, data });
     }
-    this.setValue(accountUpdate.update.permissions, Permissions.default());
+    accountUpdate.account.permissions.set(Permissions.default());
     accountUpdate.sign(zkappKey);
     AccountUpdate.attachToTransaction(accountUpdate);
 
@@ -766,7 +766,7 @@ super.init();
    * class MyContract extends SmartContract {
    *  init() {
    *    super.init();
-   *    this.setPermissions();
+   *    this.account.permissions.set(...);
    *    this.x.set(Field(1));
    *  }
    * }
@@ -923,7 +923,7 @@ super.init();
   }
 
   /**
-   * Token symbol of this token.
+   * @deprecated use `this.account.tokenSymbol`
    */
   get tokenSymbol() {
     return this.self.tokenSymbol;
@@ -1089,17 +1089,18 @@ super.init();
     return ZkappClass._methodMetadata;
   }
 
+  /**
+   * @deprecated use `this.account.<field>.set()`
+   */
   setValue<T>(maybeValue: SetOrKeep<T>, value: T) {
     AccountUpdate.setValue(maybeValue, value);
   }
 
-  // TBD: do we want to have setters for updates, e.g. this.permissions = ... ?
-  // I'm hesitant to make the API even more magical / less explicit
   /**
-   * Changes the {@link Permissions} of this {@link SmartContract}.
+   * @deprecated use `this.account.permissions.set()`
    */
   setPermissions(permissions: Permissions) {
-    this.setValue(this.self.update.permissions, permissions);
+    this.self.account.permissions.set(permissions);
   }
 }
 

--- a/src/provable/derived-leaves.ts
+++ b/src/provable/derived-leaves.ts
@@ -1,18 +1,22 @@
 import { GenericBool, GenericField, GenericHashInput } from './generic.js';
 import { createProvable } from './provable-generic.js';
 import * as Json from './gen/transaction-json.js';
-import { prefixToField } from './binable.js';
+import { bytesToBits, prefixToField } from './binable.js';
 import { fieldEncodings } from './base58.js';
 import { dataAsHash } from '../lib/events.js';
+import { HashHelpers } from '../lib/hash-generic.js';
+import { prefixes } from '../js_crypto/constants.js';
 
 export { derivedLeafTypes };
 
 function derivedLeafTypes<Field, Bool>({
   Field,
   Bool,
+  Hash,
 }: {
   Field: GenericField<Field>;
   Bool: GenericBool<Field, Bool>;
+  Hash: HashHelpers<Field>;
 }) {
   let provable = createProvable<Field>();
   const Encoding = fieldEncodings<Field>(Field);
@@ -133,22 +137,25 @@ function derivedLeafTypes<Field, Bool>({
     },
   };
 
+  // Mina_base.Zkapp_account.hash_zkapp_uri_opt
+  function hashZkappUri(uri: string) {
+    let bits = bytesToBits([...uri].map((char) => char.charCodeAt(0)));
+    bits.push(true);
+    let input: HashInput = { packed: bits.map((b) => [Field(Number(b)), 1]) };
+    let packed = Hash.packToFields(input);
+    return Hash.hashWithPrefix(prefixes.zkappUri, packed);
+  }
+
   const ZkappUri = dataAsHash<string, string, Field>({
     emptyValue() {
-      return {
-        data: '',
-        hash: Field(
-          22930868938364086394602058221028773520482901241511717002947639863679740444066n
-        ),
-      };
+      let hash = Hash.hashWithPrefix(prefixes.zkappUri, [Field(0), Field(0)]);
+      return { data: '', hash };
     },
     toJSON(data: string) {
       return data;
     },
     fromJSON(json: string) {
-      let data = json;
-      // TODO compute hash
-      throw Error('unimplemented');
+      return { data: json, hash: hashZkappUri(json) };
     },
   });
 

--- a/src/provable/derived-leaves.ts
+++ b/src/provable/derived-leaves.ts
@@ -3,6 +3,7 @@ import { createProvable } from './provable-generic.js';
 import * as Json from './gen/transaction-json.js';
 import { prefixToField } from './binable.js';
 import { fieldEncodings } from './base58.js';
+import { dataAsHash } from '../lib/events.js';
 
 export { derivedLeafTypes };
 
@@ -132,5 +133,30 @@ function derivedLeafTypes<Field, Bool>({
     },
   };
 
-  return { TokenId, TokenSymbol, AuthRequired, AuthorizationKind };
+  const ZkappUri = dataAsHash<string, string, Field>({
+    emptyValue() {
+      return {
+        data: '',
+        hash: Field(
+          22930868938364086394602058221028773520482901241511717002947639863679740444066n
+        ),
+      };
+    },
+    toJSON(data: string) {
+      return data;
+    },
+    fromJSON(json: string) {
+      let data = json;
+      // TODO compute hash
+      throw Error('unimplemented');
+    },
+  });
+
+  return {
+    TokenId,
+    TokenSymbol,
+    AuthRequired,
+    AuthorizationKind,
+    ZkappUri,
+  };
 }

--- a/src/provable/gen/js-layout.ts
+++ b/src/provable/gen/js-layout.ts
@@ -178,7 +178,7 @@ let jsLayout = {
                           },
                           docEntries: { data: null, hash: null },
                         },
-                        checkedTypeName: 'StringWithHash',
+                        checkedTypeName: 'ZkappUri',
                       },
                     },
                     tokenSymbol: {
@@ -905,7 +905,7 @@ let jsLayout = {
                     },
                     docEntries: { data: null, hash: null },
                   },
-                  checkedTypeName: 'StringWithHash',
+                  checkedTypeName: 'ZkappUri',
                 },
               },
               tokenSymbol: {

--- a/src/provable/gen/transaction-bigint.ts
+++ b/src/provable/gen/transaction-bigint.ts
@@ -11,7 +11,7 @@ import {
   TokenSymbol,
   Sign,
   AuthorizationKind,
-  StringWithHash,
+  ZkappUri,
   Events,
   SequenceEvents,
   SequenceState,
@@ -59,7 +59,7 @@ type ProvableExtended<T, TJson> = GenericProvableExtended<T, TJson, Field>;
 type Layout = GenericLayout<TypeMap>;
 
 type CustomTypes = {
-  StringWithHash: ProvableExtended<
+  ZkappUri: ProvableExtended<
     {
       data: string;
       hash: Field;
@@ -84,7 +84,7 @@ type CustomTypes = {
   SequenceState: ProvableExtended<Field, Json.TypeMap['Field']>;
 };
 let customTypes: CustomTypes = {
-  StringWithHash,
+  ZkappUri,
   TokenSymbol,
   Events,
   SequenceEvents,

--- a/src/provable/gen/transaction.ts
+++ b/src/provable/gen/transaction.ts
@@ -11,7 +11,7 @@ import {
   TokenSymbol,
   Sign,
   AuthorizationKind,
-  StringWithHash,
+  ZkappUri,
   Events,
   SequenceEvents,
   SequenceState,
@@ -59,7 +59,7 @@ type ProvableExtended<T, TJson> = GenericProvableExtended<T, TJson, Field>;
 type Layout = GenericLayout<TypeMap>;
 
 type CustomTypes = {
-  StringWithHash: ProvableExtended<
+  ZkappUri: ProvableExtended<
     {
       data: string;
       hash: Field;
@@ -84,7 +84,7 @@ type CustomTypes = {
   SequenceState: ProvableExtended<Field, Json.TypeMap['Field']>;
 };
 let customTypes: CustomTypes = {
-  StringWithHash,
+  ZkappUri,
   TokenSymbol,
   Events,
   SequenceEvents,

--- a/src/provable/poseidon-bigint.ts
+++ b/src/provable/poseidon-bigint.ts
@@ -18,9 +18,31 @@ export {
 
 type HashInput = GenericHashInput<Field>;
 const HashInput = createHashInput<Field>();
-let Hash = createHashHelpers(Field, Poseidon);
-let { packToFields, hashWithPrefix } = Hash;
+let Hash = createHashHelpers(Field, Poseidon, packToFields);
+let { hashWithPrefix } = Hash;
 
+/**
+ * Convert the {fields, packed} hash input representation to a list of field elements
+ * Random_oracle_input.Chunked.pack_to_fields
+ */
+function packToFields({ fields = [], packed = [] }: HashInput) {
+  if (packed.length === 0) return fields;
+  let packedBits = [];
+  let currentPackedField = 0n;
+  let currentSize = 0;
+  for (let [field, size] of packed) {
+    currentSize += size;
+    if (currentSize < 255) {
+      currentPackedField = currentPackedField * (1n << BigInt(size)) + field;
+    } else {
+      packedBits.push(currentPackedField);
+      currentSize = size;
+      currentPackedField = field;
+    }
+  }
+  packedBits.push(currentPackedField);
+  return fields.concat(packedBits);
+}
 /**
  * Random_oracle_input.Legacy.pack_to_fields, for the special case of a single bitstring
  */

--- a/src/provable/poseidon-bigint.ts
+++ b/src/provable/poseidon-bigint.ts
@@ -4,9 +4,11 @@ import { Poseidon } from '../js_crypto/poseidon.js';
 import { prefixes } from '../js_crypto/constants.js';
 import { createHashInput } from './provable-generic.js';
 import { GenericHashInput } from './generic.js';
+import { createHashHelpers } from 'src/lib/hash-generic.js';
 
 export {
   Poseidon,
+  Hash,
   HashInput,
   prefixes,
   packToFields,
@@ -16,39 +18,9 @@ export {
 
 type HashInput = GenericHashInput<Field>;
 const HashInput = createHashInput<Field>();
+let Hash = createHashHelpers(Field, Poseidon);
+let { packToFields, hashWithPrefix } = Hash;
 
-function salt(prefix: string) {
-  return Poseidon.update(Poseidon.initialState(), [
-    prefixToField(Field, prefix),
-  ]);
-}
-function hashWithPrefix(prefix: string, input: Field[]) {
-  let init = salt(prefix);
-  return Poseidon.update(init, input)[0];
-}
-
-/**
- * Convert the {fields, packed} hash input representation to a list of field elements
- * Random_oracle_input.Chunked.pack_to_fields
- */
-function packToFields({ fields = [], packed = [] }: HashInput) {
-  if (packed.length === 0) return fields;
-  let packedBits = [];
-  let currentPackedField = 0n;
-  let currentSize = 0;
-  for (let [field, size] of packed) {
-    currentSize += size;
-    if (currentSize < 255) {
-      currentPackedField = currentPackedField * (1n << BigInt(size)) + field;
-    } else {
-      packedBits.push(currentPackedField);
-      currentSize = size;
-      currentPackedField = field;
-    }
-  }
-  packedBits.push(currentPackedField);
-  return fields.concat(packedBits);
-}
 /**
  * Random_oracle_input.Legacy.pack_to_fields, for the special case of a single bitstring
  */

--- a/src/provable/poseidon-bigint.ts
+++ b/src/provable/poseidon-bigint.ts
@@ -1,10 +1,10 @@
 import { Field, sizeInBits } from './field-bigint.js';
-import { bitsToBytes, prefixToField } from './binable.js';
+import { bitsToBytes } from './binable.js';
 import { Poseidon } from '../js_crypto/poseidon.js';
 import { prefixes } from '../js_crypto/constants.js';
 import { createHashInput } from './provable-generic.js';
 import { GenericHashInput } from './generic.js';
-import { createHashHelpers } from 'src/lib/hash-generic.js';
+import { createHashHelpers } from '../lib/hash-generic.js';
 
 export {
   Poseidon,

--- a/src/provable/transaction-leaves-bigint.ts
+++ b/src/provable/transaction-leaves-bigint.ts
@@ -1,7 +1,7 @@
 import { Field, Bool, UInt32, UInt64, Sign } from './field-bigint.js';
 import { PublicKey } from './curve-bigint.js';
 import { derivedLeafTypes } from './derived-leaves.js';
-import { createEvents, dataAsHash } from '../lib/events.js';
+import { createEvents } from '../lib/events.js';
 import { Poseidon } from './poseidon-bigint.js';
 
 export {
@@ -16,7 +16,13 @@ export {
   TokenId,
 };
 
-export { Events, SequenceEvents, StringWithHash, TokenSymbol, SequenceState };
+export {
+  Events,
+  SequenceEvents,
+  ZkappUri as StringWithHash,
+  TokenSymbol,
+  SequenceState,
+};
 
 type AuthRequired = {
   constant: Bool;
@@ -26,8 +32,9 @@ type AuthRequired = {
 type AuthorizationKind = { isSigned: Bool; isProved: Bool };
 type TokenId = Field;
 type TokenSymbol = { symbol: string; field: Field };
+type ZkappUri = { data: string; hash: Field };
 
-const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind } =
+const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind, ZkappUri } =
   derivedLeafTypes({ Field, Bool });
 
 // types which got an annotation about its circuit type in Ocaml
@@ -45,20 +52,3 @@ const SequenceState = {
   ...Field,
   emptyValue: SequenceEvents.emptySequenceState,
 };
-
-const StringWithHash = dataAsHash<string, string, Field>({
-  emptyValue() {
-    return {
-      data: '',
-      hash: 22930868938364086394602058221028773520482901241511717002947639863679740444066n,
-    };
-  },
-  toJSON(data: string) {
-    return data;
-  },
-  fromJSON(json: string) {
-    let data = json;
-    // TODO compute hash
-    throw Error('unimplemented');
-  },
-});

--- a/src/provable/transaction-leaves-bigint.ts
+++ b/src/provable/transaction-leaves-bigint.ts
@@ -2,7 +2,7 @@ import { Field, Bool, UInt32, UInt64, Sign } from './field-bigint.js';
 import { PublicKey } from './curve-bigint.js';
 import { derivedLeafTypes } from './derived-leaves.js';
 import { createEvents } from '../lib/events.js';
-import { Poseidon } from './poseidon-bigint.js';
+import { Poseidon, Hash } from './poseidon-bigint.js';
 
 export {
   PublicKey,
@@ -16,13 +16,7 @@ export {
   TokenId,
 };
 
-export {
-  Events,
-  SequenceEvents,
-  ZkappUri as StringWithHash,
-  TokenSymbol,
-  SequenceState,
-};
+export { Events, SequenceEvents, ZkappUri, TokenSymbol, SequenceState };
 
 type AuthRequired = {
   constant: Bool;
@@ -35,9 +29,7 @@ type TokenSymbol = { symbol: string; field: Field };
 type ZkappUri = { data: string; hash: Field };
 
 const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind, ZkappUri } =
-  derivedLeafTypes({ Field, Bool });
-
-// types which got an annotation about its circuit type in Ocaml
+  derivedLeafTypes({ Field, Bool, Hash });
 
 type Event = Field[];
 type Events = {

--- a/src/provable/transaction-leaves.ts
+++ b/src/provable/transaction-leaves.ts
@@ -3,7 +3,7 @@ import { UInt32, UInt64, Sign } from '../lib/int.js';
 import { PublicKey } from '../lib/signature.js';
 import { derivedLeafTypes } from './derived-leaves.js';
 import { createEvents } from '../lib/events.js';
-import { Poseidon } from '../lib/hash.js';
+import { Poseidon, Hash } from '../lib/hash.js';
 import { provable } from '../lib/circuit_value.js';
 
 export {
@@ -18,13 +18,7 @@ export {
   TokenId,
 };
 
-export {
-  Events,
-  SequenceEvents,
-  ZkappUri as StringWithHash,
-  TokenSymbol,
-  SequenceState,
-};
+export { Events, SequenceEvents, ZkappUri, TokenSymbol, SequenceState };
 
 type AuthRequired = {
   constant: Bool;
@@ -37,9 +31,7 @@ type TokenSymbol = { symbol: string; field: Field };
 type ZkappUri = { data: string; hash: Field };
 
 const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind, ZkappUri } =
-  derivedLeafTypes({ Field, Bool });
-
-// types which got an annotation about its circuit type in Ocaml
+  derivedLeafTypes({ Field, Bool, Hash });
 
 type Event = Field[];
 type Events = {

--- a/src/provable/transaction-leaves.ts
+++ b/src/provable/transaction-leaves.ts
@@ -2,7 +2,7 @@ import { Field, Bool } from '../lib/core.js';
 import { UInt32, UInt64, Sign } from '../lib/int.js';
 import { PublicKey } from '../lib/signature.js';
 import { derivedLeafTypes } from './derived-leaves.js';
-import { createEvents, dataAsHash } from '../lib/events.js';
+import { createEvents } from '../lib/events.js';
 import { Poseidon } from '../lib/hash.js';
 import { provable } from '../lib/circuit_value.js';
 
@@ -18,7 +18,13 @@ export {
   TokenId,
 };
 
-export { Events, SequenceEvents, StringWithHash, TokenSymbol, SequenceState };
+export {
+  Events,
+  SequenceEvents,
+  ZkappUri as StringWithHash,
+  TokenSymbol,
+  SequenceState,
+};
 
 type AuthRequired = {
   constant: Bool;
@@ -28,8 +34,9 @@ type AuthRequired = {
 type AuthorizationKind = { isSigned: Bool; isProved: Bool };
 type TokenId = Field;
 type TokenSymbol = { symbol: string; field: Field };
+type ZkappUri = { data: string; hash: Field };
 
-const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind } =
+const { TokenId, TokenSymbol, AuthRequired, AuthorizationKind, ZkappUri } =
   derivedLeafTypes({ Field, Bool });
 
 // types which got an annotation about its circuit type in Ocaml
@@ -47,22 +54,3 @@ const SequenceState = {
   ...provable(Field),
   emptyValue: SequenceEvents.emptySequenceState,
 };
-
-const StringWithHash = dataAsHash<string, string, Field>({
-  emptyValue() {
-    return {
-      data: '',
-      hash: Field(
-        '22930868938364086394602058221028773520482901241511717002947639863679740444066'
-      ),
-    };
-  },
-  toJSON(data: string) {
-    return data;
-  },
-  fromJSON(json: string) {
-    let data = json;
-    // TODO compute hash
-    throw Error('unimplemented');
-  },
-});


### PR DESCRIPTION
- closes #186
- adds new API for setting update fields, deprecates existing APIs -- see changelog
- implements hashing of the zkapp URI; some refactoring of hashing helpers (make them generic over Field) to make that work