### PR TITLE
Mina-signer: Implement base58 in JS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@types/crypto-js": "^4.1.1",
         "blakejs": "1.2.1",
+        "crypto-js": "^4.1.1",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
         "reflect-metadata": "^0.1.13",
@@ -1582,6 +1584,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -2398,6 +2405,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -8878,6 +8890,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -9476,6 +9493,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "debug": {
       "version": "4.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@types/crypto-js": "^4.1.1",
         "blakejs": "1.2.1",
-        "crypto-js": "^4.1.1",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
+        "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
         "tslib": "^2.3.0"
       },
@@ -2405,11 +2405,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -6120,6 +6115,11 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9494,11 +9494,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
-    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -12224,6 +12219,11 @@
           }
         }
       }
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/crypto-js": "^4.1.1",
         "blakejs": "1.2.1",
         "env": "^0.0.2",
         "isomorphic-fetch": "^3.0.0",
@@ -1583,11 +1582,6 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "node_modules/@types/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -8889,11 +8883,6 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "@types/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
-    "@types/crypto-js": "^4.1.1",
     "blakejs": "1.2.1",
     "env": "^0.0.2",
     "isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   "dependencies": {
     "@types/crypto-js": "^4.1.1",
     "blakejs": "1.2.1",
-    "crypto-js": "^4.1.1",
     "env": "^0.0.2",
     "isomorphic-fetch": "^3.0.0",
