### PR TITLE
Fix `TransactionId.wait()`: do not wait if transaction failed

### DIFF
--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -681,15 +681,23 @@ function Network(graphqlEndpoint: string): Mina {
         console.log('got fetch error', error);
         errors = [error];
       }
+      let isSuccess = errors === undefined;
 
       let maxAttempts: number;
       let attempts = 0;
       let interval: number;
 
       return {
+        isSuccess,
         data: response?.data,
         errors,
         async wait(options?: { maxAttempts?: number; interval?: number }) {
+          if (!isSuccess) {
+            console.warn(
+              'Transaction.wait(): returning immediately because the transaction was not successful.'
+            );
+            return;
+          }
           // default is 45 attempts * 20s each = 15min
           // the block time on berkeley is currently longer than the average 3-4min, so its better to target a higher block time
           // fetching an update every 20s is more than enough with a current block time of 3min

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -54,6 +54,7 @@ export {
   filterGroups,
 };
 interface TransactionId {
+  isSuccess: boolean;
   wait(options?: { maxAttempts?: number; interval?: number }): Promise<void>;
   hash(): string | undefined;
 }
@@ -408,7 +409,7 @@ function LocalBlockchain({
     getNetworkState() {
       return networkState;
     },
-    async sendTransaction(txn: Transaction) {
+    async sendTransaction(txn: Transaction): Promise<TransactionId> {
       txn.sign();
 
       let commitments = Ledger.transactionCommitments(
@@ -508,6 +509,7 @@ function LocalBlockchain({
         }
       });
       return {
+        isSuccess: true,
         wait: async (_options?: {
           maxAttempts?: number;
           interval?: number;


### PR DESCRIPTION
has been tested as part of the work on https://github.com/o1-labs/docs2/pull/234