### PR TITLE
Address mina-signer audit, Pt 2: Low-level crypto tests

### DIFF
--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -209,7 +209,8 @@ function createCurveProjective(
     toAffine(g: GroupProjective) {
       return projectiveToAffine(g, p);
     },
-    fromAffine({ x, y }: GroupAffine) {
+    fromAffine({ x, y, infinity }: GroupAffine) {
+      if (infinity) return projectiveZero;
       return { x, y, z: 1n };
     },
   };

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -134,7 +134,7 @@ function projectiveEqual(g: GroupProjective, h: GroupProjective, p: bigint) {
   let hz3 = mod(hz2 * h.z, p);
   return (
     mod(g.x * hz2, p) === mod(h.x * gz2, p) &&
-    mod(g.y * gz3, p) === mod(h.y * hz3, p)
+    mod(g.y * hz3, p) === mod(h.y * gz3, p)
   );
 }
 

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -152,6 +152,7 @@ function projectiveEqual(g: GroupProjective, h: GroupProjective, p: bigint) {
 function projectiveOnCurve({ x, y, z }: GroupProjective, p: bigint) {
   // substitution x -> x/z^2 and y -> y/z^3 gives
   // the equation y^2 = x^3 + b*z^6
+  // (note: we allow a restricted set of x,y for z==0; this seems fine)
   let x3 = mod(mod(x * x, p) * x, p);
   let y2 = mod(y * y, p);
   let z3 = mod(mod(z * z, p) * z, p);
@@ -170,6 +171,7 @@ function createCurveProjective(
     one: generator,
     endoBase,
     endoScalar,
+    b,
 
     equal(g: GroupProjective, h: GroupProjective) {
       return projectiveEqual(g, h, p);

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -209,7 +209,7 @@ function createCurveProjective(
     toAffine(g: GroupProjective) {
       return projectiveToAffine(g, p);
     },
-    ofAffine({ x, y }: GroupAffine) {
+    fromAffine({ x, y }: GroupAffine) {
       return { x, y, z: 1n };
     },
   };

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -1,4 +1,3 @@
-import { bytesToBigInt } from './bigint-helpers.js';
 import { inverse, mod, p, q } from './finite_field.js';
 export { Pallas, Vesta, GroupAffine, GroupProjective };
 
@@ -14,6 +13,15 @@ const vestaGeneratorProjective = {
   y: 11426906929455361843568202299992114520848200991084027513389447476559454104162n,
   z: 1n,
 };
+const vestaEndoBase =
+  2942865608506852014473558576493638302197734138389222805617480874486368177743n;
+const pallasEndoBase =
+  20444556541222657078399132219657928148671392403212669005631716460534733845831n;
+const vestaEndoScalar =
+  8503465768106391777493614032514048814691664078728891710322960303815233784505n;
+const pallasEndoScalar =
+  26005156700822196841419187675678338661165322343552424574062261873906994770353n;
+
 // the b in y^2 = x^3 + b
 const b = 5n;
 
@@ -195,6 +203,9 @@ function createCurveProjective(
     scale(g: GroupProjective, s: bigint) {
       return projectiveScale(g, s, p);
     },
+    endomorphism({ x, y, z }: GroupProjective) {
+      return { x: mod(endoBase * x, p), y, z };
+    },
     toAffine(g: GroupProjective) {
       return projectiveToAffine(g, p);
     },
@@ -203,32 +214,6 @@ function createCurveProjective(
     },
   };
 }
-
-// TODO check if these really should be hardcoded, otherwise compute them
-const vestaEndoBase = bytesToBigInt(
-  new Uint8Array([
-    79, 14, 170, 80, 224, 210, 169, 42, 175, 51, 192, 71, 125, 70, 237, 15, 90,
-    15, 247, 28, 216, 180, 29, 81, 142, 82, 62, 40, 88, 154, 129, 6,
-  ])
-);
-const pallasEndoBase = bytesToBigInt(
-  new Uint8Array([
-    71, 181, 1, 2, 47, 210, 127, 123, 210, 199, 159, 209, 41, 13, 39, 5, 80, 78,
-    85, 168, 35, 42, 85, 211, 142, 69, 50, 181, 124, 53, 51, 45,
-  ])
-);
-const vestaEndoScalar = bytesToBigInt(
-  new Uint8Array([
-    185, 74, 254, 253, 189, 94, 173, 29, 73, 49, 173, 55, 210, 139, 31, 29, 176,
-    177, 170, 87, 220, 213, 170, 44, 113, 186, 205, 74, 131, 202, 204, 18,
-  ])
-);
-const pallasEndoScalar = bytesToBigInt(
-  new Uint8Array([
-    177, 241, 85, 175, 64, 24, 157, 97, 46, 117, 212, 193, 126, 82, 89, 18, 166,
-    240, 8, 227, 39, 75, 226, 174, 113, 173, 193, 215, 167, 101, 126, 57,
-  ])
-);
 
 const Pallas = createCurveProjective(
   p,

--- a/src/js_crypto/elliptic_curve.ts
+++ b/src/js_crypto/elliptic_curve.ts
@@ -149,7 +149,7 @@ function projectiveEqual(g: GroupProjective, h: GroupProjective, p: bigint) {
   return mod(g.y * hz3, p) === mod(h.y * gz3, p);
 }
 
-function projectiveOnCurve({ x, y, z }: GroupProjective, p: bigint) {
+function projectiveOnCurve({ x, y, z }: GroupProjective, p: bigint, b: bigint) {
   // substitution x -> x/z^2 and y -> y/z^3 gives
   // the equation y^2 = x^3 + b*z^6
   // (note: we allow a restricted set of x,y for z==0; this seems fine)
@@ -164,7 +164,8 @@ function createCurveProjective(
   p: bigint,
   generator: GroupProjective,
   endoBase: bigint,
-  endoScalar: bigint
+  endoScalar: bigint,
+  b: bigint
 ) {
   return {
     zero: projectiveZero,
@@ -177,7 +178,7 @@ function createCurveProjective(
       return projectiveEqual(g, h, p);
     },
     isOnCurve(g: GroupProjective) {
-      return projectiveOnCurve(g, p);
+      return projectiveOnCurve(g, p, b);
     },
     add(g: GroupProjective, h: GroupProjective) {
       return projectiveAdd(g, h, p);
@@ -233,11 +234,13 @@ const Pallas = createCurveProjective(
   p,
   pallasGeneratorProjective,
   pallasEndoBase,
-  pallasEndoScalar
+  pallasEndoScalar,
+  b
 );
 const Vesta = createCurveProjective(
   q,
   vestaGeneratorProjective,
   vestaEndoBase,
-  vestaEndoScalar
+  vestaEndoScalar,
+  b
 );

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -71,4 +71,12 @@ for (let [G, Field, Scalar] of [
     G.equal(G.scale(X, Scalar.mul(x, y)), G.scale(G.scale(X, x), y)),
     'scale / multiply is associative'
   );
+
+  // endomorphism
+  assert.equal(Field.power(G.endoBase, 3n), 1n, 'cube root in base field');
+  assert.equal(Scalar.power(G.endoScalar, 3n), 1n, 'cube root in scalar field');
+  assert(
+    G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
+    'efficient endomorphism'
+  );
 }

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -79,4 +79,14 @@ for (let [G, Field, Scalar] of [
     G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
     'efficient endomorphism'
   );
+
+  // affine
+  let affineX = G.toAffine(X);
+  assert(G.equal(G.fromAffine(affineX), X), 'affine - projective roundtrip');
+  let { x: xa, y: ya } = affineX;
+  assert.equal(
+    Field.square(ya),
+    Field.add(Field.power(xa, 3n), G.b),
+    'affine on curve'
+  );
 }

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -1,92 +1,124 @@
 import { Pallas, Vesta } from './elliptic_curve.js';
 import { Fp, Fq } from './finite_field.js';
 import assert from 'node:assert/strict';
+import { test, Random } from '../lib/testing/property.js';
 
 for (let [G, Field, Scalar] of [
   [Pallas, Fp, Fq] as const,
   [Vesta, Fq, Fp] as const,
 ]) {
-  // some random scalars
-  let [x, y] = [Scalar.random(), Scalar.random()];
-
-  // create random points by scaling 1 with a random scalar
-  let X = G.scale(G.one, Scalar.random());
-  let Y = G.scale(G.one, Scalar.random());
-  let Z = G.scale(G.one, Scalar.random());
-
-  // check on curve
-  assert(G.isOnCurve(G.zero), 'on curve');
-  assert(G.isOnCurve(G.one), 'on curve');
-  assert(G.isOnCurve(X) && G.isOnCurve(Y) && G.isOnCurve(Z), 'on curve');
-  // can't be on curve because b=5 is a non-square
-  assert(!Field.isSquare(G.b));
-  assert(!G.isOnCurve({ x: 0n, y, z: 1n }), 'x=0 => y^2 = b is not on curve');
-  // can't be on curve because the implied equation is x^6 = x^6 + b
-  assert(
-    !G.isOnCurve({ x: Scalar.power(x, 2n), y: Scalar.power(x, 3n), z: 1n }),
-    'x^3 = y^2 is not on curve'
-  );
-
-  // equal
-  assert(G.equal(G.zero, G.zero), 'equal');
-  assert(G.equal(G.one, G.one), 'equal');
-  assert(!G.equal(G.one, G.zero), 'not equal');
-  assert(G.equal(X, X), 'equal');
-  assert(!G.equal(X, Y), 'not equal');
-  // case where `equal` checks non-trivial z relationship
-  let z_ = Field.random();
-  let X_ = {
-    x: Field.mul(X.x, Field.square(z_)),
-    y: Field.mul(X.y, Field.power(z_, 3n)),
-    z: Field.mul(X.z, z_),
-  };
-  assert(G.equal(X, X_), 'equal non-trivial');
-
-  // algebraic laws - addition
-  assert(G.equal(G.add(X, Y), G.add(Y, X)), 'commutative');
-  assert(G.equal(G.add(X, G.add(Y, Z)), G.add(G.add(X, Y), Z)), 'associative');
-  assert(G.equal(G.add(X, G.zero), X), 'identity');
-  assert(G.equal(G.add(X, G.negate(X)), G.zero), 'inverse');
-
-  // addition does doubling
-  assert(G.equal(G.add(X, X), G.double(X)), 'double');
-
-  // scaling by small factors
-  assert(G.equal(G.scale(X, 0n), G.zero), 'scale by 0');
-  assert(G.equal(G.scale(X, 1n), X), 'scale by 1');
-  assert(G.equal(G.scale(X, 2n), G.add(X, X)), 'scale by 2');
-  assert(G.equal(G.scale(X, 3n), G.add(X, G.add(X, X))), 'scale by 3');
-  assert(G.equal(G.scale(X, 4n), G.double(G.double(X))), 'scale by 4');
-
-  // algebraic laws - scaling
-  assert(
-    G.equal(G.scale(X, Scalar.add(x, y)), G.add(G.scale(X, x), G.scale(X, y))),
-    'distributive'
-  );
-  assert(
-    G.equal(G.scale(X, Scalar.negate(x)), G.negate(G.scale(X, x))),
-    'distributive (negation)'
-  );
-  assert(
-    G.equal(G.scale(X, Scalar.mul(x, y)), G.scale(G.scale(X, x), y)),
-    'scale / multiply is associative'
-  );
-
-  // endomorphism
+  // endomorphism constants
   assert.equal(Field.power(G.endoBase, 3n), 1n, 'cube root in base field');
   assert.equal(Scalar.power(G.endoScalar, 3n), 1n, 'cube root in scalar field');
-  assert(
-    G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
-    'efficient endomorphism'
+
+  let randomScalar = Random(Scalar.random);
+  let randomField = Random(Field.random);
+  // create random points by scaling 1 with a random scalar
+  let randomPoint = Random(() => G.scale(G.one, Scalar.random()));
+  // let one / zero be sampled 20% of times each
+  randomPoint = Random.oneOf(
+    G.zero,
+    G.one,
+    randomPoint,
+    randomPoint,
+    randomPoint
   );
 
-  // affine
-  let affineX = G.toAffine(X);
-  assert(G.equal(G.fromAffine(affineX), X), 'affine - projective roundtrip');
-  let { x: xa, y: ya } = affineX;
-  assert.equal(
-    Field.square(ya),
-    Field.add(Field.power(xa, 3n), G.b),
-    'affine on curve'
+  test(
+    randomPoint,
+    randomPoint,
+    randomPoint,
+    randomScalar,
+    randomScalar,
+    randomField,
+    (X, Y, Z, x, y, z_) => {
+      // check on curve
+      assert(G.isOnCurve(X) && G.isOnCurve(Y) && G.isOnCurve(Z), 'on curve');
+      // can't be on curve because b=5 is a non-square
+      assert(!Field.isSquare(G.b));
+      assert(
+        !G.isOnCurve({ x: 0n, y, z: 1n }),
+        'x=0 => y^2 = b is not on curve'
+      );
+      // can't be on curve because the implied equation is x^6 = x^6 + b
+      assert(
+        !G.isOnCurve({ x: Scalar.power(x, 2n), y: Scalar.power(x, 3n), z: 1n }),
+        'x^3 = y^2 is not on curve'
+      );
+
+      // equal
+      assert(G.equal(X, X), 'equal');
+      assert(
+        !G.equal(X, G.add(X, X)) || G.equal(X, G.zero),
+        'not equal to double of itself (or zero)'
+      );
+      assert(
+        !G.equal(X, G.negate(X)) || G.equal(X, G.zero),
+        'not equal to negation of itself (or zero)'
+      );
+      assert(!G.equal(X, Y) || X === Y, 'not equal (random points)');
+      // case where `equal` checks non-trivial z relationship
+      let X_ = {
+        x: Field.mul(X.x, Field.square(z_)),
+        y: Field.mul(X.y, Field.power(z_, 3n)),
+        z: Field.mul(X.z, z_),
+      };
+      assert(G.equal(X, X_), 'equal non-trivial');
+
+      // algebraic laws - addition
+      assert(G.equal(G.add(X, Y), G.add(Y, X)), 'commutative');
+      assert(
+        G.equal(G.add(X, G.add(Y, Z)), G.add(G.add(X, Y), Z)),
+        'associative'
+      );
+      assert(G.equal(G.add(X, G.zero), X), 'identity');
+      assert(G.equal(G.add(X, G.negate(X)), G.zero), 'inverse');
+
+      // addition does doubling
+      assert(G.equal(G.add(X, X), G.double(X)), 'double');
+
+      // scaling by small factors
+      assert(G.equal(G.scale(X, 0n), G.zero), 'scale by 0');
+      assert(G.equal(G.scale(X, 1n), X), 'scale by 1');
+      assert(G.equal(G.scale(X, 2n), G.add(X, X)), 'scale by 2');
+      assert(G.equal(G.scale(X, 3n), G.add(X, G.add(X, X))), 'scale by 3');
+      assert(G.equal(G.scale(X, 4n), G.double(G.double(X))), 'scale by 4');
+
+      // algebraic laws - scaling
+      assert(
+        G.equal(
+          G.scale(X, Scalar.add(x, y)),
+          G.add(G.scale(X, x), G.scale(X, y))
+        ),
+        'distributive'
+      );
+      assert(
+        G.equal(G.scale(X, Scalar.negate(x)), G.negate(G.scale(X, x))),
+        'distributive (negation)'
+      );
+      assert(
+        G.equal(G.scale(X, Scalar.mul(x, y)), G.scale(G.scale(X, x), y)),
+        'scale / multiply is associative'
+      );
+
+      // endomorphism
+      assert(
+        G.equal(G.endomorphism(X), G.scale(X, G.endoScalar)),
+        'efficient endomorphism'
+      );
+
+      // affine
+      let affineX = G.toAffine(X);
+      assert(
+        G.equal(G.fromAffine(affineX), X),
+        'affine - projective roundtrip'
+      );
+      let { x: xa, y: ya } = affineX;
+      assert(
+        G.equal(X, G.zero) ||
+          Field.square(ya) === Field.add(Field.power(xa, 3n), G.b),
+        'affine on curve (or zero)'
+      );
+    }
   );
 }

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -1,0 +1,21 @@
+import { Pallas, Vesta } from './elliptic_curve.js';
+import { Fp, Fq } from './finite_field.js';
+import assert from 'node:assert/strict';
+
+for (let [G, Field, Scalar] of [
+  [Pallas, Fp, Fq] as const,
+  [Vesta, Fq, Fp] as const,
+]) {
+  // some random scalars
+  let [x, y, z] = [Scalar.random(), Scalar.random(), Scalar.random()];
+
+  // create random points by scaling 1 with a random scalar
+  let X = G.scale(G.one, Scalar.random());
+  let Y = G.scale(G.one, Scalar.random());
+  let Z = G.scale(G.one, Scalar.random());
+
+  // algebraic laws
+  assert.equal(G.add(X, Y), G.add(Y, X), 'commutative');
+  assert.equal(G.add(X, G.add(Y, Z)), G.add(G.add(X, Y), Z), 'associative');
+  assert.equal(G.add(X, G.zero), X);
+}

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -14,8 +14,23 @@ for (let [G, Field, Scalar] of [
   let Y = G.scale(G.one, Scalar.random());
   let Z = G.scale(G.one, Scalar.random());
 
+  // equal
+  assert(G.equal(G.zero, G.zero), 'equal');
+  assert(G.equal(G.one, G.one), 'equal');
+  assert(!G.equal(G.one, G.zero), 'equal');
+  assert(G.equal(X, X), 'equal');
+  assert(!G.equal(X, Y), 'equal');
+  // case where `equal` checks non-trivial z relationship
+  let z_ = Field.random();
+  let X_ = {
+    x: Field.mul(X.x, Field.square(z_)),
+    y: Field.mul(X.y, Field.power(z_, 3n)),
+    z: Field.mul(X.z, z_),
+  };
+  assert(G.equal(X, X_), 'equal non-trivial');
+
   // algebraic laws
-  assert.equal(G.add(X, Y), G.add(Y, X), 'commutative');
-  assert.equal(G.add(X, G.add(Y, Z)), G.add(G.add(X, Y), Z), 'associative');
-  assert.equal(G.add(X, G.zero), X);
+  assert(G.equal(G.add(X, Y), G.add(Y, X)), 'commutative');
+  assert(G.equal(G.add(X, G.add(Y, Z)), G.add(G.add(X, Y), Z)), 'associative');
+  assert(G.equal(G.add(X, G.zero), X), 'identity');
 }

--- a/src/js_crypto/elliptic_curve.unit-test.ts
+++ b/src/js_crypto/elliptic_curve.unit-test.ts
@@ -31,7 +31,7 @@ for (let [G, Field, Scalar] of [
     randomScalar,
     randomScalar,
     randomField,
-    (X, Y, Z, x, y, z_) => {
+    (X, Y, Z, x, y, f) => {
       // check on curve
       assert(G.isOnCurve(X) && G.isOnCurve(Y) && G.isOnCurve(Z), 'on curve');
       // can't be on curve because b=5 is a non-square
@@ -40,9 +40,9 @@ for (let [G, Field, Scalar] of [
         !G.isOnCurve({ x: 0n, y, z: 1n }),
         'x=0 => y^2 = b is not on curve'
       );
-      // can't be on curve because the implied equation is x^6 = x^6 + b
+      // can't be on curve because the implied equation is f^6 = f^6 + b
       assert(
-        !G.isOnCurve({ x: Scalar.power(x, 2n), y: Scalar.power(x, 3n), z: 1n }),
+        !G.isOnCurve({ x: Field.power(f, 2n), y: Field.power(f, 3n), z: 1n }),
         'x^3 = y^2 is not on curve'
       );
 
@@ -59,9 +59,9 @@ for (let [G, Field, Scalar] of [
       assert(!G.equal(X, Y) || X === Y, 'not equal (random points)');
       // case where `equal` checks non-trivial z relationship
       let X_ = {
-        x: Field.mul(X.x, Field.square(z_)),
-        y: Field.mul(X.y, Field.power(z_, 3n)),
-        z: Field.mul(X.z, z_),
+        x: Field.mul(X.x, Field.square(f)),
+        y: Field.mul(X.y, Field.power(f, 3n)),
+        z: Field.mul(X.z, f),
       };
       assert(G.equal(X, X_), 'equal non-trivial');
 

--- a/src/js_crypto/finite-field.unit-test.ts
+++ b/src/js_crypto/finite-field.unit-test.ts
@@ -1,5 +1,6 @@
 import { Fp, Fq } from './finite_field.js';
 import assert from 'node:assert/strict';
+import { Random, test } from '../lib/testing/property.js';
 
 for (let F of [Fp, Fq]) {
   // t is computed correctly from p = 2^32 * t + 1
@@ -22,73 +23,78 @@ for (let F of [Fp, Fq]) {
 
   // field arithmetic tests
   let p = F.modulus;
-  let [x, y, z] = [F.random(), F.random(), F.random()];
+  let randomF = Random(F.random);
+  test(randomF, randomF, randomF, (x, y, z) => {
+    assert.equal(F.add(1n, 1n), 2n, 'add');
+    assert.equal(F.add(p - 1n, 2n), 1n, 'add');
+    assert.equal(F.sub(3n, 3n), 0n, 'sub');
+    assert.equal(F.sub(3n, 8n), p - 5n, 'sub');
+    assert.equal(F.negate(5n), p - 5n, 'negate');
+    assert.equal(F.add(x, F.negate(x)), 0n, 'add & negate');
+    assert.equal(F.sub(F.add(x, y), x), y, 'add & sub');
+    assert.equal(F.isEven(17n), false, 'isEven');
+    assert.equal(F.isEven(p - 1n), true, 'isEven');
 
-  assert.equal(F.add(1n, 1n), 2n, 'add');
-  assert.equal(F.add(p - 1n, 2n), 1n, 'add');
-  assert.equal(F.sub(3n, 3n), 0n, 'sub');
-  assert.equal(F.sub(3n, 8n), p - 5n, 'sub');
-  assert.equal(F.negate(5n), p - 5n, 'negate');
-  assert.equal(F.add(x, F.negate(x)), 0n, 'add & negate');
-  assert.equal(F.sub(F.add(x, y), x), y, 'add & sub');
-  assert.equal(F.isEven(17n), false, 'isEven');
-  assert.equal(F.isEven(p - 1n), true, 'isEven');
+    assert.equal(F.mul(p - 1n, 2n), p - 2n, 'mul');
+    assert.equal(F.mul(p - 3n, p - 3n), 9n, 'mul');
+    assert.equal(
+      F.mul(F.mul(x, y), z),
+      F.mul(x, F.mul(y, z)),
+      'mul associative'
+    );
+    assert.equal(
+      F.mul(z, F.add(x, y)),
+      F.add(F.mul(z, x), F.mul(z, y)),
+      'mul distributive'
+    );
 
-  assert.equal(F.mul(p - 1n, 2n), p - 2n, 'mul');
-  assert.equal(F.mul(p - 3n, p - 3n), 9n, 'mul');
-  assert.equal(F.mul(F.mul(x, y), z), F.mul(x, F.mul(y, z)), 'mul associative');
-  assert.equal(
-    F.mul(z, F.add(x, y)),
-    F.add(F.mul(z, x), F.mul(z, y)),
-    'mul distributive'
-  );
+    assert.equal(F.inverse(0n), undefined, '0 has no inverse');
+    assert.equal(F.inverse(1n), 1n, 'inverse 1');
+    assert.equal(F.inverse(2n), (p + 1n) / 2n, 'inverse 2');
+    assert.equal(F.inverse(F.negate(2n)), (p - 1n) / 2n, 'inverse -2');
+    if (p % 3n === 1n) {
+      assert.equal(F.inverse(3n), p - (p - 1n) / 3n, 'inverse 3');
+    } else {
+      assert.equal(F.inverse(3n), (p + 1n) / 3n, 'inverse 3');
+    }
+    let xInv = F.inverse(x);
+    assert(xInv !== undefined, 'random x is invertible');
+    assert.equal(F.mul(xInv, x), 1n, 'inverse & mul');
 
-  assert.equal(F.inverse(0n), undefined, '0 has no inverse');
-  assert.equal(F.inverse(1n), 1n, 'inverse 1');
-  assert.equal(F.inverse(2n), (p + 1n) / 2n, 'inverse 2');
-  assert.equal(F.inverse(F.negate(2n)), (p - 1n) / 2n, 'inverse -2');
-  if (p % 3n === 1n) {
-    assert.equal(F.inverse(3n), p - (p - 1n) / 3n, 'inverse 3');
-  } else {
-    assert.equal(F.inverse(3n), (p + 1n) / 3n, 'inverse 3');
-  }
-  let xInv = F.inverse(x);
-  assert(xInv !== undefined, 'random x is invertible');
-  assert.equal(F.mul(xInv, x), 1n, 'inverse & mul');
+    assert.equal(F.div(1n, 0n), undefined, 'div');
+    assert.equal(F.div(21n, F.negate(7n)), p - 3n, 'div');
+    assert.equal(F.div(y, x), F.mul(y, xInv), 'div & inverse');
 
-  assert.equal(F.div(1n, 0n), undefined, 'div');
-  assert.equal(F.div(21n, F.negate(7n)), p - 3n, 'div');
-  assert.equal(F.div(y, x), F.mul(y, xInv), 'div & inverse');
+    assert.equal(F.square(F.negate(10n)), 100n, 'square');
+    let squareX = F.square(x);
+    assert(F.isSquare(squareX), 'square + isSquare');
+    assert([x, F.negate(x)].includes(F.sqrt(squareX)!), 'square + sqrt');
+    assert(F.isSquare(p - 1n), 'isSquare -1');
+    let i = F.power(F.twoadicRoot, 1n << 30n);
+    assert([i, F.negate(i)].includes(F.sqrt(p - 1n)!), 'sqrt -1');
 
-  assert.equal(F.square(F.negate(10n)), 100n, 'square');
-  let squareX = F.square(x);
-  assert(F.isSquare(squareX), 'square + isSquare');
-  assert([x, F.negate(x)].includes(F.sqrt(squareX)!), 'square + sqrt');
-  assert(F.isSquare(p - 1n), 'isSquare -1');
-  let i = F.power(F.twoadicRoot, 1n << 30n);
-  assert([i, F.negate(i)].includes(F.sqrt(p - 1n)!), 'sqrt -1');
+    assert.equal(F.power(F.negate(2n), 3n), F.negate(8n), 'power');
+    assert.equal(F.power(2n, p - 1n), 1n, 'power mod p-1');
+    assert.equal(F.power(2n, p - 1n + 3n), 8n, 'power mod p-1');
+    assert.equal(F.power(x, 4n), F.square(F.square(x)), 'power');
+    assert.equal(
+      F.power(x, y + z),
+      F.mul(F.power(x, y), F.power(x, z)),
+      'power & mul'
+    );
 
-  assert.equal(F.power(F.negate(2n), 3n), F.negate(8n), 'power');
-  assert.equal(F.power(2n, p - 1n), 1n, 'power mod p-1');
-  assert.equal(F.power(2n, p - 1n + 3n), 8n, 'power mod p-1');
-  assert.equal(F.power(x, 4n), F.square(F.square(x)), 'power');
-  assert.equal(
-    F.power(x, y + z),
-    F.mul(F.power(x, y), F.power(x, z)),
-    'power & mul'
-  );
+    assert.equal(F.dot([x, y], [y, x]), F.mul(2n, F.mul(x, y)), 'dot');
+    assert.equal(F.dot([x, y], [F.negate(y), x]), 0n, 'dot');
 
-  assert.equal(F.dot([x, y], [y, x]), F.mul(2n, F.mul(x, y)), 'dot');
-  assert.equal(F.dot([x, y], [F.negate(y), x]), 0n, 'dot');
+    assert(x > 1n << 128n, 'random x is large');
+    assert(x < p - (1n << 128n), 'random x is not small negative');
 
-  assert(x > 1n << 128n, 'random x is large');
-  assert(x < p - (1n << 128n), 'random x is not small negative');
-
-  assert.equal(F.fromNumber(-1), p - 1n, 'fromNumber');
-  assert.equal(F.fromBigint(-1n), p - 1n, 'fromBigint');
-  assert.equal(F.fromBigint(p + 1n), 1n, 'fromBigint');
-  assert(F.equal(10n, 10n), 'equal');
-  assert(F.equal(p - 10n, F.fromNumber(-10)), 'equal + fromNumber');
-  assert(F.equal(10n, F.fromBigint(p + 10n)), 'equal + fromBigint');
-  assert(!F.equal(5n, p - 5n), 'not equal');
+    assert.equal(F.fromNumber(-1), p - 1n, 'fromNumber');
+    assert.equal(F.fromBigint(-1n), p - 1n, 'fromBigint');
+    assert.equal(F.fromBigint(p + 1n), 1n, 'fromBigint');
+    assert(F.equal(10n, 10n), 'equal');
+    assert(F.equal(p - 10n, F.fromNumber(-10)), 'equal + fromNumber');
+    assert(F.equal(10n, F.fromBigint(p + 10n)), 'equal + fromBigint');
+    assert(!F.equal(5n, p - 5n), 'not equal');
+  });
 }

--- a/src/js_crypto/finite-field.unit-test.ts
+++ b/src/js_crypto/finite-field.unit-test.ts
@@ -81,6 +81,9 @@ for (let F of [Fp, Fq]) {
   assert.equal(F.dot([x, y], [y, x]), F.mul(2n, F.mul(x, y)), 'dot');
   assert.equal(F.dot([x, y], [F.negate(y), x]), 0n, 'dot');
 
+  assert(x > 1n << 128n, 'random x is large');
+  assert(x < p - (1n << 128n), 'random x is not small negative');
+
   assert.equal(F.fromNumber(-1), p - 1n, 'fromNumber');
   assert.equal(F.fromBigint(-1n), p - 1n, 'fromBigint');
   assert.equal(F.fromBigint(p + 1n), 1n, 'fromBigint');

--- a/src/js_crypto/finite-field.unit-test.ts
+++ b/src/js_crypto/finite-field.unit-test.ts
@@ -1,22 +1,91 @@
 import { Fp, Fq } from './finite_field.js';
+import assert from 'node:assert/strict';
 
 for (let F of [Fp, Fq]) {
   // t is computed correctly from p = 2^32 * t + 1
-  console.assert(F.t * (1n << 32n) + 1n === F.modulus);
+  assert(F.t * (1n << 32n) + 1n === F.modulus, 't is computed correctly');
 
   // the primitive root of unity is computed correctly as 5^t
   let generator = 5n;
   let rootFp = F.power(generator, F.t);
-  console.assert(rootFp === F.twoadicRoot);
+  assert(rootFp === F.twoadicRoot, 'root of unity is computed correctly');
 
   // the primitive roots of unity `r` actually satisfy the equations defining them:
-  // r^(2^32) === 1, r^(2^31) !== 1
   let shouldBe1 = F.power(F.twoadicRoot, 1n << 32n);
   let shouldBeMinus1 = F.power(F.twoadicRoot, 1n << 31n);
-  console.assert(shouldBe1 === 1n);
-  console.assert(shouldBeMinus1 + 1n === F.modulus);
+  assert(shouldBe1 === 1n, 'r^(2^32) === 1');
+  assert(shouldBeMinus1 + 1n === F.modulus, 'r^(2^32) === 1');
 
   // the primitive roots of unity are non-squares
   // -> verifies that the two-adicity is 32, and that they can be used as non-squares in the sqrt algorithm
-  console.assert(!F.isSquare(F.twoadicRoot));
+  assert(!F.isSquare(F.twoadicRoot), 'roots of unity are non-squares');
+
+  // field arithmetic tests
+  let p = F.modulus;
+  let [x, y, z] = [F.random(), F.random(), F.random()];
+
+  assert.equal(F.add(1n, 1n), 2n, 'add');
+  assert.equal(F.add(p - 1n, 2n), 1n, 'add');
+  assert.equal(F.sub(3n, 3n), 0n, 'sub');
+  assert.equal(F.sub(3n, 8n), p - 5n, 'sub');
+  assert.equal(F.negate(5n), p - 5n, 'negate');
+  assert.equal(F.add(x, F.negate(x)), 0n, 'add & negate');
+  assert.equal(F.sub(F.add(x, y), x), y, 'add & sub');
+  assert.equal(F.isEven(17n), false, 'isEven');
+  assert.equal(F.isEven(p - 1n), true, 'isEven');
+
+  assert.equal(F.mul(p - 1n, 2n), p - 2n, 'mul');
+  assert.equal(F.mul(p - 3n, p - 3n), 9n, 'mul');
+  assert.equal(F.mul(F.mul(x, y), z), F.mul(x, F.mul(y, z)), 'mul associative');
+  assert.equal(
+    F.mul(z, F.add(x, y)),
+    F.add(F.mul(z, x), F.mul(z, y)),
+    'mul distributive'
+  );
+
+  assert.equal(F.inverse(0n), undefined, '0 has no inverse');
+  assert.equal(F.inverse(1n), 1n, 'inverse 1');
+  assert.equal(F.inverse(2n), (p + 1n) / 2n, 'inverse 2');
+  assert.equal(F.inverse(F.negate(2n)), (p - 1n) / 2n, 'inverse -2');
+  if (p % 3n === 1n) {
+    assert.equal(F.inverse(3n), p - (p - 1n) / 3n, 'inverse 3');
+  } else {
+    assert.equal(F.inverse(3n), (p + 1n) / 3n, 'inverse 3');
+  }
+  let xInv = F.inverse(x);
+  assert(xInv !== undefined, 'random x is invertible');
+  assert.equal(F.mul(xInv, x), 1n, 'inverse & mul');
+
+  assert.equal(F.div(1n, 0n), undefined, 'div');
+  assert.equal(F.div(21n, F.negate(7n)), p - 3n, 'div');
+  assert.equal(F.div(y, x), F.mul(y, xInv), 'div & inverse');
+
+  assert.equal(F.square(F.negate(10n)), 100n, 'square');
+  let squareX = F.square(x);
+  assert(F.isSquare(squareX), 'square + isSquare');
+  assert([x, F.negate(x)].includes(F.sqrt(squareX)!), 'square + sqrt');
+  assert(F.isSquare(p - 1n), 'isSquare -1');
+  let i = F.power(F.twoadicRoot, 1n << 30n);
+  assert([i, F.negate(i)].includes(F.sqrt(p - 1n)!), 'sqrt -1');
+
+  assert.equal(F.power(F.negate(2n), 3n), F.negate(8n), 'power');
+  assert.equal(F.power(2n, p - 1n), 1n, 'power mod p-1');
+  assert.equal(F.power(2n, p - 1n + 3n), 8n, 'power mod p-1');
+  assert.equal(F.power(x, 4n), F.square(F.square(x)), 'power');
+  assert.equal(
+    F.power(x, y + z),
+    F.mul(F.power(x, y), F.power(x, z)),
+    'power & mul'
+  );
+
+  assert.equal(F.dot([x, y], [y, x]), F.mul(2n, F.mul(x, y)), 'dot');
+  assert.equal(F.dot([x, y], [F.negate(y), x]), 0n, 'dot');
+
+  assert.equal(F.fromNumber(-1), p - 1n, 'fromNumber');
+  assert.equal(F.fromBigint(-1n), p - 1n, 'fromBigint');
+  assert.equal(F.fromBigint(p + 1n), 1n, 'fromBigint');
+  assert(F.equal(10n, 10n), 'equal');
+  assert(F.equal(p - 10n, F.fromNumber(-10)), 'equal + fromNumber');
+  assert(F.equal(10n, F.fromBigint(p + 10n)), 'equal + fromBigint');
+  assert(!F.equal(5n, p - 5n), 'not equal');
 }

--- a/src/js_crypto/finite_field.ts
+++ b/src/js_crypto/finite_field.ts
@@ -185,30 +185,3 @@ function createField(p: bigint, t: bigint, twoadicRoot: bigint) {
     },
   };
 }
-
-// TESTS (activate by setting caml_bindings_debug = true)
-
-let caml_bindings_debug = false;
-
-if (caml_bindings_debug) test();
-
-function test() {
-  // t is computed correctly from p = 2^32 * t + 1
-  console.assert(pMinusOneOddFactor * (1n << 32n) + 1n === p);
-
-  // the primitive root of unity is computed correctly as 5^t
-  let generator = 5n;
-  let rootFp = power(generator, pMinusOneOddFactor, p);
-  console.assert(rootFp === twoadicRootFp);
-
-  // the primitive roots of unity `r` actually satisfy the equations defining them:
-  // r^(2^32) === 1, r^(2^31) !== 1
-  let shouldBe1 = power(twoadicRootFp, 1n << 32n, p);
-  let shouldBeMinus1 = power(twoadicRootFp, 1n << 31n, p);
-  console.assert(shouldBe1 === 1n);
-  console.assert(shouldBeMinus1 + 1n === p);
-
-  // the primitive roots of unity are non-squares
-  // -> verifies that the two-adicity is 32, and that they can be used as non-squares in the sqrt algorithm
-  console.assert(!Fp.isSquare(twoadicRootFp));
-}

--- a/src/provable/curve-bigint.ts
+++ b/src/provable/curve-bigint.ts
@@ -34,7 +34,7 @@ type PrivateKey = bigint;
  */
 const Group = {
   toProjective({ x, y }: Group): GroupProjective {
-    return Pallas.ofAffine({ x, y, infinity: false });
+    return Pallas.fromAffine({ x, y, infinity: false });
   },
   /**
    * Convert a projective point to a non-zero affine point.

--- a/src/provable/curve-bigint.ts
+++ b/src/provable/curve-bigint.ts
@@ -61,7 +61,7 @@ let BinablePublicKey = withVersionNumber(
     record({ x: FieldWithVersion, isOdd: Bool }, ['x', 'isOdd']),
     ({ x }) => {
       let { mul, add } = Field;
-      let ySquared = add(mul(x, mul(x, x)), 5n);
+      let ySquared = add(mul(x, mul(x, x)), Pallas.b);
       if (!Field.isSquare(ySquared)) {
         throw Error('PublicKey: not a valid group element');
       }

--- a/src/provable/curve-bigint.ts
+++ b/src/provable/curve-bigint.ts
@@ -86,7 +86,7 @@ const PublicKey = {
 
   toGroup({ x, isOdd }: PublicKey): Group {
     let { mul, add } = Field;
-    let ySquared = add(mul(x, mul(x, x)), 5n);
+    let ySquared = add(mul(x, mul(x, x)), Pallas.b);
     let y = Field.sqrt(ySquared);
     if (y === undefined) {
       throw Error('PublicKey.toGroup: not a valid group element');


### PR DESCRIPTION
Successor to https://github.com/o1-labs/snarkyjs/pull/714

Addresses the following parts of the audit -- tests for low-level crypto arithmetic:

> ## 2 Test coverage
> Result: FAIL
> * js_crypto's field arithmetic methods do not have individual unit tests
> * js_crypto should have low-level tests to verify fundamental group operations
>   * Addition is commutative X + Y == Y + X
>   * Associativity X + (Y + Z) == (X + Y) z
>   * Identity I + X == X + I == X
>   * Inverse X + inv(X) == inv(X) + X == I
>   * Scaling commutes with adding scalars A * (x + y) == A * x + A * y
>   * Scaling commutes with multiplying scalars A * (x * y) == (x * y) * A
>   * Scaling commites with negation A * neg(x) == neg(A * x)
>   * Always test on curve after scaling
>   * Note: These are easy to add, so highly recommended to implement
> * js_crypto primitives sub, inverse, div, square, fromNumber and fromBigint do not have any test coverage

This PR ended up making some changes to the curve arithmetic, so in order to enable a focused review I'm leaving other missing tests for a third PR.

* Added tests for finite field and curve arithmetic
* Fixed issues that were uncovered by these tests:
  * added missing methods `Group.equal`, `Group.isOnCurve` to be able to test
  * `Group.add` was not complete addition -- failed for `Group.add(X, X)`. I added the necessary logic to fall back to doubling. Also handles the `Group.add(X, -X) = 0` case now to return zero in the default representation
* For completeness, added implementation and tests for endomorphism