+    "js-sha256": "^0.9.0",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "typescript": "^4.8.2"
   },
   "dependencies": {
+    "@types/crypto-js": "^4.1.1",
     "blakejs": "1.2.1",
+    "crypto-js": "^4.1.1",
     "env": "^0.0.2",
     "isomorphic-fetch": "^3.0.0",
     "reflect-metadata": "^0.1.13",

--- a/src/js_crypto/bigint-helpers.ts
+++ b/src/js_crypto/bigint-helpers.ts
@@ -1,0 +1,93 @@
+export { changeBase, bytesToBigInt, bigIntToBytes };
+
+function bytesToBigInt(bytes: Uint8Array | number[]) {
+  let x = 0n;
+  let bitPosition = 0n;
+  for (let byte of bytes) {
+    x += BigInt(byte) << bitPosition;
+    bitPosition += 8n;
+  }
+  return x;
+}
+
+/**
+ * Transforms bigint to little-endian array of bytes (numbers between 0 and 255) of a given length.
+ * Throws an error if the bigint doesn't fit in the given number of bytes.
+ */
+function bigIntToBytes(x: bigint, length: number) {
+  if (x < 0n) {
+    throw Error(`bigIntToBytes: negative numbers are not supported, got ${x}`);
+  }
+  let bytes: number[] = Array(length);
+  for (let i = 0; i < length; i++, x >>= 8n) {
+    bytes[i] = Number(x & 0xffn);
+  }
+  if (x > 0n) {
+    throw Error(`bigIntToBytes: input does not fit in ${length} bytes`);
+  }
+  return bytes;
+}
+
+function changeBase(digits: bigint[], base: bigint, newBase: bigint) {
+  // 1. accumulate digits into one gigantic bigint `x`
+  let x = fromBase(digits, base);
+  // 2. compute new digits from `x`
+  let newDigits = toBase(x, newBase);
+  return newDigits;
+}
+
+// NOTE: toBase / fromBase are so complicated for performance reasons
+
+function fromBase(digits: bigint[], base: bigint) {
+  // compute powers base, base^2, base^4, ..., base^(2^k)
+  // with largest k s.t. n = 2^k < digits.length
+  let basePowers = [];
+  for (let power = base, n = 1; n < digits.length; power **= 2n, n *= 2) {
+    basePowers.push(power);
+  }
+  let k = basePowers.length;
+  // pad digits array with zeros s.t. digits.length === 2^k
+  digits = digits.concat(Array(2 ** k - digits.length).fill(0n));
+  // accumulate [x0, x1, x2, x3, ...] -> [x0 + base*x1, x2 + base*x3, ...] -> [x0 + base*x1 + base^2*(x2 + base*x3=, ...] -> ...
+  // until we end up with a single element
+  for (let i = 0; i < k; i++) {
+    let newDigits = Array(digits.length >> 1);
+    let basePower = basePowers[i];
+    for (let j = 0; j < newDigits.length; j++) {
+      newDigits[j] = digits[2 * j] + basePower * digits[2 * j + 1];
+    }
+    digits = newDigits;
+  }
+  console.assert(digits.length === 1);
+  let [digit] = digits;
+  return digit;
+}
+
+function toBase(x: bigint, base: bigint) {
+  // compute powers base, base^2, base^4, ..., base^(2^k)
+  // with largest k s.t. base^(2^k) < x
+  let basePowers = [];
+  for (let power = base; power < x; power **= 2n) {
+    basePowers.push(power);
+  }
+  let digits = [x]; // single digit w.r.t base^(2^(k+1))
+  // successively split digits w.r.t. base^(2^j) into digits w.r.t. base^(2^(j-1))
+  // until we arrive at digits w.r.t. base
+  let k = basePowers.length;
+  for (let i = 0; i < k; i++) {
+    let newDigits = Array(2 * digits.length);
+    let basePower = basePowers[k - 1 - i];
+    for (let j = 0; j < digits.length; j++) {
+      let x = digits[j];
+      let high = x / basePower;
+      newDigits[2 * j + 1] = high;
+      newDigits[2 * j] = x - high * basePower;
+    }
+    digits = newDigits;
+  }
+  // pop "leading" zero digits
+  while (digits[digits.length - 1] === 0n) {
+    digits.pop();
+  }
+  return digits;
+}

--- a/src/js_crypto/bigint-helpers.ts
+++ b/src/js_crypto/bigint-helpers.ts
@@ -36,8 +36,55 @@ function changeBase(digits: bigint[], base: bigint, newBase: bigint) {
   return newDigits;
 }
 
-// NOTE: toBase / fromBase are so complicated for performance reasons
-
+/**
+ * the algorithm for toBase / fromBase is more complicated than it naively has to be,
+ * but that is for performance reasons.
+ *
+ * we'll explain it for `fromBase`. this function is about taking an array of digits
+ * [x0, ..., xn]
+ * and returning the integer (bigint) that has those digits in the given `base`:
+ * ```
+ * let x = x0 + x1*base + x2*base**2 + ... + xn*base**n
+ * ```
+ *
+ * naively, we could just accumulate digits from left to right:
+ * ```
+ * let x = 0n;
+ * let p = 1n;
+ * for (let i=0; i<n; i++) {
+ *   x += X[i] * p;
+ *   p *= base;
+ * }
+ * ```
+ *
+ * in the ith step, `p = base**i` which is multiplied with `xi` and added to the sum.
+ * however, note that this algorithm is O(n^2): let `l = log2(base)`. the base power `p` is a bigint of bit length `i*l`,
+ * which is multiplied by a "small" number `xi` (length l), which takes O(i) time in every step.
+ * since this is done for `i = 0,...,n`, we end up with an `O(n^2)` algorithm.
+ *
+ * HOWEVER, it turns out that there are fast multiplication algorithms, and JS bigints have them built in!
+ * the Schönhage-Strassen algorithm (implemented in the V8 engine, see https://github.com/v8/v8/blob/main/src/bigint/mul-fft.cc)
+ * can multiply two n-bit numbers in time `O(n log(n) loglog(n))`, when n is large.
+ *
+ * to take advantage of asymptotically fast multiplication, we need to re-structure our algorithm such that it multiplies roughly equal-sized
+ * numbers with each other (there is no asymptotic boost for mutliplying a small with a large number). so, what we do is to go from the
+ * original digit array to arrays of successively larger digits:
+ * ```
+ * step 0:                  step 1:                              step 2:
+ * [x0, x1, x2, x3, ...] -> [x0 + base*x1, x2 + base*x3, ...] -> [x0 + base*x1 + base^2*(x2 + base*x3), ...] -> ...
+ * ```
+ *
+ * ...until after a log number of steps we end with a single "digit" which is equal to the entire sum.
+ *
+ * in the ith step, we multiply n/2^i pairs of numbers of bit length i*l. each of these multiplications takes
+ * time `O(i log(i) loglog(i))`. if we bound that with `O(i log(n) loglog(n))`, we see that our runtime is
+ * ```
+ * O( (n + 2n/2 ... + n*n/n) log(n) loglog(n) ) = O(n log(n)^2 loglog(n))
+ * ```
+ * empirically, the result is a huge improvement over the naive `O(n^2)` algorithm and scales much better with length of the digit array.
+ *
+ * similar conclusions hold for `toBase`.
+ */
 function fromBase(digits: bigint[], base: bigint) {
   // compute powers base, base^2, base^4, ..., base^(2^k)
   // with largest k s.t. n = 2^k < digits.length

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -1,4 +1,5 @@
-import { bytesToBigInt, inverse, mod, p, q } from './finite_field.js';
+import { bytesToBigInt } from './bigint-helpers.js';
+import { inverse, mod, p, q } from './finite_field.js';
 export { Pallas, Vesta, GroupAffine, GroupProjective };
 
 // TODO: constants, like generator points and cube roots for endomorphisms, should be drawn from

--- a/src/js_crypto/finite_field.ts
+++ b/src/js_crypto/finite_field.ts
@@ -1,6 +1,7 @@
+import { bytesToBigInt } from './bigint-helpers.js';
 import { randomBytes } from './random.js';
 
-export { Fp, Fq, FiniteField, p, q, mod, inverse, bytesToBigInt };
+export { Fp, Fq, FiniteField, p, q, mod, inverse };
 
 // CONSTANTS
 
@@ -111,15 +112,6 @@ function randomField(p: bigint) {
     let x = bytesToBigInt(bytes);
     if (x < p) return x;
   }
-}
-function bytesToBigInt(bytes: Uint8Array) {
-  let x = 0n;
-  let bitPosition = 0n;
-  for (let byte of bytes) {
-    x += BigInt(byte) << bitPosition;
-    bitPosition += 8n;
-  }
-  return x;
 }
 
 // SPECIALIZATIONS TO FP, FQ

--- a/src/js_crypto/poseidon.unit-test.ts
+++ b/src/js_crypto/poseidon.unit-test.ts
@@ -1,8 +1,8 @@
-import { bigIntToBytes } from '../provable/field-bigint.js';
 import { Poseidon, PoseidonLegacy } from './poseidon.js';
 import { testPoseidonKimchiFp } from './test_vectors/poseidonKimchi.js';
 import { testPoseidonLegacyFp } from './test_vectors/poseidonLegacy.js';
 import { expect } from 'expect';
+import { bigIntToBytes } from './bigint-helpers.js';
 
 let testVectors = testPoseidonKimchiFp.test_vectors;
 

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { bytesToBigInt } from '../js_crypto/finite_field.js';
+import { bytesToBigInt } from '../js_crypto/bigint-helpers.js';
 import { Circuit, ProvablePure, Provable, Keypair } from '../snarky.js';
 import { Field, Bool } from './core.js';
 import { Context } from './global-context.js';

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,5 +1,6 @@
+import { bytesToBigInt } from '../js_crypto/bigint-helpers.js';
 import { defineBinable } from '../provable/binable.js';
-import { bytesToBigInt, sizeInBits } from '../provable/field-bigint.js';
+import { sizeInBits } from '../provable/field-bigint.js';
 import { Bool, Field, Scalar, Group } from '../snarky.js';
 
 export { Field, Bool, Scalar, Group };

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -1,8 +1,57 @@
 import { versionBytes } from '../js_crypto/constants.js';
 import { Ledger } from '../snarky.js';
 import { Binable, stringToBytes, withVersionNumber } from './binable.js';
+import sha256 from 'crypto-js/sha256.js';
+import { changeBase } from '../js_crypto/bigint-helpers.js';
 
-export { base58, withBase58, fieldEncodings, Base58 };
+export {
+  stringToDigits,
+  toBase58Check,
+  base58,
+  withBase58,
+  fieldEncodings,
+  Base58,
+};
+
+const alphabet =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'.split('');
+let inverseAlphabet: Record<string, number> = {};
+alphabet.forEach((c, i) => {
+  inverseAlphabet[c] = i;
+});
+
+function stringToDigits(string: string) {
+  return [...string].map((c) => inverseAlphabet[c]);
+}
+
+function toBase58Check(input: number[] | Uint8Array, versionByte: number) {
+  let withVersion = [versionByte, ...input];
+  let checksum = computeChecksum(withVersion);
+  let withChecksum = withVersion.concat(checksum);
+  return toBase58(withChecksum);
+}
+
+function toBase58(bytes: number[] | Uint8Array) {
+  console.log('bytes js', bytes);
+  // count the leading zeroes. these get turned into leading zeroes in the output
+  let z = 0;
+  while (bytes[z] === 0) z++;
+  // for some reason, this is big-endian, so we need to reverse
+  let digits = [...bytes].map(BigInt).reverse();
+  // change base and reverse
+  let base58Digits = changeBase(digits, 256n, 58n).reverse();
+  // add leading zeroes, map into alphabet
+  base58Digits = Array(z).fill(0).concat(base58Digits);
+  return base58Digits.map((x) => alphabet[Number(x)]).join('');
+}
+
+function computeChecksum(input: number[] | Uint8Array) {
+  let inputString = String.fromCharCode(...input);
+  let hash = sha256(sha256(inputString));
+  // first 4 bytes = first int32 word
+  let int32Array = new Int32Array([hash.words[0]]);
+  return [...new Uint8Array(int32Array.buffer)].reverse();
+}
 
 type Base58<T> = {
   toBase58(t: T): string;
@@ -13,12 +62,13 @@ function base58<T>(binable: Binable<T>, versionByte: number): Base58<T> {
   return {
     toBase58(t) {
       let bytes = binable.toBytes(t);
-      let binaryString = String.fromCharCode(...bytes);
-      // this `ocamlBytes` structure is the js_of_ocaml representation of a byte array.
-      // the `t: 9` is an integer tag that says the content is a full ASCII string,
-      // see https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/mlBytes.js
-      let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
-      return Ledger.encoding.toBase58(ocamlBytes, versionByte);
+      return toBase58Check(bytes, versionByte);
+      // let binaryString = String.fromCharCode(...bytes);
+      // // this `ocamlBytes` structure is the js_of_ocaml representation of a byte array.
+      // // the `t: 9` is an integer tag that says the content is a full ASCII string,
+      // // see https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/mlBytes.js
+      // let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
+      // return Ledger.encoding.toBase58(ocamlBytes, versionByte);
     },
     fromBase58(base58) {
       let ocamlBytes = Ledger.encoding.ofBase58(base58, versionByte);

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -37,7 +37,9 @@ function fromBase58Check(base58: string, versionByte: number) {
     throw Error('fromBase58Check: invalid checksum');
   // check version byte
   if (originalBytes[0] !== versionByte)
-    throw Error('fromBase58Check: version byte does not match');
+    throw Error(
+      `fromBase58Check: input version byte ${versionByte} does not match encoded version byte ${originalBytes[0]}`
+    );
   // return result
   return originalBytes.slice(1);
 }

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -27,7 +27,7 @@ function toBase58Check(input: number[] | Uint8Array, versionByte: number) {
 }
 
 function fromBase58Check(base58: string, versionByte: number) {
-  // TODO: should raise on invalid character
+  // throws on invalid character
   let bytes = fromBase58(base58);
   // check checksum
   let checksum = bytes.slice(-4);
@@ -58,7 +58,11 @@ function toBase58(bytes: number[] | Uint8Array) {
 }
 
 function fromBase58(base58: string) {
-  let base58Digits = [...base58].map((c) => BigInt(inverseAlphabet[c]));
+  let base58Digits = [...base58].map((c) => {
+    let digit = inverseAlphabet[c];
+    if (digit === undefined) throw Error('fromBase58: invalid character');
+    return BigInt(digit);
+  });
   let z = 0;
   while (base58Digits[z] === 0n) z++;
   let digits = changeBase(base58Digits.reverse(), 58n, 256n).reverse();

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -1,12 +1,11 @@
 import { versionBytes } from '../js_crypto/constants.js';
-import { Ledger } from '../snarky.js';
-import { Binable, stringToBytes, withVersionNumber } from './binable.js';
+import { Binable, withVersionNumber } from './binable.js';
 import { sha256 } from 'js-sha256';
 import { changeBase } from '../js_crypto/bigint-helpers.js';
 
 export {
-  stringToDigits,
   toBase58Check,
+  fromBase58Check,
   base58,
   withBase58,
   fieldEncodings,
@@ -20,15 +19,27 @@ alphabet.forEach((c, i) => {
   inverseAlphabet[c] = i;
 });
 
-function stringToDigits(string: string) {
-  return [...string].map((c) => inverseAlphabet[c]);
-}
-
 function toBase58Check(input: number[] | Uint8Array, versionByte: number) {
   let withVersion = [versionByte, ...input];
   let checksum = computeChecksum(withVersion);
   let withChecksum = withVersion.concat(checksum);
   return toBase58(withChecksum);
+}
+
+function fromBase58Check(base58: string, versionByte: number) {
+  // TODO: should raise on invalid character
+  let bytes = fromBase58(base58);
+  // check checksum
+  let checksum = bytes.slice(-4);
+  let originalBytes = bytes.slice(0, -4);
+  let actualChecksum = computeChecksum(originalBytes);
+  if (!arrayEqual(checksum, actualChecksum))
+    throw Error('fromBase58Check: invalid checksum');
+  // check version byte
+  if (originalBytes[0] !== versionByte)
+    throw Error('fromBase58Check: version byte does not match');
+  // return result
+  return originalBytes.slice(1);
 }
 
 function toBase58(bytes: number[] | Uint8Array) {
@@ -40,8 +51,17 @@ function toBase58(bytes: number[] | Uint8Array) {
   // change base and reverse
   let base58Digits = changeBase(digits, 256n, 58n).reverse();
   // add leading zeroes, map into alphabet
-  base58Digits = Array(z).fill(0).concat(base58Digits);
+  base58Digits = Array(z).fill(0n).concat(base58Digits);
   return base58Digits.map((x) => alphabet[Number(x)]).join('');
+}
+
+function fromBase58(base58: string) {
+  let base58Digits = [...base58].map((c) => BigInt(inverseAlphabet[c]));
+  let z = 0;
+  while (base58Digits[z] === 0n) z++;
+  let digits = changeBase(base58Digits.reverse(), 58n, 256n).reverse();
+  digits = Array(z).fill(0n).concat(digits);
+  return digits.map(Number);
 }
 
 function computeChecksum(input: number[] | Uint8Array) {
@@ -64,8 +84,7 @@ function base58<T>(binable: Binable<T>, versionByte: number): Base58<T> {
       return toBase58Check(bytes, versionByte);
     },
     fromBase58(base58) {
-      let ocamlBytes = Ledger.encoding.ofBase58(base58, versionByte);
-      let bytes = stringToBytes(ocamlBytes.c);
+      let bytes = fromBase58Check(base58, versionByte);
       return binable.fromBytes(bytes);
     },
   };
@@ -116,4 +135,12 @@ function fieldEncodings<Field>(Field: Binable<Field>) {
     STATE_HASH_VERSION
   );
   return { TokenId, ReceiptChainHash, LedgerHash, EpochSeed, StateHash };
+}
+
+function arrayEqual(a: unknown[], b: unknown[]) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -44,13 +44,6 @@ function toBase58(bytes: number[] | Uint8Array) {
   return base58Digits.map((x) => alphabet[Number(x)]).join('');
 }
 
-async function computeChecksumAsync(input: number[]) {
-  let inputBytes = new Uint8Array(input);
-  let output1 = await crypto.subtle.digest('SHA-256', inputBytes);
-  let output = await crypto.subtle.digest('SHA-256', output1);
-  return [...new Uint8Array(output)].slice(0, 4);
-}
-
 function computeChecksum(input: number[] | Uint8Array) {
   let hash1 = sha256.create();
   hash1.update(input);

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -1,4 +1,4 @@
-import { toBase58Check } from './base58.js';
+import { fromBase58Check, toBase58Check } from './base58.js';
 import { Ledger, isReady, shutdown } from '../snarky.js';
 import { expect } from 'expect';
 
@@ -14,5 +14,9 @@ let base58Ocaml = Ledger.encoding.toBase58(ocamlBytes, version);
 let base58 = toBase58Check(bytes, version);
 
 expect(base58).toEqual(base58Ocaml);
+
+let recoveredBytes = fromBase58Check(base58, version);
+
+expect(recoveredBytes).toEqual(bytes);
 
 shutdown();

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -1,19 +1,18 @@
-import { stringToDigits, toBase58Check } from './base58.js';
+import { toBase58Check } from './base58.js';
 import { Ledger, isReady, shutdown } from '../snarky.js';
+import { expect } from 'expect';
 
 await isReady;
 
-let bytes = [0, 0, 0, 0];
+let bytes = [250, 200, 150, 100, 50, 0];
 let version = 0x01;
 
 let binaryString = String.fromCharCode(...bytes);
 let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
-let base58 = Ledger.encoding.toBase58(ocamlBytes, version);
-console.log('digits ocaml', stringToDigits(base58));
+let base58Ocaml = Ledger.encoding.toBase58(ocamlBytes, version);
 
-let base582 = toBase58Check(bytes, version);
+let base58 = toBase58Check(bytes, version);
 
-console.log(base58);
-console.log(base582);
+expect(base58).toEqual(base58Ocaml);
 
 shutdown();

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -4,19 +4,40 @@ import { expect } from 'expect';
 
 await isReady;
 
-let bytes = [250, 200, 150, 100, 50, 0];
-let version = 0x01;
+function check(bytes: number[], version: number) {
+  let binaryString = String.fromCharCode(...bytes);
+  let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
+  let base58Ocaml = Ledger.encoding.toBase58(ocamlBytes, version);
 
-let binaryString = String.fromCharCode(...bytes);
-let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
-let base58Ocaml = Ledger.encoding.toBase58(ocamlBytes, version);
+  // check consistency with OCaml result
+  let base58 = toBase58Check(bytes, version);
+  expect(base58).toEqual(base58Ocaml);
 
-let base58 = toBase58Check(bytes, version);
+  // check roundtrip
+  let recoveredBytes = fromBase58Check(base58, version);
+  expect(recoveredBytes).toEqual(bytes);
+}
 
-expect(base58).toEqual(base58Ocaml);
+check([0, 1, 2, 3, 4, 5], 10);
+check([250, 200, 150, 100, 50, 0], 1);
+check([0, 0], 0);
+check([1], 100);
+check([], 0x01);
 
-let recoveredBytes = fromBase58Check(base58, version);
+let goodExample = 'AhgX24Hr3v';
+expect(toBase58Check([0, 1, 2], 1)).toEqual(goodExample);
 
-expect(recoveredBytes).toEqual(bytes);
+// negative tests
+
+// throws on invalid character
+expect(() => fromBase58Check('@hgX24Hr3v', 1)).toThrow('invalid character');
+
+// throws on invalid checksum
+expect(() => fromBase58Check('AhgX24Hr3u', 1)).toThrow('invalid checksum');
+
+// throws on invalid version byte
+expect(() => fromBase58Check('AhgX24Hr3v', 2)).toThrow(
+  '2 does not match encoded version byte 1'
+);
 
 shutdown();

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -1,0 +1,19 @@
+import { stringToDigits, toBase58Check } from './base58.js';
+import { Ledger, isReady, shutdown } from '../snarky.js';
+
+await isReady;
+
+let bytes = [0, 0, 0, 0];
+let version = 0x01;
+
+let binaryString = String.fromCharCode(...bytes);
+let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
+let base58 = Ledger.encoding.toBase58(ocamlBytes, version);
+console.log('digits ocaml', stringToDigits(base58));
+
+let base582 = toBase58Check(bytes, version);
+
+console.log(base58);
+console.log(base582);
+
+shutdown();

--- a/src/provable/bigint.unit-test.ts
+++ b/src/provable/bigint.unit-test.ts
@@ -1,6 +1,7 @@
-import { bigIntToBytes, bytesToBigInt, Field } from './field-bigint.js';
+import { Field } from './field-bigint.js';
 import { expect } from 'expect';
 import { shutdown } from '../snarky.js';
+import { bytesToBigInt, bigIntToBytes } from '../js_crypto/bigint-helpers.js';
 
 function testBigintRoundtrip(x: bigint, size: number) {
   let bytes = bigIntToBytes(x, size);

--- a/src/provable/binable.ts
+++ b/src/provable/binable.ts
@@ -1,5 +1,5 @@
 // generic encoding infrastructure
-import { bigIntToBytes, bytesToBigInt } from './field-bigint.js';
+import { bytesToBigInt, bigIntToBytes } from '../js_crypto/bigint-helpers.js';
 import { GenericField } from './generic.js';
 
 export {

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -1,3 +1,4 @@
+import { bigIntToBytes } from '../js_crypto/bigint-helpers.js';
 import { Fp, mod } from '../js_crypto/finite_field.js';
 import { BinableWithBits, defineBinable, withBits } from './binable.js';
 import { GenericHashInput, GenericProvableExtended } from './generic.js';
@@ -9,9 +10,7 @@ export {
   HashInput,
   ProvableBigint,
   BinableBigint,
-  bigIntToBytes,
   sizeInBits,
-  bytesToBigInt,
   checkRange,
   checkField,
 };
@@ -205,34 +204,6 @@ function BinableBigint<T extends bigint = bigint>(
     }),
     sizeInBits
   );
-}
-
-function bytesToBigInt(bytes: Uint8Array | number[]) {
-  let x = 0n;
-  let bitPosition = 0n;
-  for (let byte of bytes) {
-    x += BigInt(byte) << bitPosition;
-    bitPosition += 8n;
-  }
-  return x;
-}
-
-/**
- * Transforms bigint to little-endian array of bytes (numbers between 0 and 255) of a given length.
- * Throws an error if the bigint doesn't fit in the given number of bytes.
- */
-function bigIntToBytes(x: bigint, length: number) {
-  if (x < 0n) {
-    throw Error(`bigIntToBytes: negative numbers are not supported, got ${x}`);
-  }
-  let bytes: number[] = Array(length);
-  for (let i = 0; i < length; i++, x >>= 8n) {
-    bytes[i] = Number(x & 0xffn);
-  }
-  if (x > 0n) {
-    throw Error(`bigIntToBytes: input does not fit in ${length} bytes`);
-  }
-  return bytes;
 }
 
 // validity checks


### PR DESCRIPTION
closes #677 

Implements base58 check in JS, which was the last remaining OCaml dependency of the mina-signer code base. Base58 check is implemented using the following ingredients:
* a `changeBase` function (which was already there), to map an array of digits in one base into an array of digits in another base. In this case we go from base 256 (bytes) to base 58, and back.
* for computing the checksum, a sha256 implementation, which we take from the [js-sha256](https://www.npmjs.com/package/js-sha256) library: (700,000 downloads / week, has no runtime dependencies of its own)
  * we'd prefer to use the built-in [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest), but it is async, which would be too disruptive to our API surface