### PR TITLE
profile times for integration tests

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           npm ci
           npm run build:node
+          touch profiling.md
           sh run-ci-tests.sh
           cat profiling.md >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -39,6 +39,7 @@ jobs:
           npm ci
           npm run build:node
           sh run-ci-tests.sh
+          cat profiling.md >> $GITHUB_STEP_SUMMARY
 
   Build-And-Test-Web:
     timeout-minutes: 90

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 o1labs*.tgz
 tests/report/
 tests/test-artifacts/
+profiling.md

--- a/run-ci-tests.sh
+++ b/run-ci-tests.sh
@@ -3,9 +3,9 @@ case $TEST_TYPE in
     "Simple integration tests" ) 
       echo "Running basic integration tests";
       ./run src/examples/zkapps/hello_world/run.ts --bundle || exit 1
-      ./run src/examples/simple_zkapp.ts || exit 1
-      ./run src/examples/zkapps/reducer/reducer_composite.ts || exit 1
-      ./run src/examples/zkapps/composability.ts || exit 1 ;; 
+      ./run src/examples/simple_zkapp.ts --bundle || exit 1
+      ./run src/examples/zkapps/reducer/reducer_composite.ts --bundle || exit 1
+      ./run src/examples/zkapps/composability.ts --bundle || exit 1 ;; 
 
     "Voting integration tests" )
       echo "Running voting integration tests";

--- a/src/examples/profiler.ts
+++ b/src/examples/profiler.ts
@@ -1,0 +1,43 @@
+import { time } from 'console';
+import fs from 'fs';
+
+export { getProfiler };
+
+function getProfiler(name: string) {
+  let times: Record<string, any> = {};
+  let label: string;
+
+  return {
+    get times() {
+      return times;
+    },
+    start(label_: string) {
+      label = label_;
+      times = {
+        ...times,
+        [label]: {
+          start: performance.now(),
+        },
+      };
+    },
+    stop() {
+      times[label].end = performance.now();
+    },
+    store() {
+      let profilingData = `## Times for ${name}\n\n`;
+      profilingData += `| Name | time passed in s |\n|---|---|`;
+      let totalTimePassed = 0;
+
+      Object.keys(times).forEach((k) => {
+        let timePassed = (times[k].end - times[k].start) / 1000;
+        totalTimePassed += timePassed;
+
+        profilingData += `\n|${k}|${timePassed}|`;
+      });
+
+      profilingData += `\n\nIn total, it took ${totalTimePassed} seconds to run the entire benchmark\n\n\n`;
+
+      fs.appendFileSync('profiling.md', profilingData);
+    },
+  };
+}

--- a/src/examples/profiler.ts
+++ b/src/examples/profiler.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 
 export { getProfiler };
 
+const round = (x: number) => Math.round(x * 100) / 100;
+
 function getProfiler(name: string) {
   let times: Record<string, any> = {};
   let label: string;
@@ -22,6 +24,7 @@ function getProfiler(name: string) {
     },
     stop() {
       times[label].end = performance.now();
+      return this;
     },
     store() {
       let profilingData = `## Times for ${name}\n\n`;
@@ -32,10 +35,12 @@ function getProfiler(name: string) {
         let timePassed = (times[k].end - times[k].start) / 1000;
         totalTimePassed += timePassed;
 
-        profilingData += `\n|${k}|${timePassed}|`;
+        profilingData += `\n|${k}|${round(timePassed)}|`;
       });
 
-      profilingData += `\n\nIn total, it took ${totalTimePassed} seconds to run the entire benchmark\n\n\n`;
+      profilingData += `\n\nIn total, it took ${round(
+        totalTimePassed
+      )} seconds to run the entire benchmark\n\n\n`;
 
       fs.appendFileSync('profiling.md', profilingData);
     },

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -14,6 +14,7 @@ import {
   Bool,
   PublicKey,
 } from 'snarkyjs';
+import { getProfiler } from './profiler.js';
 
 const doProofs = true;
 
@@ -75,6 +76,8 @@ class SimpleZkapp extends SmartContract {
   }
 }
 
+const SimpleProfiler = getProfiler('Simple zkApp');
+SimpleProfiler.start('Simple zkApp test flow');
 let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
 Mina.setActiveInstance(Local);
 
