### PR TITLE
Mina-signer: in-SNARK verifiable Signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Transaction.fromJSON` to recover transaction object from JSON https://github.com/o1-labs/snarkyjs/pull/705
 
+### Changed
+
+- BREAKING CHANGE: Modify signature algorithm used by `Signature.{create,verify}` to be compatible with mina-signer https://github.com/o1-labs/snarkyjs/pull/710
+  - Signatures created with mina-signer's `client.signFields()` can now be verified inside a SNARK!
+  - Breaks existing deployed smart contracts which use `Signature.verify()`
+
 ## [0.8.0](https://github.com/o1-labs/snarkyjs/compare/d880bd6e...c5a36207)
 
 ### Added

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1877,7 +1877,11 @@ function signJsonTransaction(
       accountUpdate.authorization.proof === null
     ) {
       zkappCommand = JSON.parse(
-        Ledger.signAccountUpdate(JSON.stringify(zkappCommand), privateKey, i)
+        Ledger.signOtherAccountUpdate(
+          JSON.stringify(zkappCommand),
+          privateKey,
+          i
+        )
       );
     }
   }

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -2,6 +2,8 @@ import { bytesToBigInt } from '../js_crypto/bigint-helpers.js';
 import { defineBinable } from '../provable/binable.js';
 import { sizeInBits } from '../provable/field-bigint.js';
 import { Bool, Field, Scalar, Group } from '../snarky.js';
+import { Scalar as ScalarBigint } from '../provable/curve-bigint.js';
+import { mod } from '../js_crypto/finite_field.js';
 
 export { Field, Bool, Scalar, Group };
 
@@ -71,4 +73,9 @@ That means it can't be called in a @method or similar environment, and there's n
     field: Field(x & lowBitMask),
     highBit: Bool(x >> lowBitSize === 1n),
   };
+};
+
+Scalar.fromBigInt = function (scalar: bigint) {
+  scalar = mod(scalar, ScalarBigint.modulus);
+  return Scalar.fromJSON(scalar.toString());
 };

--- a/src/mina-signer/MinaSigner.ts
+++ b/src/mina-signer/MinaSigner.ts
@@ -23,6 +23,7 @@ import {
   publicKeyToHex,
   rosettaTransactionToSignedCommand,
 } from './src/rosetta.js';
+import { sign, Signature } from './src/signature.js';
 
 export { Client as default };
 
@@ -95,6 +96,33 @@ class Client {
     let publicKey = PrivateKey.toPublicKey(privateKey);
     return PublicKey.toBase58(publicKey);
   }
+
+  /**
+   * Signs an arbitrary list of field elements in a SNARK-compatible way.
+   * The resulting signature can be verified in SnarkyJS as follows:
+   * ```ts
+   * // sign field elements with mina-signer
+   * let signed = client.signFieldElements(fields, privateKey);
+   *
+   * // read signature in snarkyjs and verify
+   * let signature = Signature.fromBase58(signed.signature);
+   * let isValid: Bool = signature.verify(publicKey, fields.map(Field));
+   * ```
+   *
+   * @param fields An arbitrary list of field elements
+   * @param privateKey The private key used for signing
+   * @returns The signed field elements
+   */
+  signFields(fields: bigint[], privateKey: Json.PrivateKey): Signed<bigint[]> {
+    let privateKey_ = PrivateKey.fromBase58(privateKey);
+    let signature = sign({ fields }, privateKey_, 'testnet');
+    return {
+      signature: Signature.toBase58(signature),
+      publicKey: PublicKey.toBase58(PrivateKey.toPublicKey(privateKey_)),
+      data: fields,
+    };
+  }
+  // TODO verifyFields
 
   /**
    * Signs an arbitrary message

--- a/src/mina-signer/MinaSigner.ts
+++ b/src/mina-signer/MinaSigner.ts
@@ -23,7 +23,7 @@ import {
   publicKeyToHex,
   rosettaTransactionToSignedCommand,
 } from './src/rosetta.js';
-import { sign, Signature } from './src/signature.js';
+import { sign, Signature, verify } from './src/signature.js';
 
 export { Client as default };
 
@@ -122,7 +122,22 @@ class Client {
       data: fields,
     };
   }
-  // TODO verifyFields
+
+  /**
+   * Verifies a signature created by {@link signFields}.
+   *
+   * @param signedFields The signed field elements
+   * @returns True if the `signedFields` contains a valid signature matching
+   * the fields and publicKey.
+   */
+  verifyFields({ data, signature, publicKey }: Signed<bigint[]>) {
+    return verify(
+      Signature.fromBase58(signature),
+      { fields: data },
+      PublicKey.fromBase58(publicKey),
+      'testnet'
+    );
+  }
 
   /**
    * Signs an arbitrary message
@@ -142,7 +157,7 @@ class Client {
   }
 
   /**
-   * Verifies that a signature matches a message.
+   * Verifies a signature created by {@link signMessage}.
    *
    * @param signedMessage A signed message
    * @returns True if the `signedMessage` contains a valid signature matching

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -37,6 +37,7 @@ export {
   NetworkId,
   signLegacy,
   verifyLegacy,
+  deriveNonce,
 };
 
 const networkIdMainnet = 0x01n;

--- a/src/mina-signer/tests/verify-in-snark.unit-test.ts
+++ b/src/mina-signer/tests/verify-in-snark.unit-test.ts
@@ -3,8 +3,8 @@ import { ZkProgram } from '../../lib/proof_system.js';
 import Client from '../MinaSigner.js';
 import { PrivateKey, Signature } from '../../lib/signature.js';
 import { provablePure } from '../../lib/circuit_value.js';
+import { expect } from 'expect';
 
-await isReady;
 let fields = [10n, 20n, 30n, 340817401n, 2091283n, 1n, 0n];
 let privateKey = 'EKENaWFuAiqktsnWmxq8zaoR8bSgVdscsghJE5tV6hPoNm8qBKWM';
 
@@ -12,11 +12,21 @@ let privateKey = 'EKENaWFuAiqktsnWmxq8zaoR8bSgVdscsghJE5tV6hPoNm8qBKWM';
 let client = new Client({ network: 'mainnet' });
 let signed = client.signFields(fields, privateKey);
 
+// verify with mina-signer
+let ok = client.verifyFields(signed);
+expect(ok).toEqual(true);
+
+// sign with snarkyjs and check that we get the same signature
+await isReady;
+let fieldsSnarky = fields.map(Field);
+let privateKeySnarky = PrivateKey.fromBase58(privateKey);
+let signatureSnarky = Signature.create(privateKeySnarky, fieldsSnarky);
+expect(signatureSnarky.toBase58()).toEqual(signed.signature);
+
 // verify out-of-snark with snarkyjs
-let publicKey = PrivateKey.fromBase58(privateKey).toPublicKey();
-let message = fields.map(Field);
+let publicKey = privateKeySnarky.toPublicKey();
 let signature = Signature.fromBase58(signed.signature);
-signature.verify(publicKey, message).assertTrue();
+signature.verify(publicKey, fieldsSnarky).assertTrue();
 
 // verify in-snark with snarkyjs
 const MyProgram = ZkProgram({
@@ -25,12 +35,15 @@ const MyProgram = ZkProgram({
     verifySignature: {
       privateInputs: [Signature],
       method(_: null, signature: Signature) {
-        signature.verify(publicKey, message).assertTrue();
+        signature.verify(publicKey, fieldsSnarky).assertTrue();
       },
     },
   },
 });
+
+await MyProgram.compile();
 let proof = await MyProgram.verifySignature(null, signature);
-await MyProgram.verify(proof);
+ok = await MyProgram.verify(proof);
+expect(ok).toEqual(true);
 
 shutdown();

--- a/src/mina-signer/tests/verify-in-snark.unit-test.ts
+++ b/src/mina-signer/tests/verify-in-snark.unit-test.ts
@@ -1,0 +1,36 @@
+import { Field, isReady, shutdown } from '../../snarky.js';
+import { ZkProgram } from '../../lib/proof_system.js';
+import Client from '../MinaSigner.js';
+import { PrivateKey, Signature } from '../../lib/signature.js';
+import { provablePure } from '../../lib/circuit_value.js';
+
+await isReady;
+let fields = [10n, 20n, 30n, 340817401n, 2091283n, 1n, 0n];
+let privateKey = 'EKENaWFuAiqktsnWmxq8zaoR8bSgVdscsghJE5tV6hPoNm8qBKWM';
+
+// sign with mina-signer
+let client = new Client({ network: 'mainnet' });
+let signed = client.signFields(fields, privateKey);
+
+// verify out-of-snark with snarkyjs
+let publicKey = PrivateKey.fromBase58(privateKey).toPublicKey();
+let message = fields.map(Field);
+let signature = Signature.fromBase58(signed.signature);
+signature.verify(publicKey, message).assertTrue();
+
+// verify in-snark with snarkyjs
+const MyProgram = ZkProgram({
+  publicInput: provablePure(null),
+  methods: {
+    verifySignature: {
+      privateInputs: [Signature],
+      method(_: null, signature: Signature) {
+        signature.verify(publicKey, message).assertTrue();
+      },
+    },
+  },
+});
+let proof = await MyProgram.verifySignature(null, signature);
+await MyProgram.verify(proof);
+
+shutdown();

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1274,7 +1274,7 @@ declare class Ledger {
   /**
    * Signs an account update.
    */
-  static signAccountUpdate(
+  static signOtherAccountUpdate(
     txJson: string,
     privateKey: { s: Scalar },
     i: number

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -990,6 +990,11 @@ declare class Scalar {
    * This operation does NOT affect the circuit and can't be used to prove anything about the string representation of the Scalar.
    */
   static fromJSON(x: string | number | boolean): Scalar;
+  /**
+   * Create a constant {@link Scalar} from a bigint.
+   * If the bigint is too large, it is reduced modulo the scalar field order.
+   */
+  static fromBigInt(s: bigint): Scalar;
   static check(x: Scalar): void;
 }
 


### PR DESCRIPTION
closes https://github.com/MinaProtocol/mina/issues/11327

this is about letting users sign data with mina-signer (i.e., with their wallet), such that the signature can be verified by a smart contract. in other words, we need to make sure there is a signing function in mina-signer whose signatures can be verified in-snark by snarkyjs.

- adds `signFields` and `verifyFields` to mina-signer
- modifies the existing `Signature.create` and `Signature.verify` in snarkyjs, to be compatible with `signFields`
  - note that `Signature.create` is not for in-snark usage, but `Signature.verify` is
  
Making snarkyjs signatures compatible uncovered a bug/irregularity in the previous implementation:
- after hashing the message to be signed, the algorithm reinterprets the hash (a base field element) as a scalar
- in snarkyjs, this was done with `Scalar.fromBits(hash.toBits())`
- however, it turned out that `Scalar` uses [a "shifted" representation](https://github.com/MinaProtocol/mina/blob/f6756507ff7380a691516ce02a3cf7d9d32915ae/src/lib/pickles_types/shifted_value.ml#L44) and `fromBits` just interprets the bits to already be in shifted form
- so, it can be said that the existing algorithm used a non-standard way of moving from base field to scalar
- this is fixed here, by unshifting the scalar. in the case of the in-snark verify, we do the unshifting on the group element level, leveraging the existing `Group.scale` method. it's not clear to me if there's a more efficient way to do this