### PR TITLE
Tweak send API with example & fix

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1377,6 +1377,7 @@ class AccountUpdate implements Types.AccountUpdate {
     } else {
       body.tokenId = short(body.tokenId!);
     }
+    if (body.callDepth === 0) delete body.callDepth;
     if (body.caller === TokenId.toBase58(TokenId.default)) {
       delete body.caller;
     } else {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -945,7 +945,7 @@ super.init();
   }
 
   send(args: {
-    to: PublicKey | AccountUpdate;
+    to: PublicKey | AccountUpdate | SmartContract;
     amount: number | bigint | UInt64;
   }) {
     return this.self.send(args);


### PR DESCRIPTION
This came out of writing docs for payments (#381)
* adapts the `AccountUpdate.send()` API so that the `to` field can also be a smart contract. (this saves us from creating an additional account update, if we pass in `this` for example)
* clean up the `simple_zkapp_payment.ts` example and ensure it covers all cases of payments and matches the docs, and works
* making the example work uncovered a subtle bug, which is fixed here: the nonce precondition _value_ has to be the default if we don't use a nonce precondition, because otherwise the hash created from the transaction (which only sees `null` for the precondition) won't match the hash computed in the prover