@@ -165,3 +168,5 @@ console.log(
     .get()
     .div(1e9)} MINA`
 );
+
+SimpleProfiler.stop().store();

--- a/src/examples/zkapps/composability.ts
+++ b/src/examples/zkapps/composability.ts
@@ -12,6 +12,7 @@ import {
   state,
   State,
 } from 'snarkyjs';
+import { getProfiler } from '../profiler.js';
 
 const doProofs = true;
 
@@ -49,6 +50,8 @@ class Caller extends SmartContract {
   }
 }
 
+const ComposabilityProfiler = getProfiler('Composability zkApp');
+ComposabilityProfiler.start('Composability test flow');
 // script to deploy zkapps and do interactions
 
 let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
@@ -106,3 +109,4 @@ await tx.send();
 
 // should hopefully be 12 since we added 5 + 6 + 1
 console.log('state: ' + zkapp.sum.get());
+ComposabilityProfiler.stop().store();

--- a/src/examples/zkapps/dex/happy-path-with-proofs.ts
+++ b/src/examples/zkapps/dex/happy-path-with-proofs.ts
@@ -2,8 +2,12 @@ import { isReady, Mina, AccountUpdate, UInt64 } from 'snarkyjs';
 import { createDex, TokenContract, addresses, keys } from './dex.js';
 import { expect } from 'expect';
 import { tic, toc } from '../tictoc.js';
+import { getProfiler } from '../../profiler.js';
 
 await isReady;
+
+const TokenProfiler = getProfiler('Token with Proofs');
+TokenProfiler.start('Token with proofs test flow');
 let doProofs = true;
 
 tic('Happy path with proofs');
@@ -119,3 +123,4 @@ expect(balances.user.X).toEqual(oldBalances.user.X - USER_DX);
 
 toc();
 console.log('dex happy path with proofs was successful! 🎉');
+TokenProfiler.stop().store();

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -10,6 +10,8 @@ import {
 import { createDex, TokenContract, addresses, keys, tokenIds } from './dex.js';
 import { expect } from 'expect';
 
+import { getProfiler } from '../../profiler.js';
+
 await isReady;
 let doProofs = false;
 
@@ -53,6 +55,10 @@ await main({ withVesting: true });
 console.log('all dex tests were successful! 🎉');
 
 async function main({ withVesting }: { withVesting: boolean }) {
+  const DexProfiler = getProfiler(
+    `DEX testing ${withVesting ? 'with vesting' : ''}`
+  );
+  DexProfiler.start('DEX test flow');
   if (withVesting) console.log('\nWITH VESTING');
   else console.log('\nNO VESTING');
 
@@ -410,7 +416,11 @@ async function main({ withVesting }: { withVesting: boolean }) {
     );
   }
   // tests below are not specific to vesting
-  if (withVesting) return;
+  if (withVesting) {
+    DexProfiler.stop();
+    DexProfiler.store();
+    return;
+  }
 
   /**
    * Happy path (tokens creation on receiver side in case of their absence)
@@ -524,6 +534,9 @@ async function main({ withVesting }: { withVesting: boolean }) {
   expect(balances.dex.X * balances.dex.Y).toBeGreaterThanOrEqual(
     oldBalances.dex.X * oldBalances.dex.Y
   );
+
+  DexProfiler.stop();
+  DexProfiler.store();
 }
 
 shutdown();

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -417,8 +417,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
   }
   // tests below are not specific to vesting
   if (withVesting) {
-    DexProfiler.stop();
-    DexProfiler.store();
+    DexProfiler.stop().store();
     return;
   }
 
@@ -535,8 +534,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     oldBalances.dex.X * oldBalances.dex.Y
   );
 
-  DexProfiler.stop();
-  DexProfiler.store();
+  DexProfiler.stop().store();
 }
 
 shutdown();

--- a/src/examples/zkapps/dex/upgradability.ts
+++ b/src/examples/zkapps/dex/upgradability.ts
@@ -12,6 +12,7 @@ import {
 } from 'snarkyjs';
 import { createDex, TokenContract, addresses, keys, tokenIds } from './dex.js';
 import { expect } from 'expect';
+import { getProfiler } from '../../profiler.js';
 
 let doProofs = false;
 
@@ -31,6 +32,8 @@ await atomicActionsTest({
 console.log('all atomic actions tests were successful!');
 
 async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
+  const DexProfiler = getProfiler('DEX profiler atomic actions');
+  DexProfiler.start('DEX test flow');
   let Local = Mina.LocalBlockchain({
     proofsEnabled: doProofs,
     enforceTransactionLimits: false,
@@ -233,9 +236,12 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
   await tx.sign([keys.dex]).send();
 
   Mina.getAccount(addresses.dex).delegate?.assertEquals(newDelegate);
+  DexProfiler.stop().store();
 }
 
 async function upgradeabilityTests({ withVesting }: { withVesting: boolean }) {
+  const DexProfiler = getProfiler('DEX profiler upgradeability tests');
+  DexProfiler.start('DEX test flow');
   let Local = Mina.LocalBlockchain({
     proofsEnabled: doProofs,
     enforceTransactionLimits: false,
@@ -453,4 +459,5 @@ async function upgradeabilityTests({ withVesting }: { withVesting: boolean }) {
   });
   await tx.prove();
   await tx.sign([keys.user]).send();
+  DexProfiler.stop().store();
 }

--- a/src/examples/zkapps/hello_world/run.ts
+++ b/src/examples/zkapps/hello_world/run.ts
@@ -1,5 +1,9 @@
 import { HelloWorld, adminPrivateKey } from './hello_world.js';
 import { Mina, PrivateKey, AccountUpdate, Field } from 'snarkyjs';
+import { getProfiler } from '../../profiler.js';
+
+const HelloWorldProfier = getProfiler('Hello World');
+HelloWorldProfier.start('Hello World test flow');
 
 let txn, txn2, txn3, txn4;
 // setup local ledger
@@ -200,3 +204,6 @@ function handleError(error: any, errorMessage: string) {
     throw Error(error);
   }
 }
+
+HelloWorldProfier.stop();
+HelloWorldProfier.store();

--- a/src/examples/zkapps/hello_world/run.ts
+++ b/src/examples/zkapps/hello_world/run.ts
@@ -205,5 +205,4 @@ function handleError(error: any, errorMessage: string) {
   }
 }
 
-HelloWorldProfier.stop();
-HelloWorldProfier.store();
+HelloWorldProfier.stop().store();

--- a/src/examples/zkapps/reducer/reducer_composite.ts
+++ b/src/examples/zkapps/reducer/reducer_composite.ts
@@ -15,6 +15,7 @@ import {
   Reducer,
 } from 'snarkyjs';
 import assert from 'node:assert/strict';
+import { getProfiler } from 'src/examples/profiler.js';
 
 await isReady;
 
@@ -71,6 +72,8 @@ class CounterZkapp extends SmartContract {
   }
 }
 
+const ReducerProfiler = getProfiler('Reducer zkApp');
+ReducerProfiler.start('Reducer zkApp test flow');
 const doProofs = true;
 const initialCounter = Field(0);
 
@@ -179,3 +182,4 @@ await tx.send();
 
 console.log('state after rollup: ' + zkapp.counter.get());
 assert.equal(zkapp.counter.get().toString(), '4');
+ReducerProfiler.stop().store();

--- a/src/examples/zkapps/reducer/reducer_composite.ts
+++ b/src/examples/zkapps/reducer/reducer_composite.ts
@@ -15,7 +15,7 @@ import {
   Reducer,
 } from 'snarkyjs';
 import assert from 'node:assert/strict';
-import { getProfiler } from 'src/examples/profiler.js';
+import { getProfiler } from '../../profiler.js';
 
 await isReady;
 

--- a/src/examples/zkapps/voting/run.ts
+++ b/src/examples/zkapps/voting/run.ts
@@ -1,11 +1,4 @@
-import {
-  Experimental,
-  Mina,
-  PrivateKey,
-  PublicKey,
-  UInt32,
-  UInt64,
-} from 'snarkyjs';
+import { PrivateKey, UInt32, UInt64 } from 'snarkyjs';
 import { VotingApp, VotingAppParams } from './factory.js';
 import {
   ElectionPreconditions,
@@ -15,6 +8,7 @@ import {
 import { OffchainStorage } from './off_chain_storage.js';
 import { Member } from './member.js';
 import { testSet } from './test.js';
+import { getProfiler } from '../../profiler.js';
 
 console.log('Running Voting script...');
 
@@ -56,6 +50,8 @@ console.log('Building contracts for set 1...');
 let contracts_set1 = await VotingApp(params_set1);
 
 console.log('Testing set 1...');
+const VotingProfiler = getProfiler('Voting profiler set 1');
+VotingProfiler.start('Voting test flow');
 await testSet(contracts_set1, params_set1, storage_set1);
-
+VotingProfiler.stop().store();
 // ..


### PR DESCRIPTION
- profiling for integration test times in CI 
	- adds the result to the summary page of each CI run, see https://github.com/o1-labs/snarkyjs/actions/runs/3677985581/attempts/1#summary-10042318738
	- right now, only the integration tests as a whole are being profiled, but if we want we can also profile each test case/transaction
	- can be extended if desired

closes https://github.com/o1-labs/snarkyjs/issues/604