### PR TITLE
Mina-signer: Transaction hash

### DIFF
--- a/MINA_COMMIT
+++ b/MINA_COMMIT
@@ -1,2 +1,2 @@
 The mina commit used to generate the backends for node and chrome is
-abb49583365cd454b50bc2863743ad16e528ea80
+4a65ce4fc328fb47b6a62a43ddf1ba8a910860b4

--- a/run-ci-tests.sh
+++ b/run-ci-tests.sh
@@ -23,7 +23,7 @@ case $TEST_TYPE in
 
     "Unit tests" )
       echo "Running unit tests";
-      npm run test:unit
+      npm run test:unit || exit 1
       npm run test ;;
 
     * ) echo "ERROR: Invalid enviroment variable, not clear what tests to run! $CI_NODE_INDEX"; exit 1 ;;

--- a/src/build/extractJsooMethods.cjs
+++ b/src/build/extractJsooMethods.cjs
@@ -14,6 +14,7 @@ let classNames = [
   'Scalar',
   'Ledger',
   'Pickles',
+  'Test',
 ];
 
 (async () => {

--- a/src/js_crypto/constants.ts
+++ b/src/js_crypto/constants.ts
@@ -22,7 +22,8 @@ let versionBytes = {
   "publicKey": 203,
   "userCommandMemo": 20,
   "privateKey": 90,
-  "signature": 154
+  "signature": 154,
+  "transactionHash": 18
 };
 let poseidonParamsKimchiFp = {
   "mds": [

--- a/src/js_crypto/constants.ts
+++ b/src/js_crypto/constants.ts
@@ -23,7 +23,8 @@ let versionBytes = {
   "userCommandMemo": 20,
   "privateKey": 90,
   "signature": 154,
-  "transactionHash": 18
+  "transactionHash": 18,
+  "signedCommandV1": 19
 };
 let poseidonParamsKimchiFp = {
   "mds": [

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -21,7 +21,8 @@ const FieldBinable = defineBinable({
     return [...(t.toConstant() as any as InternalConstantField).value[1]];
   },
   fromBytesInternal(bytes, offset) {
-    let uint8array = Uint8Array.from(bytes.slice(offset, offset + 32));
+    let uint8array = new Uint8Array(32);
+    uint8array.set(bytes.slice(offset, offset + 32));
     return [
       Object.assign(Object.create(Field(1).constructor.prototype), {
         value: [0, uint8array],

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -20,7 +20,7 @@ const FieldBinable = defineBinable({
   toBytes(t: Field) {
     return [...(t.toConstant() as any as InternalConstantField).value[1]];
   },
-  fromBytesInternal(bytes, offset) {
+  readBytes(bytes, offset) {
     let uint8array = new Uint8Array(32);
     uint8array.set(bytes.slice(offset, offset + 32));
     return [
@@ -34,7 +34,7 @@ const FieldBinable = defineBinable({
 
 Field.toBytes = FieldBinable.toBytes;
 Field.fromBytes = FieldBinable.fromBytes;
-Field.fromBytesInternal = FieldBinable.fromBytesInternal;
+Field.readBytes = FieldBinable.readBytes;
 Field.sizeInBytes = () => 32;
 
 Bool.toInput = function (x) {
@@ -46,13 +46,13 @@ const BoolBinable = defineBinable({
   toBytes(b: Bool) {
     return [Number(b.toBoolean())];
   },
-  fromBytesInternal(bytes, offset) {
+  readBytes(bytes, offset) {
     return [Bool(!!bytes[offset]), offset + 1];
   },
 });
 Bool.toBytes = BoolBinable.toBytes;
 Bool.fromBytes = BoolBinable.fromBytes;
-Bool.fromBytesInternal = BoolBinable.fromBytesInternal;
+Bool.readBytes = BoolBinable.readBytes;
 Bool.sizeInBytes = () => 1;
 
 Scalar.toFieldsCompressed = function (s: Scalar) {

--- a/src/mina-signer/memo.ts
+++ b/src/mina-signer/memo.ts
@@ -1,4 +1,9 @@
-import { Binable, stringToBytes, withBits } from '../provable/binable.js';
+import {
+  Binable,
+  defineBinable,
+  stringToBytes,
+  withBits,
+} from '../provable/binable.js';
 import { base58 } from '../provable/base58.js';
 import {
   HashInputLegacy,
@@ -24,21 +29,24 @@ function hash(memo: string) {
   return hashWithPrefix(prefixes.zkappMemo, fields);
 }
 
-const Binable: Binable<string> = {
-  sizeInBytes() {
-    return 34;
-  },
+const SIZE = 34;
+const Binable: Binable<string> = defineBinable({
   toBytes(memo) {
     return stringToBytes(memo);
   },
-  fromBytes(bytes) {
-    return String.fromCharCode(...bytes);
+  fromBytesInternal(bytes, start) {
+    let end = start + SIZE;
+    let memo = String.fromCharCode(...bytes.slice(start, end));
+    return [memo, end];
   },
-};
+});
 
 const Memo = {
   fromString,
   hash,
-  ...withBits(Binable),
+  ...withBits(Binable, SIZE * 8),
   ...base58(Binable, versionBytes.userCommandMemo),
+  sizeInBytes() {
+    return SIZE;
+  },
 };

--- a/src/mina-signer/memo.ts
+++ b/src/mina-signer/memo.ts
@@ -34,7 +34,7 @@ const Binable: Binable<string> = defineBinable({
   toBytes(memo) {
     return stringToBytes(memo);
   },
-  fromBytesInternal(bytes, start) {
+  readBytes(bytes, start) {
     let end = start + SIZE;
     let memo = String.fromCharCode(...bytes.slice(start, end));
     return [memo, end];

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -256,7 +256,10 @@ type UserCommandEnum = {
 
 type BodyEnum =
   | { type: 'Payment'; value: Payment }
-  | { type: 'StakeDelegation'; value: Delegation };
+  | {
+      type: 'StakeDelegation';
+      value: { type: 'SetDelegate'; value: Delegation };
+    };
 
 type Common = {
   fee: UInt64;

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -13,6 +13,8 @@ export {
   verifyPayment,
   verifyStakeDelegation,
   verifyStringSignature,
+  paymentFromJson,
+  delegationFromJson,
   PaymentJson,
   DelegationJson,
   Tag,
@@ -21,6 +23,7 @@ export {
   BodyEnum,
   Payment,
   Delegation,
+  Common,
 };
 
 function signPayment(

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -17,6 +17,10 @@ export {
   DelegationJson,
   Tag,
   UserCommand,
+  UserCommandEnum,
+  BodyEnum,
+  Payment,
+  Delegation,
 };
 
 function signPayment(
@@ -221,19 +225,40 @@ function stringToInput(string: string) {
 type Tag = 'Payment' | 'StakeDelegation';
 
 type UserCommand = {
-  common: {
-    fee: UInt64;
-    feePayer: PublicKey;
-    nonce: UInt32;
-    validUntil: UInt32;
-    memo: string;
-  };
+  common: Common;
   body: {
     tag: Tag;
     source: PublicKey;
     receiver: PublicKey;
     amount: UInt64;
   };
+};
+
+type UserCommandEnum = {
+  common: Common;
+  body: BodyEnum;
+};
+
+type BodyEnum =
+  | { type: 'Payment'; value: Payment }
+  | { type: 'StakeDelegation'; value: Delegation };
+
+type Common = {
+  fee: UInt64;
+  feePayer: PublicKey;
+  nonce: UInt32;
+  validUntil: UInt32;
+  memo: string;
+};
+
+type Payment = {
+  source: PublicKey;
+  receiver: PublicKey;
+  amount: UInt64;
+};
+type Delegation = {
+  delegator: PublicKey;
+  newDelegate: PublicKey;
 };
 
 type CommonJson = {

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -16,7 +16,6 @@ export {
   paymentFromJson,
   delegationFromJson,
   commonFromJson,
-  amountFromJson,
   PaymentJson,
   DelegationJson,
   CommonJson,
@@ -185,21 +184,13 @@ function delegationFromJson({
 
 function commonFromJson(c: CommonJson) {
   return {
-    fee: amountFromJson(c.fee),
+    fee: UInt64.fromJSON(c.fee),
     feePayer: PublicKey.fromJSON(c.feePayer),
     nonce: UInt32.fromJSON(c.nonce),
     validUntil: UInt32.fromJSON(c.validUntil),
     // TODO: this might need to be fromBase58
     memo: Memo.fromString(c.memo),
   };
-}
-
-function amountFromJson(amount: string): UInt64 {
-  let a = BigInt(amount) * 1_000_000_000n;
-  if (a < 0n || a > UInt64.maxValue) {
-    throw Error('invalid token amount');
-  }
-  return a;
 }
 
 function signString(

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -15,6 +15,8 @@ export {
   verifyStringSignature,
   PaymentJson,
   DelegationJson,
+  Tag,
+  UserCommand,
 };
 
 function signPayment(

--- a/src/mina-signer/sign-legacy.ts
+++ b/src/mina-signer/sign-legacy.ts
@@ -15,8 +15,11 @@ export {
   verifyStringSignature,
   paymentFromJson,
   delegationFromJson,
+  commonFromJson,
+  amountFromJson,
   PaymentJson,
   DelegationJson,
+  CommonJson,
   Tag,
   UserCommand,
   UserCommandEnum,
@@ -182,12 +185,21 @@ function delegationFromJson({
 
 function commonFromJson(c: CommonJson) {
   return {
-    fee: UInt64.fromJSON(c.fee),
+    fee: amountFromJson(c.fee),
     feePayer: PublicKey.fromJSON(c.feePayer),
     nonce: UInt32.fromJSON(c.nonce),
     validUntil: UInt32.fromJSON(c.validUntil),
+    // TODO: this might need to be fromBase58
     memo: Memo.fromString(c.memo),
   };
+}
+
+function amountFromJson(amount: string): UInt64 {
+  let a = BigInt(amount) * 1_000_000_000n;
+  if (a < 0n || a > UInt64.maxValue) {
+    throw Error('invalid token amount');
+  }
+  return a;
 }
 
 function signString(

--- a/src/mina-signer/signature.ts
+++ b/src/mina-signer/signature.ts
@@ -21,7 +21,7 @@ import {
 import {
   bitsToBytes,
   bytesToBits,
-  tuple,
+  record,
   withVersionNumber,
 } from '../provable/binable.js';
 import { base58 } from '../provable/base58.js';
@@ -45,20 +45,10 @@ type NetworkId = 'mainnet' | 'testnet';
 type Signature = { r: Field; s: Scalar };
 
 const BinableSignature = withVersionNumber(
-  tuple([Field, Scalar]),
+  record({ r: Field, s: Scalar }, ['r', 's']),
   versionNumbers.signature
 );
-const BinableBase58 = base58(BinableSignature, versionBytes.signature);
-
-const Signature = {
-  toBase58({ r, s }: Signature) {
-    return BinableBase58.toBase58([r, s]);
-  },
-  fromBase58(signatureBase58: string): Signature {
-    let [r, s] = BinableBase58.fromBase58(signatureBase58);
-    return { r, s };
-  },
-};
+const Signature = base58(BinableSignature, versionBytes.signature);
 
 /**
  * Convenience wrapper around {@link sign} where the message is a single {@link Field} element

--- a/src/mina-signer/signature.ts
+++ b/src/mina-signer/signature.ts
@@ -48,7 +48,10 @@ const BinableSignature = withVersionNumber(
   record({ r: Field, s: Scalar }, ['r', 's']),
   versionNumbers.signature
 );
-const Signature = base58(BinableSignature, versionBytes.signature);
+const Signature = {
+  ...BinableSignature,
+  ...base58(BinableSignature, versionBytes.signature),
+};
 
 /**
  * Convenience wrapper around {@link sign} where the message is a single {@link Field} element

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -1,22 +1,16 @@
 import { Bool, Field, UInt32, UInt64 } from '../provable/field-bigint.js';
 import { Memo } from './memo.js';
-import { Binable, record } from '../provable/binable.js';
-import { Tag, UserCommand } from './sign-legacy.js';
+import { enumWithArgument, record } from '../provable/binable.js';
+import {
+  Delegation,
+  Payment,
+  UserCommand,
+  UserCommandEnum,
+} from './sign-legacy.js';
 
 // binable
 
 let BinablePublicKey = record({ x: Field, isOdd: Bool }, ['x', 'isOdd']);
-let BinableTag: Binable<Tag> = {
-  sizeInBytes() {
-    return 1;
-  },
-  toBytes(tag) {
-    return [{ Payment: 0, StakeDelegation: 1 }[tag]];
-  },
-  fromBytes([byte]) {
-    return (['Payment', 'StakeDelegation'] as Tag[])[byte];
-  },
-};
 
 const Common = record<UserCommand['common']>(
   {
@@ -28,16 +22,32 @@ const Common = record<UserCommand['common']>(
   },
   ['fee', 'feePayer', 'nonce', 'validUntil', 'memo']
 );
-const Body = record<UserCommand['body']>(
+const Payment = record<Payment>(
   {
-    tag: BinableTag,
     source: BinablePublicKey,
     receiver: BinablePublicKey,
     amount: UInt64,
   },
-  ['tag', 'source', 'receiver', 'amount']
+  ['source', 'receiver', 'amount']
 );
-const UserCommand = record<UserCommand>(
+const Delegation = record<Delegation>(
+  {
+    delegator: BinablePublicKey,
+    newDelegate: BinablePublicKey,
+  },
+  ['delegator', 'newDelegate']
+);
+const Body = enumWithArgument<
+  [
+    { type: 'Payment'; value: Payment },
+    { type: 'StakeDelegation'; value: Delegation }
+  ]
+>([
+  { type: 'Payment', value: Payment },
+  { type: 'StakeDelegation', value: Delegation },
+]);
+
+const UserCommand = record<UserCommandEnum>(
   {
     common: Common,
     body: Body,

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -29,8 +29,6 @@ import { versionBytes } from '../js_crypto/constants.js';
 export {
   hashPayment,
   hashStakeDelegation,
-  hashPaymentV1,
-  hashStakeDelegationV1,
   SignedCommand,
   SignedCommandV1,
   Common,
@@ -43,19 +41,24 @@ export {
 type Signed<T> = { data: T; signature: string };
 const dummySignature: Signature = { r: Field(1), s: Scalar(1) };
 
-function hashPayment({ data }: Signed<PaymentJson>) {
-  let payload = userCommandToEnum(paymentFromJson(data));
+function hashPayment(signed: Signed<PaymentJson>, { berkeley = false } = {}) {
+  if (!berkeley) return hashPaymentV1(signed);
+  let payload = userCommandToEnum(paymentFromJson(signed.data));
   return hashSignedCommand({
-    signer: PublicKey.fromBase58(data.body.source),
+    signer: PublicKey.fromBase58(signed.data.body.source),
     signature: dummySignature,
     payload,
   });
 }
 
-function hashStakeDelegation({ data }: Signed<DelegationJson>) {
-  let payload = userCommandToEnum(delegationFromJson(data));
+function hashStakeDelegation(
+  signed: Signed<DelegationJson>,
+  { berkeley = false } = {}
+) {
+  if (!berkeley) return hashStakeDelegationV1(signed);
+  let payload = userCommandToEnum(delegationFromJson(signed.data));
   return hashSignedCommand({
-    signer: PublicKey.fromBase58(data.body.delegator),
+    signer: PublicKey.fromBase58(signed.data.body.delegator),
     signature: dummySignature,
     payload,
   });

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -143,7 +143,7 @@ const HashBase58 = base58(
       toBytes(t: Uint8Array) {
         return [t.length, ...t];
       },
-      fromBytesInternal(bytes) {
+      readBytes(bytes) {
         return [Uint8Array.from(bytes.slice(1)), bytes.length];
       },
     }),

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -1,18 +1,73 @@
 import { Bool, Field, UInt32, UInt64 } from '../provable/field-bigint.js';
 import { Memo } from './memo.js';
-import { enumWithArgument, record } from '../provable/binable.js';
 import {
+  defineBinable,
+  enumWithArgument,
+  record,
+} from '../provable/binable.js';
+import {
+  Common,
   Delegation,
   Payment,
   UserCommand,
   UserCommandEnum,
+  PaymentJson,
+  DelegationJson,
+  delegationFromJson,
+  paymentFromJson,
 } from './sign-legacy.js';
+import { PublicKey } from '../provable/curve-bigint.js';
+import { Signature } from './signature.js';
+import { blake2b } from 'blakejs';
+import { base58 } from '../provable/base58.js';
+import { versionBytes } from '../js_crypto/constants.js';
+
+export { hashPayment, hashStakeDelegation };
+
+type Signed<T> = { data: T; signature: string };
+
+function hashPayment({ signature, data }: Signed<PaymentJson>) {
+  let payload = userCommandToEnum(paymentFromJson(data));
+  return hashSignedCommand({
+    signer: PublicKey.fromBase58(data.body.source),
+    signature: Signature.fromBase58(signature),
+    payload,
+  });
+}
+
+function hashStakeDelegation({ signature, data }: Signed<DelegationJson>) {
+  let payload = userCommandToEnum(delegationFromJson(data));
+  return hashSignedCommand({
+    signer: PublicKey.fromBase58(data.body.delegator),
+    signature: Signature.fromBase58(signature),
+    payload,
+  });
+}
+
+function hashSignedCommand(command: SignedCommand) {
+  let inputBytes = SignedCommand.toBytes(command);
+  let bytes = blake2b(Uint8Array.from(inputBytes), undefined, 32);
+  return Base58Hash.toBase58(bytes);
+}
+
+// helper
+
+function userCommandToEnum({ common, body }: UserCommand): UserCommandEnum {
+  let { tag: type, ...value } = body;
+  switch (type) {
+    case 'Payment':
+      return { common, body: { type, value } };
+    case 'StakeDelegation':
+      let { source: delegator, receiver: newDelegate } = value;
+      return { common, body: { type, value: { delegator, newDelegate } } };
+  }
+}
 
 // binable
 
 let BinablePublicKey = record({ x: Field, isOdd: Bool }, ['x', 'isOdd']);
 
-const Common = record<UserCommand['common']>(
+const Common = record<Common>(
   {
     fee: UInt64,
     feePayer: BinablePublicKey,
@@ -23,18 +78,11 @@ const Common = record<UserCommand['common']>(
   ['fee', 'feePayer', 'nonce', 'validUntil', 'memo']
 );
 const Payment = record<Payment>(
-  {
-    source: BinablePublicKey,
-    receiver: BinablePublicKey,
-    amount: UInt64,
-  },
+  { source: BinablePublicKey, receiver: BinablePublicKey, amount: UInt64 },
   ['source', 'receiver', 'amount']
 );
 const Delegation = record<Delegation>(
-  {
-    delegator: BinablePublicKey,
-    newDelegate: BinablePublicKey,
-  },
+  { delegator: BinablePublicKey, newDelegate: BinablePublicKey },
   ['delegator', 'newDelegate']
 );
 const Body = enumWithArgument<
@@ -47,10 +95,26 @@ const Body = enumWithArgument<
   { type: 'StakeDelegation', value: Delegation },
 ]);
 
-const UserCommand = record<UserCommandEnum>(
-  {
-    common: Common,
-    body: Body,
-  },
-  ['common', 'body']
+const UserCommand = record({ common: Common, body: Body }, ['common', 'body']);
+
+type SignedCommand = {
+  payload: UserCommandEnum;
+  signer: PublicKey;
+  signature: Signature;
+};
+const SignedCommand = record<SignedCommand>(
+  { payload: UserCommand, signer: BinablePublicKey, signature: Signature },
+  ['payload', 'signer', 'signature']
+);
+
+const Base58Hash = base58(
+  defineBinable<Uint8Array>({
+    toBytes(t: Uint8Array) {
+      return [...t];
+    },
+    fromBytesInternal(bytes, offset) {
+      return [Uint8Array.from(bytes), offset];
+    },
+  }),
+  versionBytes.transactionHash
 );

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -1,11 +1,11 @@
 import { Bool, Field, UInt32, UInt64 } from '../provable/field-bigint.js';
 import { Memo } from './memo.js';
-import { Binable, tuple } from '../provable/binable.js';
+import { Binable, record } from '../provable/binable.js';
 import { Tag, UserCommand } from './sign-legacy.js';
 
 // binable
 
-let BinablePublicKey = tuple([Field, Bool]);
+let BinablePublicKey = record({ x: Field, isOdd: Bool }, ['x', 'isOdd']);
 let BinableTag: Binable<Tag> = {
   sizeInBytes() {
     return 1;
@@ -17,33 +17,30 @@ let BinableTag: Binable<Tag> = {
     return (['Payment', 'StakeDelegation'] as Tag[])[byte];
   },
 };
-const BinableUserCommand_ = tuple([
-  UInt64, // fee
-  BinablePublicKey, // feePayer
-  UInt32, // nonce
-  UInt32, // validUntil
-  Memo, // memo
-  BinableTag, // tag
-  BinablePublicKey, // source
-  BinablePublicKey, // receiver
-  UInt64, // amount
-]);
 
-const UserCommand = {
-  toBytes({
-    common: { fee, feePayer, memo, nonce, validUntil },
-    body: { amount, receiver, source, tag },
-  }: UserCommand) {
-    return BinableUserCommand_.toBytes([
-      fee,
-      [feePayer.x, feePayer.isOdd],
-      nonce,
-      validUntil,
-      memo,
-      tag,
-      [source.x, source.isOdd],
-      [receiver.x, receiver.isOdd],
-      amount,
-    ]);
+const Common = record<UserCommand['common']>(
+  {
+    fee: UInt64,
+    feePayer: BinablePublicKey,
+    nonce: UInt32,
+    validUntil: UInt32,
+    memo: Memo,
   },
-};
+  ['fee', 'feePayer', 'nonce', 'validUntil', 'memo']
+);
+const Body = record<UserCommand['body']>(
+  {
+    tag: BinableTag,
+    source: BinablePublicKey,
+    receiver: BinablePublicKey,
+    amount: UInt64,
+  },
+  ['tag', 'source', 'receiver', 'amount']
+);
+const UserCommand = record<UserCommand>(
+  {
+    common: Common,
+    body: Body,
+  },
+  ['common', 'body']
+);

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -67,7 +67,13 @@ function userCommandToEnum({ common, body }: UserCommand): UserCommandEnum {
       return { common, body: { type, value } };
     case 'StakeDelegation':
       let { source: delegator, receiver: newDelegate } = value;
-      return { common, body: { type, value: { delegator, newDelegate } } };
+      return {
+        common,
+        body: {
+          type,
+          value: { type: 'SetDelegate', value: { delegator, newDelegate } },
+        },
+      };
   }
 }
 
@@ -97,14 +103,19 @@ const Delegation = record<Delegation>(
   { delegator: BinablePublicKey, newDelegate: BinablePublicKey },
   ['delegator', 'newDelegate']
 );
+type DelegationEnum = { type: 'SetDelegate'; value: Delegation };
+const DelegationEnum = enumWithArgument<[DelegationEnum]>([
+  { type: 'SetDelegate', value: Delegation },
+]);
+
 const Body = enumWithArgument<
   [
     { type: 'Payment'; value: Payment },
-    { type: 'StakeDelegation'; value: Delegation }
+    { type: 'StakeDelegation'; value: DelegationEnum }
   ]
 >([
   { type: 'Payment', value: Payment },
-  { type: 'StakeDelegation', value: Delegation },
+  { type: 'StakeDelegation', value: DelegationEnum },
 ]);
 
 const UserCommand = record({ common: Common, body: Body }, ['common', 'body']);

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -1,0 +1,49 @@
+import { Bool, Field, UInt32, UInt64 } from '../provable/field-bigint.js';
+import { Memo } from './memo.js';
+import { Binable, tuple } from '../provable/binable.js';
+import { Tag, UserCommand } from './sign-legacy.js';
+
+// binable
+
+let BinablePublicKey = tuple([Field, Bool]);
+let BinableTag: Binable<Tag> = {
+  sizeInBytes() {
+    return 1;
+  },
+  toBytes(tag) {
+    return [{ Payment: 0, StakeDelegation: 1 }[tag]];
+  },
+  fromBytes([byte]) {
+    return (['Payment', 'StakeDelegation'] as Tag[])[byte];
+  },
+};
+const BinableUserCommand_ = tuple([
+  UInt64, // fee
+  BinablePublicKey, // feePayer
+  UInt32, // nonce
+  UInt32, // validUntil
+  Memo, // memo
+  BinableTag, // tag
+  BinablePublicKey, // source
+  BinablePublicKey, // receiver
+  UInt64, // amount
+]);
+
+const UserCommand = {
+  toBytes({
+    common: { fee, feePayer, memo, nonce, validUntil },
+    body: { amount, receiver, source, tag },
+  }: UserCommand) {
+    return BinableUserCommand_.toBytes([
+      fee,
+      [feePayer.x, feePayer.isOdd],
+      nonce,
+      validUntil,
+      memo,
+      tag,
+      [source.x, source.isOdd],
+      [receiver.x, receiver.isOdd],
+      amount,
+    ]);
+  },
+};

--- a/src/mina-signer/transaction-hash.ts
+++ b/src/mina-signer/transaction-hash.ts
@@ -1,6 +1,7 @@
-import { Bool, Field, UInt32, UInt64 } from '../provable/field-bigint.js';
-import { Memo } from './memo.js';
+import { Bool, Field } from '../provable/field-bigint.js';
 import {
+  BinableBigintInteger,
+  BinableString,
   defineBinable,
   enumWithArgument,
   record,
@@ -16,13 +17,20 @@ import {
   delegationFromJson,
   paymentFromJson,
 } from './sign-legacy.js';
-import { PublicKey } from '../provable/curve-bigint.js';
+import { PublicKey, Scalar } from '../provable/curve-bigint.js';
 import { Signature } from './signature.js';
 import { blake2b } from 'blakejs';
 import { base58 } from '../provable/base58.js';
 import { versionBytes } from '../js_crypto/constants.js';
 
-export { hashPayment, hashStakeDelegation };
+export {
+  hashPayment,
+  hashStakeDelegation,
+  SignedCommand,
+  Common,
+  userCommandToEnum,
+  Signed,
+};
 
 type Signed<T> = { data: T; signature: string };
 
@@ -69,16 +77,20 @@ let BinablePublicKey = record({ x: Field, isOdd: Bool }, ['x', 'isOdd']);
 
 const Common = record<Common>(
   {
-    fee: UInt64,
+    fee: BinableBigintInteger,
     feePayer: BinablePublicKey,
-    nonce: UInt32,
-    validUntil: UInt32,
-    memo: Memo,
+    nonce: BinableBigintInteger,
+    validUntil: BinableBigintInteger,
+    memo: BinableString,
   },
   ['fee', 'feePayer', 'nonce', 'validUntil', 'memo']
 );
 const Payment = record<Payment>(
-  { source: BinablePublicKey, receiver: BinablePublicKey, amount: UInt64 },
+  {
+    source: BinablePublicKey,
+    receiver: BinablePublicKey,
+    amount: BinableBigintInteger,
+  },
   ['source', 'receiver', 'amount']
 );
 const Delegation = record<Delegation>(
@@ -96,6 +108,7 @@ const Body = enumWithArgument<
 ]);
 
 const UserCommand = record({ common: Common, body: Body }, ['common', 'body']);
+const BinableSignature = record({ r: Field, s: Scalar }, ['r', 's']);
 
 type SignedCommand = {
   payload: UserCommandEnum;
@@ -103,7 +116,11 @@ type SignedCommand = {
   signature: Signature;
 };
 const SignedCommand = record<SignedCommand>(
-  { payload: UserCommand, signer: BinablePublicKey, signature: Signature },
+  {
+    payload: UserCommand,
+    signer: BinablePublicKey,
+    signature: BinableSignature,
+  },
   ['payload', 'signer', 'signature']
 );
 

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -2,6 +2,7 @@ import { shutdown, Test } from '../snarky.js';
 import {
   Common,
   hashPayment,
+  hashStakeDelegation,
   Signed,
   SignedCommand,
   userCommandToEnum,
@@ -73,9 +74,8 @@ let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
 let digest1 = hashPayment(payment);
 expect(digest1).toEqual(digest0);
 
-result = Test.transactionHash.serializePayment(
-  JSON.stringify(delegationToOcaml(delegation))
-);
+let ocamlDelegation = JSON.stringify(delegationToOcaml(delegation));
+result = Test.transactionHash.serializePayment(ocamlDelegation);
 let delegationBytes0 = [...result.data];
 payload = userCommandToEnum(delegationFromJson(delegation.data));
 command = {
@@ -87,6 +87,10 @@ let delegationBytes1 = SignedCommand.toBytes(command);
 expect(JSON.stringify(delegationBytes1)).toEqual(
   JSON.stringify(delegationBytes0)
 );
+
+digest0 = Test.transactionHash.hashPayment(ocamlDelegation);
+digest1 = hashStakeDelegation(delegation);
+expect(digest1).toEqual(digest0);
 
 shutdown();
 

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -50,6 +50,7 @@ let delegation: Signed<DelegationJson> = {
     '7mWyu5cpHDvYj28RGuJKzBQkU35KgHwaM34oPxoxXbFddv1kpL3e6NdUsMZMhyrrgkgVYo5cNvfiXhtshF35ZqTmSdPcUToN',
 };
 
+// common serialization
 let result = Test.transactionHash.serializeCommon(
   JSON.stringify(commonToOcaml(payment.data.common))
 );
@@ -58,6 +59,7 @@ let common = commonFromJson(payment.data.common);
 let bytes1 = Common.toBytes(common);
 expect(JSON.stringify(bytes1)).toEqual(JSON.stringify(bytes0));
 
+// payment serialization
 let ocamlPayment = JSON.stringify(paymentToOcaml(payment));
 result = Test.transactionHash.serializePayment(ocamlPayment);
 let paymentBytes0 = [...result.data];
@@ -70,10 +72,16 @@ let command = {
 let paymentBytes1 = SignedCommand.toBytes(command);
 expect(JSON.stringify(paymentBytes1)).toEqual(JSON.stringify(paymentBytes0));
 
+// payment roundtrip
+let commandRecovered = SignedCommand.fromBytes(paymentBytes1);
+expect(commandRecovered).toEqual(command);
+
+// payment hash
 let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
 let digest1 = hashPayment(payment);
 expect(digest1).toEqual(digest0);
 
+// delegation serialization
 let ocamlDelegation = JSON.stringify(delegationToOcaml(delegation));
 result = Test.transactionHash.serializePayment(ocamlDelegation);
 let delegationBytes0 = [...result.data];
@@ -88,6 +96,12 @@ expect(JSON.stringify(delegationBytes1)).toEqual(
   JSON.stringify(delegationBytes0)
 );
 
+// delegation roundtrip
+commandRecovered = SignedCommand.fromBytes(delegationBytes1);
+console.log(commandRecovered);
+expect(commandRecovered).toEqual(command);
+
+// delegation hash
 digest0 = Test.transactionHash.hashPayment(ocamlDelegation);
 digest1 = hashStakeDelegation(delegation);
 expect(digest1).toEqual(digest0);

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -27,7 +27,7 @@ import { stringToBytes } from '../provable/binable.js';
 let payment: Signed<PaymentJson> = {
   data: {
     common: {
-      fee: '8',
+      fee: '8000000000',
       feePayer: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
       nonce: '600',
       validUntil: '107',
@@ -231,7 +231,13 @@ function delegationToOcamlV1({
 
 function commonToOcaml({ fee, feePayer, nonce, validUntil, memo }: CommonJson) {
   memo = Memo.toBase58(Memo.fromString(memo));
-  return { fee, fee_payer_pk: feePayer, nonce, valid_until: validUntil, memo };
+  return {
+    fee: (BigInt(fee) / 1_000_000_000n).toString(),
+    fee_payer_pk: feePayer,
+    nonce,
+    valid_until: validUntil,
+    memo,
+  };
 }
 function commonToOcamlV1({
   fee,

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -232,7 +232,7 @@ function delegationToOcamlV1({
 function commonToOcaml({ fee, feePayer, nonce, validUntil, memo }: CommonJson) {
   memo = Memo.toBase58(Memo.fromString(memo));
   return {
-    fee: (BigInt(fee) / 1_000_000_000n).toString(),
+    fee: fee.slice(0, -9),
     fee_payer_pk: feePayer,
     nonce,
     valid_until: validUntil,
@@ -248,7 +248,7 @@ function commonToOcamlV1({
 }: CommonJson) {
   memo = Memo.toBase58(Memo.fromString(memo));
   return {
-    fee,
+    fee: fee.slice(0, -9),
     fee_payer_pk: feePayer,
     nonce,
     valid_until: validUntil,

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -2,9 +2,7 @@ import { Ledger, shutdown, Test } from '../snarky.js';
 import {
   Common,
   hashPayment,
-  hashPaymentV1,
   hashStakeDelegation,
-  hashStakeDelegationV1,
   Signed,
   SignedCommand,
   SignedCommandV1,
@@ -85,7 +83,7 @@ expect(commandRecovered).toEqual(command);
 
 // payment hash
 let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
-let digest1 = hashPayment(payment);
+let digest1 = hashPayment(payment, { berkeley: true });
 expect(digest1).toEqual(digest0);
 
 // delegation serialization
@@ -109,7 +107,7 @@ expect(commandRecovered).toEqual(command);
 
 // delegation hash
 digest0 = Test.transactionHash.hashPayment(ocamlDelegation);
-digest1 = hashStakeDelegation(delegation);
+digest1 = hashStakeDelegation(delegation, { berkeley: true });
 expect(digest1).toEqual(digest0);
 
 // payment v1 serialization
@@ -129,7 +127,7 @@ expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
 
 // payment v1 hash
 digest0 = Test.transactionHash.hashPaymentV1(ocamlPaymentV1);
-digest1 = hashPaymentV1(payment);
+digest1 = hashPayment(payment);
 expect(digest1).toEqual(digest0);
 
 // delegation v1 serialization
@@ -149,7 +147,7 @@ expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
 
 // delegation v1 hash
 digest0 = Test.transactionHash.hashPaymentV1(ocamlDelegationV1);
-digest1 = hashStakeDelegationV1(delegation);
+digest1 = hashStakeDelegation(delegation);
 expect(digest1).toEqual(digest0);
 
 shutdown();

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -1,0 +1,94 @@
+import { Test } from '../snarky.js';
+import {
+  Common,
+  Signed,
+  SignedCommand,
+  userCommandToEnum,
+} from './transaction-hash.js';
+import { PaymentJson, commonFromJson, paymentFromJson } from './sign-legacy.js';
+import { Signature } from './signature.js';
+import { PublicKey } from '../provable/curve-bigint.js';
+import { Memo } from './memo.js';
+import { expect } from 'expect';
+
+let payment: Signed<PaymentJson> = {
+  data: {
+    common: {
+      fee: '8',
+      feePayer: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+      nonce: '600',
+      validUntil: '107',
+      memo: 'blub',
+    },
+    body: {
+      source: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+      receiver: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+      amount: '99',
+    },
+  },
+  signature:
+    '7mWyu5cpHDvYj28RGuJKzBQkU35KgHwaM34oPxoxXbFddv1kpL3e6NdUsMZMhyrrgkgVYo5cNvfiXhtshF35ZqTmSdPcUToN',
+};
+
+let paymentOcaml = {
+  payload: {
+    common: {
+      fee: '8',
+      fee_payer_pk: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+      nonce: '600',
+      valid_until: '107',
+      memo: Memo.toBase58(Memo.fromString('blub')),
+    },
+    body: [
+      'Payment',
+      {
+        source_pk: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+        receiver_pk: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+        amount: '99',
+      },
+    ],
+  },
+  signer: 'B62qs2FVpaWkoNdEUgmSmUF8etXJWTnELboJK8MjLfeiSxP9MY7qjZr',
+  signature:
+    '7mWyu5cpHDvYj28RGuJKzBQkU35KgHwaM34oPxoxXbFddv1kpL3e6NdUsMZMhyrrgkgVYo5cNvfiXhtshF35ZqTmSdPcUToN',
+};
+
+console.log('--- comparing payment.common ---');
+
+let result = Test.transactionHash.serializeCommon(
+  JSON.stringify(paymentOcaml.payload.common)
+);
+let bytes0 = [...result.data];
+console.log();
+console.log(JSON.stringify(bytes0));
+console.log();
+
+let common = commonFromJson(payment.data.common);
+let bytes1 = Common.toBytes(common);
+console.log(JSON.stringify(bytes1));
+console.log();
+
+console.log('equal?', JSON.stringify(bytes0) === JSON.stringify(bytes1));
+
+console.log('--- comparing payment ---');
+
+result = Test.transactionHash.serializePayment(JSON.stringify(paymentOcaml));
+let commandBytes0 = [...result.data];
+console.log();
+console.log(JSON.stringify(commandBytes0));
+console.log();
+
+let payload = userCommandToEnum(paymentFromJson(payment.data));
+let command = {
+  signer: PublicKey.fromBase58(payment.data.body.source),
+  signature: Signature.fromBase58(payment.signature),
+  payload,
+};
+let commandBytes1 = SignedCommand.toBytes(command);
+console.log(JSON.stringify(commandBytes1));
+
+console.log(
+  'equal?',
+  JSON.stringify(commandBytes0) === JSON.stringify(commandBytes1)
+);
+expect(JSON.stringify(commandBytes1)).toEqual(JSON.stringify(commandBytes0));

--- a/src/mina-signer/transaction-hash.unit-test.ts
+++ b/src/mina-signer/transaction-hash.unit-test.ts
@@ -1,6 +1,7 @@
 import { shutdown, Test } from '../snarky.js';
 import {
   Common,
+  hashPayment,
   Signed,
   SignedCommand,
   userCommandToEnum,
@@ -56,9 +57,8 @@ let common = commonFromJson(payment.data.common);
 let bytes1 = Common.toBytes(common);
 expect(JSON.stringify(bytes1)).toEqual(JSON.stringify(bytes0));
 
-result = Test.transactionHash.serializePayment(
-  JSON.stringify(paymentToOcaml(payment))
-);
+let ocamlPayment = JSON.stringify(paymentToOcaml(payment));
+result = Test.transactionHash.serializePayment(ocamlPayment);
 let paymentBytes0 = [...result.data];
 let payload = userCommandToEnum(paymentFromJson(payment.data));
 let command = {
@@ -68,6 +68,10 @@ let command = {
 };
 let paymentBytes1 = SignedCommand.toBytes(command);
 expect(JSON.stringify(paymentBytes1)).toEqual(JSON.stringify(paymentBytes0));
+
+let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
+let digest1 = hashPayment(payment);
+expect(digest1).toEqual(digest0);
 
 result = Test.transactionHash.serializePayment(
   JSON.stringify(delegationToOcaml(delegation))

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -2,7 +2,7 @@ import { versionBytes } from '../js_crypto/constants.js';
 import { Ledger } from '../snarky.js';
 import { Binable, stringToBytes, withVersionNumber } from './binable.js';
 
-export { base58, fieldEncodings, Base58 };
+export { base58, withBase58, fieldEncodings, Base58 };
 
 type Base58<T> = {
   toBase58(t: T): string;
@@ -26,6 +26,13 @@ function base58<T>(binable: Binable<T>, versionByte: number): Base58<T> {
       return binable.fromBytes(bytes);
     },
   };
+}
+
+function withBase58<T>(
+  binable: Binable<T>,
+  versionByte: number
+): Binable<T> & Base58<T> {
+  return { ...binable, ...base58(binable, versionByte) };
 }
 
 // encoding of fields as base58, compatible with ocaml encodings (provided the versionByte and versionNumber are the same)

--- a/src/provable/binable.ts
+++ b/src/provable/binable.ts
@@ -3,6 +3,7 @@ import { GenericField } from './generic.js';
 
 export {
   Binable,
+  defineBinable,
   withVersionNumber,
   tuple,
   record,
@@ -27,8 +28,8 @@ type Binable<T> = {
 type BinableWithBits<T> = Binable<T> & {
   toBits(t: T): boolean[];
   fromBits(bits: boolean[]): T;
-  sizeInBytes: number;
-  sizeInBits: number;
+  sizeInBytes(): number;
+  sizeInBits(): number;
 };
 
 function defineBinable<T>({
@@ -229,8 +230,12 @@ function withBits<T>(
     fromBits(bits: boolean[]) {
       return binable.fromBytes(bitsToBytes(bits));
     },
-    sizeInBytes: Math.ceil(sizeInBits / 8),
-    sizeInBits,
+    sizeInBytes() {
+      return Math.ceil(sizeInBits / 8);
+    },
+    sizeInBits() {
+      return sizeInBits;
+    },
   };
 }
 

--- a/src/provable/curve-bigint.ts
+++ b/src/provable/curve-bigint.ts
@@ -2,7 +2,7 @@ import { Fq } from '../js_crypto/finite_field.js';
 import { GroupProjective, Pallas } from '../js_crypto/elliptic_curve.js';
 import { versionBytes } from '../js_crypto/constants.js';
 import { record, withCheck, withVersionNumber } from './binable.js';
-import { base58 } from './base58.js';
+import { base58, withBase58 } from './base58.js';
 import {
   BinableBigint,
   Bool,
@@ -75,7 +75,7 @@ let BinablePublicKey = withVersionNumber(
  */
 const PublicKey = {
   ...provable({ x: Field, isOdd: Bool }),
-  ...base58(BinablePublicKey, versionBytes.publicKey),
+  ...withBase58(BinablePublicKey, versionBytes.publicKey),
 
   toJSON(publicKey: PublicKey) {
     return PublicKey.toBase58(publicKey);

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -191,7 +191,7 @@ function BinableBigint<T extends bigint = bigint>(
       toBytes(x) {
         return bigIntToBytes(x, sizeInBytes);
       },
-      fromBytesInternal(bytes, start) {
+      readBytes(bytes, start) {
         let x = 0n;
         let bitPosition = 0n;
         let end = Math.min(start + sizeInBytes, bytes.length);

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -1,5 +1,5 @@
 import { Fp, mod } from '../js_crypto/finite_field.js';
-import { BinableWithBits, withBits } from './binable.js';
+import { BinableWithBits, defineBinable, withBits } from './binable.js';
 import { GenericHashInput, GenericProvableExtended } from './generic.js';
 
 export { Field, Bool, UInt32, UInt64, Sign };
@@ -187,24 +187,22 @@ function BinableBigint<T extends bigint = bigint>(
 ): BinableWithBits<T> {
   let sizeInBytes = Math.ceil(sizeInBits / 8);
   return withBits(
-    {
+    defineBinable({
       toBytes(x) {
         return bigIntToBytes(x, sizeInBytes);
       },
-      fromBytes(bytes) {
-        if (bytes.length > sizeInBytes) {
-          throw Error(
-            `fromBytes: input bytes too long, max length is ${sizeInBytes}, got ${bytes.length}`
-          );
+      fromBytesInternal(bytes, start) {
+        let x = 0n;
+        let bitPosition = 0n;
+        let end = start + sizeInBytes;
+        for (let i = start; i < end; i++) {
+          x += BigInt(bytes[i]) << bitPosition;
+          bitPosition += 8n;
         }
-        let x = bytesToBigInt(bytes) as T;
         check(x);
-        return x;
+        return [x as T, end];
       },
-      sizeInBytes() {
-        return sizeInBytes;
-      },
-    },
+    }),
     sizeInBits
   );
 }

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -194,7 +194,7 @@ function BinableBigint<T extends bigint = bigint>(
       fromBytesInternal(bytes, start) {
         let x = 0n;
         let bitPosition = 0n;
-        let end = start + sizeInBytes;
+        let end = Math.min(start + sizeInBytes, bytes.length);
         for (let i = start; i < end; i++) {
           x += BigInt(bytes[i]) << bitPosition;
           bitPosition += 8n;

--- a/src/provable/generic.ts
+++ b/src/provable/generic.ts
@@ -35,10 +35,10 @@ type GenericProvableExtended<T, TJson, Field> = GenericProvable<T, Field> & {
 
 type GenericField<Field> = ((value: number | string | bigint) => Field) &
   GenericProvableExtended<Field, string, Field> &
-  Binable<Field>;
+  Binable<Field> & { sizeInBytes(): number };
 type GenericBool<Field, Bool = unknown> = ((value: boolean) => Bool) &
   GenericProvableExtended<Bool, boolean, Field> &
-  Binable<Bool>;
+  Binable<Bool> & { sizeInBytes(): number };
 
 type GenericHashInput<Field> = { fields?: Field[]; packed?: [Field, number][] };
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1225,6 +1225,7 @@ declare const Test: {
     examplePayment(): string;
     serializePayment(payment: string): { data: Uint8Array };
     serializeCommon(common: string): { data: Uint8Array };
+    hashPayment(payment: string): string;
   };
 };
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1224,8 +1224,10 @@ declare const Test: {
   transactionHash: {
     examplePayment(): string;
     serializePayment(payment: string): { data: Uint8Array };
+    serializePaymentV1(payment: string): string;
     serializeCommon(common: string): { data: Uint8Array };
     hashPayment(payment: string): string;
+    hashPaymentV1(payment: string): string;
   };
 };
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -419,6 +419,10 @@ declare class Field {
   static toInput(x: Field): { fields: Field[] };
   static toBytes(x: Field): number[];
   static fromBytes(bytes: number[]): Field;
+  static fromBytesInternal(
+    bytes: number[],
+    offset: number
+  ): [value: Field, offset: number];
   static sizeInBytes(): number;
 }
 
@@ -601,6 +605,10 @@ declare class Bool {
   static toInput(x: Bool): { packed: [Field, number][] };
   static toBytes(x: Bool): number[];
   static fromBytes(bytes: number[]): Bool;
+  static fromBytesInternal(
+    bytes: number[],
+    offset: number
+  ): [value: Bool, offset: number];
   static sizeInBytes(): number;
 }
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -23,6 +23,9 @@ export {
   Gate,
 };
 
+// internal
+export { Test };
+
 /**
  * `Provable<T>` is the general circuit type interface. It describes how a type `T` is made up of field elements and auxiliary (non-field element) data.
  *
@@ -1216,6 +1219,14 @@ declare class Ledger {
     >;
   };
 }
+
+declare const Test: {
+  transactionHash: {
+    examplePayment(): string;
+    serializePayment(payment: string): { data: Uint8Array };
+    serializeCommon(common: string): { data: Uint8Array };
+  };
+};
 
 /**
  * js_of_ocaml representation of a byte array,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -422,7 +422,7 @@ declare class Field {
   static toInput(x: Field): { fields: Field[] };
   static toBytes(x: Field): number[];
   static fromBytes(bytes: number[]): Field;
-  static fromBytesInternal(
+  static readBytes(
     bytes: number[],
     offset: number
   ): [value: Field, offset: number];
@@ -608,7 +608,7 @@ declare class Bool {
   static toInput(x: Bool): { packed: [Field, number][] };
   static toBytes(x: Bool): number[];
   static fromBytes(bytes: number[]): Bool;
-  static fromBytesInternal(
+  static readBytes(
     bytes: number[],
     offset: number
   ): [value: Bool, offset: number];

--- a/src/snarky.js
+++ b/src/snarky.js
@@ -13,10 +13,11 @@ export {
   shutdown,
   isReady,
   Pickles,
+  Test,
 };
 let isReadyBoolean = false;
 let isReady = snarky_ready.then(() => (isReadyBoolean = true));
 let isItReady = () => isReadyBoolean;
 
-let { Field, Bool, Circuit, Poseidon, Group, Scalar, Ledger, Pickles } =
+let { Field, Bool, Circuit, Poseidon, Group, Scalar, Ledger, Pickles, Test } =
   proxyClasses(getSnarky, isItReady, snarkySpec);

--- a/src/snarky/snarky-class-spec.js
+++ b/src/snarky/snarky-class-spec.js
@@ -513,4 +513,13 @@ export default [
       },
     ],
   },
+  {
+    name: 'Test',
+    props: [
+      {
+        name: 'transactionHash',
+        type: 'object',
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
closes #667

This PR adds three things:
* A file `transaction-hash.ts` which implements `hashPayment` and `hashStakeDelegeation`. Both functions use the old "mainnet" behaviour of hashing by default, but can be made to use berkeley-style hashing with the optional `{ berkeley: true }` argument. Therefore, this PR removes the need to publish a separate version of `mina-signer` for mainnet compatibility until the hardfork.
  * Transaction hashing is conceptually simple: First, the input is serialized into an array of bytes using `bin_prot` logic. Second, the array of bytes is fed to the blake2b hash function, and the result is base58check'd. The devil lies in the details of the `bin_prot` serialization.
* A new set of unit tests which check all kinds of transaction hashing, plus sub-algorithms like the `bin_prot` serialization, against newly exposed OCaml versions.
* Implementations of some `bin_prot` primitives like serialization of integers, strings and records. Also, `Binable` is refactored somewhat because its previous implementation relied on statically known sizes of types, which is not available in general (for example, strings should be (de)serializable without statically knowing their size). The new formulation instead introduces a `readBytes` function that has to be implemented by every type of binable, which not only deserializes the type from a given array of bytes at a given offset, but also returns the new offset, so that higher-level binables know where to continue.