### PR TITLE
Fix fetchMissingData: re-fetch cached accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - also fixes `Struct.fromJSON`
 - `SmartContract.fetchEvents` fixed when multiple event types existed https://github.com/o1-labs/snarkyjs/issues/627
 - Error when using reduce with a `Struct` as state type https://github.com/o1-labs/snarkyjs/pull/689
+- Fix use of stale cached accounts in `Mina.transaction` https://github.com/o1-labs/snarkyjs/issues/430
 
 ## [0.7.3](https://github.com/o1-labs/snarkyjs/compare/5f20f496...d880bd6e)
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -55,7 +55,7 @@ export {
 };
 interface TransactionId {
   wait(options?: { maxAttempts?: number; interval?: number }): Promise<void>;
-  hash(): string;
+  hash(): string | undefined;
 }
 
 interface Transaction {


### PR DESCRIPTION
closes #430 (let's see if this can finally stay closed!)

this is confirmed to fix one instance of stale account data (incorrect nonce) used by `Mina.transaction`. The issue was that an account that already was fecthed once, and was therefore cached, was not re-fetched when it was marked to be fetched during `Mina.transaction`. This meant that an account that was _updated_ by an earlier transaction remained stale.

The simple solution is to fetch all accounts that are marked for fetching.

closes #599

as a  side-effect, this makes the cache invalidation timeout completely unused, therefore we remove it and close the issue of making it configurable