### PR TITLE
Property testing for account updates

### DIFF
--- a/src/build/jsLayoutToTypes.mjs
+++ b/src/build/jsLayoutToTypes.mjs
@@ -147,7 +147,7 @@ ${
   !isJson
     ? 'export { Json };\n' +
       `export * from '${leavesRelPath}';\n` +
-      'export { provableFromLayout, toJSONEssential, Layout };\n'
+      'export { provableFromLayout, toJSONEssential, Layout, TypeMap };\n'
     : `export * from '${leavesRelPath}';\n` + 'export { TypeMap };\n'
 }
 

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -47,9 +47,11 @@ function createEvents<Field>({
       let hash = hashWithPrefix(prefixes.events, [events.hash, eventHash]);
       return { hash, data: [event, ...events.data] };
     },
+    fromList(events: Event[]): Events {
+      return [...events].reverse().reduce(Events.pushEvent, Events.empty());
+    },
     hash(events: Event[]) {
-      return [...events].reverse().reduce(Events.pushEvent, Events.empty())
-        .hash;
+      return Events.fromList(events).hash;
     },
   };
   const EventsProvable = {
@@ -81,10 +83,13 @@ function createEvents<Field>({
       ]);
       return { hash, data: [event, ...sequenceEvents.data] };
     },
-    hash(events: Event[]) {
+    fromList(events: Event[]): Events {
       return [...events]
         .reverse()
-        .reduce(SequenceEvents.pushEvent, SequenceEvents.empty()).hash;
+        .reduce(SequenceEvents.pushEvent, SequenceEvents.empty());
+    },
+    hash(events: Event[]) {
+      return this.fromList(events).hash;
     },
     // different than events
     emptySequenceState() {

--- a/src/lib/testing/property.ts
+++ b/src/lib/testing/property.ts
@@ -1,5 +1,5 @@
-import { Random, RandomAccountUpdate } from './random.js';
-export { test, Random, RandomAccountUpdate };
+import { Random } from './random.js';
+export { test, Random };
 
 const defaultTimeBudget = 100; // ms
 const isVerbose = false;
@@ -41,7 +41,6 @@ function testN<T extends readonly Random<any>[]>(
       errorMessages.push(
         `Failed: ${message ? `"${message}"` : `assertion #${count}`}`
       );
-      console.log(errorMessages);
     }
     fail ||= !ok;
   }

--- a/src/lib/testing/property.ts
+++ b/src/lib/testing/property.ts
@@ -1,7 +1,9 @@
-import { Random } from './random.js';
-export { test, Random };
+import { Random, withHardCoded } from './random.js';
+export { test, Random, withHardCoded };
 
 const defaultTimeBudget = 100; // ms
+const minRuns = 15;
+const maxRuns = 100;
 const isVerbose = false;
 
 function test<T extends readonly Random<any>[]>(...args: ArrayTestArgs<T>) {
@@ -17,16 +19,16 @@ function test<T extends readonly Random<any>[]>(...args: ArrayTestArgs<T>) {
   let gens = args as any as T;
   let nexts = gens.map((g) => g.create()) as Nexts<T>;
   let start = performance.now();
-  // run at least 10 times
-  testN(10, nexts, run);
+  // run at least `minRuns` times
+  testN(minRuns, nexts, run);
   let time = performance.now() - start;
-  if (time > timeBudget) return 10;
-  // (10 + remainingRuns) * timePerRun = timeBudget
-  let remainingRuns = Math.floor(timeBudget / (time / 10)) - 10;
-  // run at most 100 times
-  if (remainingRuns > 90) remainingRuns = 90;
+  if (time > timeBudget) return minRuns;
+  // (minRuns + remainingRuns) * timePerRun = timeBudget
+  let remainingRuns = Math.floor(timeBudget / (time / minRuns)) - minRuns;
+  // run at most `maxRuns` times
+  if (remainingRuns > maxRuns - minRuns) remainingRuns = maxRuns - minRuns;
   testN(remainingRuns, nexts, run);
-  return 10 + remainingRuns;
+  return minRuns + remainingRuns;
 }
 
 function testN<T extends readonly (() => any)[]>(

--- a/src/lib/testing/property.ts
+++ b/src/lib/testing/property.ts
@@ -1,0 +1,84 @@
+import { Random, RandomAccountUpdate } from './random.js';
+export { test, Random, RandomAccountUpdate };
+
+const defaultTimeBudget = 100; // ms
+const isVerbose = false;
+
+function test<T extends readonly Random<any>[]>(...args: ArrayTestArgs<T>) {
+  let timeBudget = defaultTimeBudget;
+  let run: (...args: ArrayRunArgs<T>) => void;
+  let arg = args.pop();
+  if (typeof arg !== 'function') {
+    if (arg !== undefined) timeBudget = (arg as any).timeBudget;
+    run = args.pop() as any;
+  } else {
+    run = arg;
+  }
+  let gens = args as any as T;
+  let start = performance.now();
+  // run at least 10 times
+  testN<T>(10, gens, run);
+  let time = performance.now() - start;
+  if (time > timeBudget) return 10;
+  // (10 + remainingRuns) * timePerRun = timeBudget
+  let remainingRuns = Math.floor(timeBudget / (time / 10)) - 10;
+  if (remainingRuns > 90) remainingRuns = 90;
+  testN<T>(remainingRuns, gens, run);
+  return 10 + remainingRuns;
+}
+
+function testN<T extends readonly Random<any>[]>(
+  N: number,
+  gens: T,
+  run: (...args: ArrayRunArgs<T>) => void
+) {
+  let errorMessages: string[] = [];
+  let fail = false;
+  let count = 0;
+  function assert(ok: boolean, message?: string) {
+    count++;
+    if (!ok) {
+      errorMessages.push(
+        `Failed: ${message ? `"${message}"` : `assertion #${count}`}`
+      );
+      console.log(errorMessages);
+    }
+    fail ||= !ok;
+  }
+  for (let i = 1; i < N; i++) {
+    fail = false;
+    let error: Error | undefined;
+    let values = gens.map((gen) => gen.next());
+    try {
+      if (isVerbose) console.log('testing', ...values);
+      (run as any)(...values, assert);
+    } catch (e: any) {
+      error = e;
+      fail = true;
+    }
+    if (fail) {
+      console.log('failing inputs:');
+      values.forEach((v) => console.dir(v, { depth: Infinity }));
+      let message = '\n' + errorMessages.join('\n');
+      if (error !== undefined) {
+        error.message = `${message}\nFailed - error during test execution:
+${error.message}`;
+        throw error;
+      }
+      throw Error(message);
+    }
+  }
+}
+
+// types
+
+type ArrayTestArgs<T extends readonly Random<any>[]> = [
+  ...gens: T,
+  run: (...args: ArrayRunArgs<T>) => void
+  // options?: { timeBudget?: number } // TODO make this work
+];
+
+type ArrayRunArgs<T extends readonly Random<any>[]> = [
+  ...values: { [K in keyof T]: T[K] extends Random<infer U> ? U : never },
+  assert: (b: boolean, message?: string) => void
+];

--- a/src/lib/testing/random.ts
+++ b/src/lib/testing/random.ts
@@ -1,0 +1,259 @@
+import {
+  customTypes,
+  Layout,
+  TypeMap,
+  Json,
+  AccountUpdate,
+} from '../../provable/gen/transaction-bigint.js';
+import * as Bigint from '../../provable/transaction-leaves-bigint.js';
+import { genericLayoutFold } from '../../provable/from-layout.js';
+import { jsLayout } from '../../provable/gen/js-layout.js';
+import { GenericProvable, primitiveTypeMap } from '../../provable/generic.js';
+import { PrivateKey } from '../../provable/curve-bigint.js';
+import { randomBytes } from '../../js_crypto/random.js';
+import { alphabet } from '../../provable/base58.js';
+
+export { RandomAccountUpdate };
+
+type Random<T> = {
+  next(): T;
+};
+function Random<T>(next: () => T): Random<T> {
+  return { next };
+}
+
+const boolean = Random(() => Math.random() > 0.5);
+const base58 = (size: number | Random<number>) =>
+  map(array(oneof(...alphabet), size), (a) => a.join(''));
+
+const Field = Random(Bigint.Field.random);
+const Bool = map(boolean, Bigint.Bool);
+const UInt32 = Random(Bigint.UInt32.random);
+const UInt64 = Random(Bigint.UInt64.random);
+const Sign = map(boolean, (b) => Bigint.Sign(b ? 1 : -1));
+const PublicKey = Random(() => PrivateKey.toPublicKey(PrivateKey.random()));
+const TokenId = Field;
+const AuthorizationKind = reject(
+  record<Bigint.AuthorizationKind>({
+    isProved: Bool,
+    isSigned: Bool,
+  }),
+  (t) => !!t.isProved && !!t.isSigned
+);
+const AuthRequired = map(
+  oneof<Json.AuthRequired[]>(
+    'None',
+    'Proof',
+    'Signature',
+    'Either',
+    'Impossible'
+  ),
+  Bigint.AuthRequired.fromJSON
+);
+const TokenSymbol = map(string(nat(6)), Bigint.TokenSymbol.fromJSON);
+const Events = map(array(array(Field, nat(5)), nat(2)), Bigint.Events.fromList);
+const SequenceEvents = Events;
+const SequenceState = oneof(Bigint.SequenceState.emptyValue(), Field);
+const ZkappUri = map(string(nat(20)), Bigint.ZkappUri.fromJSON);
+
+const PrimitiveMap = primitiveTypeMap<bigint>();
+type Types = typeof TypeMap & typeof customTypes & typeof PrimitiveMap;
+type Provable<T> = GenericProvable<T, bigint>;
+type Generators = {
+  [K in keyof Types]: Types[K] extends Provable<infer U> ? Random<U> : never;
+};
+const Generators: Generators = {
+  Field,
+  Bool,
+  UInt32,
+  UInt64,
+  Sign,
+  PublicKey,
+  TokenId,
+  AuthorizationKind,
+  AuthRequired,
+  TokenSymbol,
+  Events,
+  SequenceEvents,
+  SequenceState,
+  ZkappUri,
+  null: constant(null),
+  string: base58(50), // TODO replace various strings, like signature, with parsed types
+  number: nat(5), // TODO need richer type for call depth
+};
+let typeToGenerator = new Map<Provable<any>, Random<any>>(
+  [TypeMap, PrimitiveMap, customTypes]
+    .map(Object.entries)
+    .flat()
+    .map(([key, value]) => [value, Generators[key as keyof Generators]])
+);
+
+function generatorFromLayout<T>(typeData: Layout): Random<T> {
+  return {
+    next() {
+      return generate(typeData);
+    },
+  };
+}
+
+function generate<T>(typeData: Layout): T {
+  return genericLayoutFold<undefined, any, TypeMap, Json.TypeMap>(
+    TypeMap,
+    customTypes,
+    {
+      map(type, _, name) {
+        let gen = typeToGenerator.get(type);
+        if (gen === undefined)
+          throw Error(`could not find generator for type ${name}`);
+        return gen.next();
+      },
+      reduceArray(array) {
+        return array;
+      },
+      reduceObject(_, object) {
+        return object;
+      },
+      reduceFlaggedOption({ isSome, value }, typeData) {
+        let isSomeBoolean = TypeMap.Bool.toJSON(isSome);
+        return isSomeBoolean ? { isSome, value } : empty(typeData);
+      },
+      reduceOrUndefined(value) {
+        let isSome = this.map(TypeMap.Bool);
+        let isSomeBoolean = TypeMap.Bool.toJSON(isSome);
+        return isSomeBoolean ? value : undefined;
+      },
+    },
+    typeData,
+    undefined
+  );
+}
+
+function empty(typeData: Layout) {
+  let zero = TypeMap.Field.fromJSON('0');
+  return genericLayoutFold<undefined, any, TypeMap, Json.TypeMap>(
+    TypeMap,
+    customTypes,
+    {
+      map(type) {
+        if (type.emptyValue) return type.emptyValue();
+        return type.fromFields(
+          Array(type.sizeInFields()).fill(zero),
+          type.toAuxiliary()
+        );
+      },
+      reduceArray(array) {
+        return array;
+      },
+      reduceObject(_, object) {
+        return object;
+      },
+      reduceFlaggedOption({ isSome, value }, typeData) {
+        if (typeData.optionType === 'closedInterval') {
+          let innerInner = typeData.inner.entries.lower;
+          let innerType = TypeMap[innerInner.type as 'UInt32' | 'UInt64'];
+          value.lower = innerType.fromJSON(typeData.rangeMin);
+          value.upper = innerType.fromJSON(typeData.rangeMax);
+        }
+        return { isSome, value };
+      },
+      reduceOrUndefined() {
+        return undefined;
+      },
+    },
+    typeData,
+    undefined
+  );
+}
+
+const RandomAccountUpdate = generatorFromLayout<AccountUpdate>(
+  jsLayout.AccountUpdate as any
+);
+
+/**
+ * min and max are inclusive!
+ */
+function int(min: number, max: number): Random<number> {
+  if (max < min) throw Error('max < min');
+  return {
+    next() {
+      return min + Math.floor((max + 1 - min) * Math.random());
+    },
+  };
+}
+function nat(max: number) {
+  return int(0, max);
+}
+
+function constant<T>(t: T) {
+  return Random(() => t);
+}
+
+function bytes(size: number | Random<number>) {
+  let size_ = typeof size === 'number' ? constant(size) : size;
+  return {
+    next() {
+      return [...randomBytes(size_.next())];
+    },
+  };
+}
+function string(size: number | Random<number>) {
+  return map(bytes(size), (b) => String.fromCharCode(...b));
+}
+
+function oneof<Types extends readonly any[]>(
+  ...values: { [K in keyof Types]: Types[K] | Random<Types[K]> }
+): Random<Types[number]> {
+  type T = Types[number];
+  let I = nat(values.length - 1);
+  let isGenerator = values.map(
+    (v) => typeof v === 'object' && v && 'next' in v
+  );
+  return {
+    next(): T {
+      let i = I.next();
+      let value = values[i];
+      return isGenerator[i] ? (value as Random<T>).next() : (value as T);
+    },
+  };
+}
+function map<T, S>(rng: Random<T>, to: (t: T) => S): Random<S> {
+  return {
+    next() {
+      return to(rng.next());
+    },
+  };
+}
+
+function array<T>(
+  element: Random<T>,
+  size: number | Random<number>
+): Random<T[]> {
+  let size_ = typeof size === 'number' ? constant(size) : size;
+  return {
+    next() {
+      return Array.from({ length: size_.next() }, () => element.next());
+    },
+  };
+}
+function record<T extends {}>(gens: {
+  [K in keyof T]: Random<T[K]>;
+}): Random<T> {
+  return {
+    next() {
+      return Object.fromEntries(
+        Object.entries<Random<any>>(gens).map(([key, gen]) => [key, gen.next()])
+      ) as T;
+    },
+  };
+}
+
+function reject<T>(gen: Random<T>, isRejected: (t: T) => boolean) {
+  return {
+    next() {
+      while (true) {
+        let t = gen.next();
+        if (!isRejected(t)) return t;
+      }
+    },
+  };
+}

--- a/src/lib/testing/testing.unit-test.ts
+++ b/src/lib/testing/testing.unit-test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'expect';
+import { AccountUpdate } from '../../provable/gen/transaction-bigint.js';
+import { test, Random } from './property.js';
+
+// some trivial roundtrip tests
+test(Random.accountUpdate, (accountUpdate, assert) => {
+  let json = AccountUpdate.toJSON(accountUpdate);
+  let jsonString = JSON.stringify(json);
+  assert(
+    jsonString ===
+      JSON.stringify(AccountUpdate.toJSON(AccountUpdate.fromJSON(json)))
+  );
+  let fields = AccountUpdate.toFields(accountUpdate);
+  let auxiliary = AccountUpdate.toAuxiliary(accountUpdate);
+  let recovered = AccountUpdate.fromFields(fields, auxiliary);
+  assert(jsonString === JSON.stringify(AccountUpdate.toJSON(recovered)));
+});
+
+// check that test fails for a property that does not hold in general
+expect(() => {
+  test(Random.nat(100), Random.nat(100), (x, y, assert) => {
+    assert(x !== y, 'two different numbers can never be the same');
+  });
+}).toThrow('two different numbers');

--- a/src/mina-signer/src/transaction-hash.ts
+++ b/src/mina-signer/src/transaction-hash.ts
@@ -1,8 +1,9 @@
 import { Bool, Field, UInt64 } from '../../provable/field-bigint.js';
 import {
   Binable,
-  BinableBigintInteger,
   BinableString,
+  BinableUint64,
+  BinableUint32,
   defineBinable,
   enumWithArgument,
   record,
@@ -95,10 +96,10 @@ let BinablePublicKey = record({ x: Field, isOdd: Bool }, ['x', 'isOdd']);
 
 const Common = record<Common>(
   {
-    fee: BinableBigintInteger,
+    fee: BinableUint64,
     feePayer: BinablePublicKey,
-    nonce: BinableBigintInteger,
-    validUntil: BinableBigintInteger,
+    nonce: BinableUint32,
+    validUntil: BinableUint32,
     memo: BinableString,
   },
   ['fee', 'feePayer', 'nonce', 'validUntil', 'memo']
@@ -107,7 +108,7 @@ const Payment = record<Payment>(
   {
     source: BinablePublicKey,
     receiver: BinablePublicKey,
-    amount: BinableBigintInteger,
+    amount: BinableUint64,
   },
   ['source', 'receiver', 'amount']
 );
@@ -215,17 +216,18 @@ function userCommandToV1({ common, body }: UserCommand): UserCommandV1 {
 // another version number on `fee`, and I'm not sure what the correct answer is. I think this doesn't matter because
 // the type layout here, including version numbers, is frozen, so if it works once it'll work forever.
 const with1 = <T>(binable: Binable<T>) => withVersionNumber(binable, 1);
-const IntegerV1 = with1(with1(BinableBigintInteger));
+const Uint64V1 = with1(with1(BinableUint64));
+const Uint32V1 = with1(with1(BinableUint32));
 type CommonV1 = Common & { feeToken: UInt64 };
 const CommonV1 = with1(
   with1(
     record<CommonV1>(
       {
-        fee: with1(IntegerV1),
-        feeToken: with1(IntegerV1),
+        fee: with1(Uint64V1),
+        feeToken: with1(Uint64V1),
         feePayer: PublicKey,
-        nonce: IntegerV1,
-        validUntil: IntegerV1,
+        nonce: Uint32V1,
+        validUntil: Uint32V1,
         memo: with1(BinableString),
       },
       ['fee', 'feeToken', 'feePayer', 'nonce', 'validUntil', 'memo']
@@ -239,8 +241,8 @@ const PaymentV1 = with1(
       {
         source: PublicKey,
         receiver: PublicKey,
-        tokenId: IntegerV1,
-        amount: with1(IntegerV1),
+        tokenId: Uint64V1,
+        amount: with1(Uint64V1),
       },
       ['source', 'receiver', 'tokenId', 'amount']
     )

--- a/src/mina-signer/src/transaction-hash.unit-test.ts
+++ b/src/mina-signer/src/transaction-hash.unit-test.ts
@@ -23,6 +23,7 @@ import { Memo } from './memo.js';
 import { expect } from 'expect';
 import { versionBytes } from '../../js_crypto/constants.js';
 import { stringToBytes } from '../../provable/binable.js';
+import { Random, test } from '../../lib/testing/property.js';
 
 let signature =
   '7mWyu5cpHDvYj28RGuJKzBQkU35KgHwaM34oPxoxXbFddv1kpL3e6NdUsMZMhyrrgkgVYo5cNvfiXhtshF35ZqTmSdPcUToN';
@@ -44,6 +45,25 @@ let payment: Signed<PaymentJson> = {
   },
   signature,
 };
+let { record } = Random;
+let commonGenerator = record({
+  fee: Random.json.uint64,
+  feePayer: Random.json.publicKey,
+  nonce: Random.json.uint32,
+  validUntil: Random.json.uint32,
+  memo: Random.string(Random.nat(32)),
+});
+let paymentGenerator = record<Signed<PaymentJson>>({
+  data: record({
+    common: commonGenerator,
+    body: record({
+      source: Random.json.publicKey,
+      receiver: Random.json.publicKey,
+      amount: Random.json.uint64,
+    }),
+  }),
+  signature: Random.json.signature,
+});
 
 let delegation: Signed<DelegationJson> = {
   data: {
@@ -55,101 +75,113 @@ let delegation: Signed<DelegationJson> = {
   },
   signature,
 };
+let delegationGenerator = record<Signed<DelegationJson>>({
+  data: record({
+    common: commonGenerator,
+    body: record({
+      delegator: Random.json.publicKey,
+      newDelegate: Random.json.publicKey,
+    }),
+  }),
+  signature: Random.json.signature,
+});
 
-// common serialization
-let result = Test.transactionHash.serializeCommon(
-  JSON.stringify(commonToOcaml(payment.data.common))
-);
-let bytes0 = [...result.data];
-let common = commonFromJson(payment.data.common);
-let bytes1 = Common.toBytes(common);
-expect(JSON.stringify(bytes1)).toEqual(JSON.stringify(bytes0));
+test(paymentGenerator, delegationGenerator, (payment, delegation, assert) => {
+  // common serialization
+  let result = Test.transactionHash.serializeCommon(
+    JSON.stringify(commonToOcaml(payment.data.common))
+  );
+  let bytes0 = [...result.data];
+  let common = commonFromJson(payment.data.common);
+  let bytes1 = Common.toBytes(common);
+  expect(JSON.stringify(bytes1)).toEqual(JSON.stringify(bytes0));
 
-// payment serialization
-let ocamlPayment = JSON.stringify(paymentToOcaml(payment));
-result = Test.transactionHash.serializePayment(ocamlPayment);
-let paymentBytes0 = [...result.data];
-let payload = userCommandToEnum(paymentFromJson(payment.data));
-let command = {
-  signer: PublicKey.fromBase58(payment.data.body.source),
-  signature: Signature.fromBase58(payment.signature),
-  payload,
-};
-let paymentBytes1 = SignedCommand.toBytes(command);
-expect(JSON.stringify(paymentBytes1)).toEqual(JSON.stringify(paymentBytes0));
+  // payment serialization
+  let ocamlPayment = JSON.stringify(paymentToOcaml(payment));
+  result = Test.transactionHash.serializePayment(ocamlPayment);
+  let paymentBytes0 = [...result.data];
+  let payload = userCommandToEnum(paymentFromJson(payment.data));
+  let command = {
+    signer: PublicKey.fromBase58(payment.data.body.source),
+    signature: Signature.fromBase58(payment.signature),
+    payload,
+  };
+  let paymentBytes1 = SignedCommand.toBytes(command);
+  expect(JSON.stringify(paymentBytes1)).toEqual(JSON.stringify(paymentBytes0));
 
-// payment roundtrip
-let commandRecovered = SignedCommand.fromBytes(paymentBytes1);
-expect(commandRecovered).toEqual(command);
+  // payment roundtrip
+  let commandRecovered = SignedCommand.fromBytes(paymentBytes1);
+  expect(commandRecovered).toEqual(command);
 
-// payment hash
-let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
-let digest1 = hashPayment(payment, { berkeley: true });
-expect(digest1).toEqual(digest0);
+  // payment hash
+  let digest0 = Test.transactionHash.hashPayment(ocamlPayment);
+  let digest1 = hashPayment(payment, { berkeley: true });
+  expect(digest1).toEqual(digest0);
 
-// delegation serialization
-let ocamlDelegation = JSON.stringify(delegationToOcaml(delegation));
-result = Test.transactionHash.serializePayment(ocamlDelegation);
-let delegationBytes0 = [...result.data];
-payload = userCommandToEnum(delegationFromJson(delegation.data));
-command = {
-  signer: PublicKey.fromBase58(payment.data.body.source),
-  signature: Signature.fromBase58(payment.signature),
-  payload,
-};
-let delegationBytes1 = SignedCommand.toBytes(command);
-expect(JSON.stringify(delegationBytes1)).toEqual(
-  JSON.stringify(delegationBytes0)
-);
+  // delegation serialization
+  let ocamlDelegation = JSON.stringify(delegationToOcaml(delegation));
+  result = Test.transactionHash.serializePayment(ocamlDelegation);
+  let delegationBytes0 = [...result.data];
+  payload = userCommandToEnum(delegationFromJson(delegation.data));
+  command = {
+    signer: PublicKey.fromBase58(payment.data.body.source),
+    signature: Signature.fromBase58(payment.signature),
+    payload,
+  };
+  let delegationBytes1 = SignedCommand.toBytes(command);
+  expect(JSON.stringify(delegationBytes1)).toEqual(
+    JSON.stringify(delegationBytes0)
+  );
 
-// delegation roundtrip
-commandRecovered = SignedCommand.fromBytes(delegationBytes1);
-expect(commandRecovered).toEqual(command);
+  // delegation roundtrip
+  commandRecovered = SignedCommand.fromBytes(delegationBytes1);
+  expect(commandRecovered).toEqual(command);
 
-// delegation hash
-digest0 = Test.transactionHash.hashPayment(ocamlDelegation);
-digest1 = hashStakeDelegation(delegation, { berkeley: true });
-expect(digest1).toEqual(digest0);
+  // delegation hash
+  digest0 = Test.transactionHash.hashPayment(ocamlDelegation);
+  digest1 = hashStakeDelegation(delegation, { berkeley: true });
+  expect(digest1).toEqual(digest0);
 
-// payment v1 serialization
-let ocamlPaymentV1 = JSON.stringify(paymentToOcamlV1(payment));
-let ocamlBase58V1 = Test.transactionHash.serializePaymentV1(ocamlPaymentV1);
-let v1Bytes0 = stringToBytes(
-  Ledger.encoding.ofBase58(ocamlBase58V1, versionBytes.signedCommandV1).c
-);
-let paymentV1Body = userCommandToV1(paymentFromJson(payment.data));
-let paymentV1 = {
-  signer: PublicKey.fromBase58(payment.data.body.source),
-  signature: Signature.fromBase58(payment.signature),
-  payload: paymentV1Body,
-};
-let v1Bytes1 = SignedCommandV1.toBytes(paymentV1);
-expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
+  // payment v1 serialization
+  let ocamlPaymentV1 = JSON.stringify(paymentToOcamlV1(payment));
+  let ocamlBase58V1 = Test.transactionHash.serializePaymentV1(ocamlPaymentV1);
+  let v1Bytes0 = stringToBytes(
+    Ledger.encoding.ofBase58(ocamlBase58V1, versionBytes.signedCommandV1).c
+  );
+  let paymentV1Body = userCommandToV1(paymentFromJson(payment.data));
+  let paymentV1 = {
+    signer: PublicKey.fromBase58(payment.data.body.source),
+    signature: Signature.fromBase58(payment.signature),
+    payload: paymentV1Body,
+  };
+  let v1Bytes1 = SignedCommandV1.toBytes(paymentV1);
+  expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
 
-// payment v1 hash
-digest0 = Test.transactionHash.hashPaymentV1(ocamlPaymentV1);
-digest1 = hashPayment(payment);
-expect(digest1).toEqual(digest0);
+  // payment v1 hash
+  digest0 = Test.transactionHash.hashPaymentV1(ocamlPaymentV1);
+  digest1 = hashPayment(payment);
+  expect(digest1).toEqual(digest0);
 
-// delegation v1 serialization
-let ocamlDelegationV1 = JSON.stringify(delegationToOcamlV1(delegation));
-ocamlBase58V1 = Test.transactionHash.serializePaymentV1(ocamlDelegationV1);
-v1Bytes0 = stringToBytes(
-  Ledger.encoding.ofBase58(ocamlBase58V1, versionBytes.signedCommandV1).c
-);
-let delegationV1Body = userCommandToV1(delegationFromJson(delegation.data));
-let delegationV1 = {
-  signer: PublicKey.fromBase58(payment.data.body.source),
-  signature: Signature.fromBase58(payment.signature),
-  payload: delegationV1Body,
-};
-v1Bytes1 = SignedCommandV1.toBytes(delegationV1);
-expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
+  // delegation v1 serialization
+  let ocamlDelegationV1 = JSON.stringify(delegationToOcamlV1(delegation));
+  ocamlBase58V1 = Test.transactionHash.serializePaymentV1(ocamlDelegationV1);
+  v1Bytes0 = stringToBytes(
+    Ledger.encoding.ofBase58(ocamlBase58V1, versionBytes.signedCommandV1).c
+  );
+  let delegationV1Body = userCommandToV1(delegationFromJson(delegation.data));
+  let delegationV1 = {
+    signer: PublicKey.fromBase58(payment.data.body.source),
+    signature: Signature.fromBase58(payment.signature),
+    payload: delegationV1Body,
+  };
+  v1Bytes1 = SignedCommandV1.toBytes(delegationV1);
+  expect(JSON.stringify(v1Bytes1)).toEqual(JSON.stringify(v1Bytes0));
 
-// delegation v1 hash
-digest0 = Test.transactionHash.hashPaymentV1(ocamlDelegationV1);
-digest1 = hashStakeDelegation(delegation);
-expect(digest1).toEqual(digest0);
+  // delegation v1 hash
+  digest0 = Test.transactionHash.hashPaymentV1(ocamlDelegationV1);
+  digest1 = hashStakeDelegation(delegation);
+  expect(digest1).toEqual(digest0);
+});
 
 shutdown();
 

--- a/src/provable/base58.ts
+++ b/src/provable/base58.ts
@@ -10,6 +10,7 @@ export {
   withBase58,
   fieldEncodings,
   Base58,
+  alphabet,
 };
 
 const alphabet =

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -1,28 +1,26 @@
 import { fromBase58Check, toBase58Check } from './base58.js';
 import { Ledger, isReady, shutdown } from '../snarky.js';
 import { expect } from 'expect';
+import { test, Random } from '../lib/testing/property.js';
 
 await isReady;
 
-function check(bytes: number[], version: number) {
+let bytes = Random.bytes(Random.nat(10));
+let version = Random.nat(10);
+
+test(bytes, version, (bytes, version, assert) => {
   let binaryString = String.fromCharCode(...bytes);
   let ocamlBytes = { t: 9, c: binaryString, l: bytes.length };
   let base58Ocaml = Ledger.encoding.toBase58(ocamlBytes, version);
 
   // check consistency with OCaml result
   let base58 = toBase58Check(bytes, version);
-  expect(base58).toEqual(base58Ocaml);
+  assert(base58 === base58Ocaml, 'base58 agrees with ocaml');
 
   // check roundtrip
   let recoveredBytes = fromBase58Check(base58, version);
   expect(recoveredBytes).toEqual(bytes);
-}
-
-check([0, 1, 2, 3, 4, 5], 10);
-check([250, 200, 150, 100, 50, 0], 1);
-check([0, 0], 0);
-check([1], 100);
-check([], 0x01);
+});
 
 let goodExample = 'AhgX24Hr3v';
 expect(toBase58Check([0, 1, 2], 1)).toEqual(goodExample);

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -1,11 +1,14 @@
 import { fromBase58Check, toBase58Check } from './base58.js';
 import { Ledger, isReady, shutdown } from '../snarky.js';
 import { expect } from 'expect';
-import { test, Random } from '../lib/testing/property.js';
+import { test, Random, withHardCoded } from '../lib/testing/property.js';
 
 await isReady;
 
-let bytes = Random.bytes(Random.nat(100));
+let bytes = withHardCoded(
+  Random.bytes(Random.nat(100)),
+  [0, 0, 0, 0] // definitely test some zero bytes
+);
 let version = Random.nat(100);
 
 test(bytes, version, (bytes, version, assert) => {

--- a/src/provable/base58.unit-test.ts
+++ b/src/provable/base58.unit-test.ts
@@ -5,8 +5,8 @@ import { test, Random } from '../lib/testing/property.js';
 
 await isReady;
 
-let bytes = Random.bytes(Random.nat(10));
-let version = Random.nat(10);
+let bytes = Random.bytes(Random.nat(100));
+let version = Random.nat(100);
 
 test(bytes, version, (bytes, version, assert) => {
   let binaryString = String.fromCharCode(...bytes);

--- a/src/provable/binable.unit-test.ts
+++ b/src/provable/binable.unit-test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'expect';
+import { BinableUint32, BinableUint64 } from './binable.js';
+
+let uint32s = [0n, 1n, 2n, 10n, 24234098n, 0xffff_ffffn];
+let uint64s = [...uint32s, 0x1000_0000_ffff_ffffn, 0xffff_ffff_ffff_ffffn];
+
+for (let uint32 of uint32s) {
+  let bytes = BinableUint32.toBytes(uint32);
+  let result = BinableUint32.fromBytes(bytes);
+  expect(result).toEqual(uint32);
+}
+for (let uint64 of uint64s) {
+  let bytes = BinableUint64.toBytes(uint64);
+  let result = BinableUint64.fromBytes(bytes);
+  expect(result).toEqual(uint64);
+}
+
+let noUint64s = [
+  -1n,
+  -10n,
+  -0xffff_ffff_ffff_ffffn,
+  0x1_0000_0000_0000_0000n,
+  0x1_2345_789a_bcde_ffffn,
+];
+let noUint32s = [...noUint64s, 0x1_0000_0000n, 0xffff_ffff_ffffn];
+
+for (let noUint32 of noUint32s) {
+  expect(() => BinableUint32.toBytes(noUint32)).toThrow('uint32 out of range');
+}
+for (let noUint64 of noUint64s) {
+  expect(() => BinableUint64.toBytes(noUint64)).toThrow('uint64 out of range');
+}

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -116,7 +116,7 @@ const Sign = pseudoClass(
   function Sign(value: 1 | -1): Sign {
     if (value !== 1 && value !== -1)
       throw Error('Sign: input must be 1 or -1.');
-    return (BigInt(value) % Fp.modulus) as Sign;
+    return mod(BigInt(value), Fp.modulus) as Sign;
   },
   {
     ...ProvableBigint<Sign, 'Positive' | 'Negative'>(checkSign),

--- a/src/provable/field-bigint.ts
+++ b/src/provable/field-bigint.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from '../js_crypto/random.js';
 import { bigIntToBytes } from '../js_crypto/bigint-helpers.js';
 import { Fp, mod } from '../js_crypto/finite_field.js';
 import { BinableWithBits, defineBinable, withBits } from './binable.js';
@@ -86,6 +87,8 @@ const Bool = pseudoClass(
 function Unsigned(bits: number) {
   let maxValue = (1n << BigInt(bits)) - 1n;
   let checkUnsigned = checkRange(0n, 1n << BigInt(bits), `UInt${bits}`);
+  let binable = BinableBigint(bits, checkUnsigned);
+  let bytes = Math.ceil(bits / 8);
 
   return pseudoClass(
     function Unsigned(value: bigint | number | string) {
@@ -95,11 +98,14 @@ function Unsigned(bits: number) {
     },
     {
       ...ProvableBigint(checkUnsigned),
-      ...BinableBigint(bits, checkUnsigned),
+      ...binable,
       toInput(x: bigint): HashInput {
         return { fields: [], packed: [[x, bits]] };
       },
       maxValue,
+      random() {
+        return binable.fromBytes([...randomBytes(bytes)]);
+      },
     }
   );
 }

--- a/src/provable/from-layout.ts
+++ b/src/provable/from-layout.ts
@@ -430,7 +430,8 @@ function ProvableFromLayout<
 type GenericFoldSpec<T, R, TypeMap extends AnyTypeMap> = {
   map: (
     type: GenericProvableExtended<any, any, TypeMap['Field']>,
-    value?: T
+    value?: T,
+    name?: string
   ) => R;
   reduceArray: (array: R[], typeData: ArrayLayout<TypeMap>) => R;
   reduceObject: (keys: string[], record: Record<string, R>) => R;
@@ -460,7 +461,7 @@ function genericLayoutFold<
   let { checkedTypeName } = typeData;
   if (checkedTypeName) {
     // there's a custom type!
-    return spec.map(customTypes[checkedTypeName], value);
+    return spec.map(customTypes[checkedTypeName], value, checkedTypeName);
   }
   if (typeData.type === 'array') {
     let arrayTypeData = typeData as ArrayLayout<TypeMap>;
@@ -482,7 +483,7 @@ function genericLayoutFold<
         let v: { isSome: T; value: T } | undefined = value as any;
         return spec.reduceFlaggedOption(
           {
-            isSome: spec.map(TypeMap.Bool, v?.isSome),
+            isSome: spec.map(TypeMap.Bool, v?.isSome, 'Bool'),
             value: genericLayoutFold(
               TypeMap,
               customTypes,
@@ -518,10 +519,10 @@ function genericLayoutFold<
     });
     return spec.reduceObject(keys, object);
   }
-  if (primitiveTypes.has(typeData.type as string)) {
-    return spec.map((PrimitiveMap as any)[typeData.type], value);
+  if (primitiveTypes.has(typeData.type)) {
+    return spec.map((PrimitiveMap as any)[typeData.type], value, typeData.type);
   }
-  return spec.map((TypeMap as any)[typeData.type], value);
+  return spec.map((TypeMap as any)[typeData.type], value, typeData.type);
 }
 
 // types
@@ -532,7 +533,7 @@ type WithChecked<TypeMap extends AnyTypeMap> = {
 };
 
 type BaseLayout<TypeMap extends AnyTypeMap> = {
-  type: keyof TypeMap;
+  type: keyof TypeMap & string;
 } & WithChecked<TypeMap>;
 
 type RangeLayout<TypeMap extends AnyTypeMap, T = BaseLayout<TypeMap>> = {

--- a/src/provable/from-layout.ts
+++ b/src/provable/from-layout.ts
@@ -4,7 +4,7 @@ import {
   primitiveTypes,
 } from './generic.js';
 
-export { ProvableFromLayout, GenericLayout };
+export { ProvableFromLayout, GenericLayout, genericLayoutFold };
 
 type GenericTypeMap<
   Field,
@@ -52,6 +52,12 @@ function ProvableFromLayout<
   type Layout = GenericLayout<TypeMap>;
 
   const PrimitiveMap = primitiveTypeMap<Field>();
+
+  type FoldSpec<T, R> = GenericFoldSpec<T, R, TypeMap>;
+
+  function layoutFold<T, R>(spec: FoldSpec<T, R>, typeData: Layout, value?: T) {
+    return genericLayoutFold(TypeMap, customTypes, spec, typeData, value);
+  }
 
   function provableFromLayout<T, TJson>(typeData: Layout) {
     return {
@@ -294,65 +300,39 @@ function ProvableFromLayout<
     return (TypeMap as any)[typeData.type].fromFields(fields, aux);
   }
 
-  function emptyValue(typeData: Layout): any {
-    let { checkedTypeName } = typeData;
-    if (checkedTypeName) {
-      return emptyValueBase(typeData);
-    }
-    if (typeData.type === 'array') {
-      let arrayTypeData = typeData as ArrayLayout<TypeMap>;
-      let { inner, staticLength } = arrayTypeData;
-      if (staticLength == null) return [];
-      return Array(staticLength).fill(emptyValue(inner));
-    }
-    if (typeData.type === 'option') {
-      let optionTypeData = typeData as OptionLayout<TypeMap>;
-      switch (optionTypeData.optionType) {
-        case 'closedInterval':
-        case 'flaggedOption': {
-          let isSome = TypeMap.Bool.fromJSON(false);
-          let value = emptyValue(optionTypeData.inner);
-          if (optionTypeData.optionType === 'closedInterval') {
-            let innerInner = optionTypeData.inner.entries.lower;
-            let innerType =
-              TypeMap[innerInner.type as keyof TypeMap & keyof JsonMap];
-            value.lower = innerType.fromJSON(optionTypeData.rangeMin);
-            value.upper = innerType.fromJSON(optionTypeData.rangeMax);
+  function emptyValue(typeData: Layout) {
+    let zero = TypeMap.Field.fromJSON('0');
+    return layoutFold<undefined, any>(
+      {
+        map(type) {
+          if (type.emptyValue) return type.emptyValue();
+          return type.fromFields(
+            Array(type.sizeInFields()).fill(zero),
+            type.toAuxiliary()
+          );
+        },
+        reduceArray(array) {
+          return array;
+        },
+        reduceObject(_, object) {
+          return object;
+        },
+        reduceFlaggedOption({ isSome, value }, typeData) {
+          if (typeData.optionType === 'closedInterval') {
+            let innerInner = typeData.inner.entries.lower;
+            let innerType = TypeMap[innerInner.type as 'UInt32' | 'UInt64'];
+            value.lower = innerType.fromJSON(typeData.rangeMin);
+            value.upper = innerType.fromJSON(typeData.rangeMax);
           }
           return { isSome, value };
-        }
-        case 'orUndefined': {
+        },
+        reduceOrUndefined() {
           return undefined;
-        }
-        default:
-          throw Error('bug');
-      }
-    }
-    if (typeData.type === 'object') {
-      let { keys, entries } = typeData as ObjectLayout<TypeMap>;
-      let values: Record<string, any> = {};
-      for (let i = 0; i < keys.length; i++) {
-        let typeEntry = entries[keys[i]];
-        values[keys[i]] = emptyValue(typeEntry);
-      }
-      return values;
-    }
-    return emptyValueBase(typeData);
-  }
-  function emptyValueBase(typeData: Layout) {
-    let { checkedTypeName } = typeData;
-    if (checkedTypeName) {
-      let checkedType = customTypes[checkedTypeName];
-      if (checkedType.emptyValue) return checkedType.emptyValue();
-    }
-    let typeName = typeData.type as keyof TypeMap & keyof JsonMap;
-    if (TypeMap[typeName]) {
-      let type = TypeMap[typeName];
-      if (type.emptyValue) return type.emptyValue();
-    }
-    let zero = Field.fromJSON('0');
-    let fields: Field[] = Array(sizeInFields(typeData)).fill(zero);
-    return fromFields(typeData, fields, toAuxiliary(typeData));
+        },
+      },
+      typeData,
+      undefined
+    );
   }
 
   function check(typeData: Layout, value: any) {
@@ -409,66 +389,6 @@ function ProvableFromLayout<
     );
   }
 
-  type FoldSpec<T, R> = {
-    map: (type: GenericProvableExtended<any, any, Field>, value?: T) => R;
-    reduceArray: (array: R[], typeData: ArrayLayout<TypeMap>) => R;
-    reduceObject: (keys: string[], record: Record<string, R>) => R;
-    reduceFlaggedOption: (option: { isSome: R; value: R }) => R;
-    reduceOrUndefined: (value?: R) => R;
-  };
-
-  function layoutFold<T, R>(
-    spec: FoldSpec<T, R>,
-    typeData: Layout,
-    value?: T
-  ): R {
-    let { checkedTypeName } = typeData;
-    if (checkedTypeName) {
-      // there's a custom type!
-      return spec.map(customTypes[checkedTypeName], value);
-    }
-    if (typeData.type === 'array') {
-      let arrayTypeData = typeData as ArrayLayout<TypeMap>;
-      let v: T[] | undefined[] | undefined = value as any;
-      if (arrayTypeData.staticLength != null && v === undefined) {
-        v = Array<undefined>(arrayTypeData.staticLength).fill(undefined);
-      }
-      let array = v?.map((x) => layoutFold(spec, arrayTypeData.inner, x)) ?? [];
-      return spec.reduceArray(array, arrayTypeData);
-    }
-    if (typeData.type === 'option') {
-      let { optionType, inner } = typeData as OptionLayout<TypeMap>;
-      switch (optionType) {
-        case 'closedInterval':
-        case 'flaggedOption':
-          let v: { isSome: T; value: T } | undefined = value as any;
-          return spec.reduceFlaggedOption({
-            isSome: spec.map(TypeMap.Bool, v?.isSome),
-            value: layoutFold(spec, inner, v?.value),
-          });
-        case 'orUndefined':
-          let mapped =
-            value === undefined ? undefined : layoutFold(spec, inner, value);
-          return spec.reduceOrUndefined(mapped);
-        default:
-          throw Error('bug');
-      }
-    }
-    if (typeData.type === 'object') {
-      let { keys, entries } = typeData as ObjectLayout<TypeMap>;
-      let v: Record<string, T> | undefined = value as any;
-      let object: Record<string, R> = {};
-      keys.forEach((key) => {
-        object[key] = layoutFold(spec, entries[key], v?.[key]);
-      });
-      return spec.reduceObject(keys, object);
-    }
-    if (primitiveTypes.has(typeData.type as string)) {
-      return spec.map((PrimitiveMap as any)[typeData.type], value);
-    }
-    return spec.map((TypeMap as any)[typeData.type], value);
-  }
-
   // helper for pretty-printing / debugging
 
   function toJSONEssential(typeData: Layout, value: any) {
@@ -503,6 +423,105 @@ function ProvableFromLayout<
   }
 
   return { provableFromLayout, toJSONEssential };
+}
+
+// generic over leaf types
+
+type GenericFoldSpec<T, R, TypeMap extends AnyTypeMap> = {
+  map: (
+    type: GenericProvableExtended<any, any, TypeMap['Field']>,
+    value?: T
+  ) => R;
+  reduceArray: (array: R[], typeData: ArrayLayout<TypeMap>) => R;
+  reduceObject: (keys: string[], record: Record<string, R>) => R;
+  reduceFlaggedOption: (
+    option: { isSome: R; value: R },
+    typeData: FlaggedOptionLayout<TypeMap>
+  ) => R;
+  reduceOrUndefined: (value?: R) => R;
+};
+
+function genericLayoutFold<
+  T,
+  R,
+  TypeMap extends AnyTypeMap,
+  JsonMap extends AnyTypeMap
+>(
+  TypeMap: TypeMapValues<TypeMap, JsonMap>,
+  customTypes: Record<
+    string,
+    GenericProvableExtended<any, any, TypeMap['Field']>
+  >,
+  spec: GenericFoldSpec<T, R, TypeMap>,
+  typeData: GenericLayout<TypeMap>,
+  value?: T
+): R {
+  let PrimitiveMap = primitiveTypeMap<TypeMap['Field']>();
+  let { checkedTypeName } = typeData;
+  if (checkedTypeName) {
+    // there's a custom type!
+    return spec.map(customTypes[checkedTypeName], value);
+  }
+  if (typeData.type === 'array') {
+    let arrayTypeData = typeData as ArrayLayout<TypeMap>;
+    let v: T[] | undefined[] | undefined = value as any;
+    if (arrayTypeData.staticLength !== null && v === undefined) {
+      v = Array<undefined>(arrayTypeData.staticLength).fill(undefined);
+    }
+    let array =
+      v?.map((x) =>
+        genericLayoutFold(TypeMap, customTypes, spec, arrayTypeData.inner, x)
+      ) ?? [];
+    return spec.reduceArray(array, arrayTypeData);
+  }
+  if (typeData.type === 'option') {
+    let { optionType, inner } = typeData as OptionLayout<TypeMap>;
+    switch (optionType) {
+      case 'closedInterval':
+      case 'flaggedOption':
+        let v: { isSome: T; value: T } | undefined = value as any;
+        return spec.reduceFlaggedOption(
+          {
+            isSome: spec.map(TypeMap.Bool, v?.isSome),
+            value: genericLayoutFold(
+              TypeMap,
+              customTypes,
+              spec,
+              inner,
+              v?.value
+            ),
+          },
+          typeData as FlaggedOptionLayout<TypeMap>
+        );
+      case 'orUndefined':
+        let mapped =
+          value === undefined
+            ? undefined
+            : genericLayoutFold(TypeMap, customTypes, spec, inner, value);
+        return spec.reduceOrUndefined(mapped);
+      default:
+        throw Error('bug');
+    }
+  }
+  if (typeData.type === 'object') {
+    let { keys, entries } = typeData as ObjectLayout<TypeMap>;
+    let v: Record<string, T> | undefined = value as any;
+    let object: Record<string, R> = {};
+    keys.forEach((key) => {
+      object[key] = genericLayoutFold(
+        TypeMap,
+        customTypes,
+        spec,
+        entries[key],
+        v?.[key]
+      );
+    });
+    return spec.reduceObject(keys, object);
+  }
+  if (primitiveTypes.has(typeData.type as string)) {
+    return spec.map((PrimitiveMap as any)[typeData.type], value);
+  }
+  return spec.map((TypeMap as any)[typeData.type], value);
 }
 
 // types
@@ -542,6 +561,11 @@ type OptionLayout<TypeMap extends AnyTypeMap, T = BaseLayout<AnyTypeMap>> = {
     }
 ) &
   WithChecked<TypeMap>;
+
+type FlaggedOptionLayout<
+  TypeMap extends AnyTypeMap,
+  T = BaseLayout<AnyTypeMap>
+> = Exclude<OptionLayout<TypeMap, T>, { optionType: 'orUndefined' }>;
 
 type ArrayLayout<TypeMap extends AnyTypeMap> = {
   type: 'array';

--- a/src/provable/gen/transaction-bigint.ts
+++ b/src/provable/gen/transaction-bigint.ts
@@ -27,7 +27,7 @@ import { jsLayout } from './js-layout.js';
 export { customTypes, ZkappCommand, AccountUpdate };
 export { Json };
 export * from '../transaction-leaves-bigint.js';
-export { provableFromLayout, toJSONEssential, Layout };
+export { provableFromLayout, toJSONEssential, Layout, TypeMap };
 
 type TypeMap = {
   PublicKey: PublicKey;

--- a/src/provable/gen/transaction.ts
+++ b/src/provable/gen/transaction.ts
@@ -27,7 +27,7 @@ import { jsLayout } from './js-layout.js';
 export { customTypes, ZkappCommand, AccountUpdate };
 export { Json };
 export * from '../transaction-leaves.js';
-export { provableFromLayout, toJSONEssential, Layout };
+export { provableFromLayout, toJSONEssential, Layout, TypeMap };
 
 type TypeMap = {
   PublicKey: PublicKey;

--- a/src/provable/generic.ts
+++ b/src/provable/generic.ts
@@ -59,21 +59,27 @@ function primitiveTypeMap<Field>(): {
   string: GenericProvableExtended<string, string, Field>;
   null: GenericProvableExtended<null, null, Field>;
 } {
-  return {
-    number: {
-      ...emptyType,
-      toAuxiliary: (value = 0) => [value],
-      toJSON: (value) => value,
-      fromJSON: (value) => value,
-      fromFields: (_, [value]) => value,
-    },
-    string: {
-      ...emptyType,
-      toAuxiliary: (value = '') => [value],
-      toJSON: (value) => value,
-      fromJSON: (value) => value,
-      fromFields: (_, [value]) => value,
-    },
-    null: emptyType,
-  };
+  return primitiveTypeMap_;
 }
+
+const primitiveTypeMap_: {
+  number: GenericProvableExtended<number, number, any>;
+  string: GenericProvableExtended<string, string, any>;
+  null: GenericProvableExtended<null, null, any>;
+} = {
+  number: {
+    ...emptyType,
+    toAuxiliary: (value = 0) => [value],
+    toJSON: (value) => value,
+    fromJSON: (value) => value,
+    fromFields: (_, [value]) => value,
+  },
+  string: {
+    ...emptyType,
+    toAuxiliary: (value = '') => [value],
+    toJSON: (value) => value,
+    fromJSON: (value) => value,
+    fromFields: (_, [value]) => value,
+  },
+  null: emptyType,
+};


### PR DESCRIPTION
This adds a [quickcheck-style](https://en.wikipedia.org/wiki/QuickCheck) testing lib based on random generation of many examples. The main goal is being able to generate many non-trivial examples of complex structures like account updates. To this end, the testing lib is integrated with the deriver code, so the combinators for account updates don't need to be specified manually.

### Why not use an existing property-based testing framework, like [fast-check](https://github.com/dubzzz/fast-check)?

* integration with deriver code would've been a pain
* we would've had to write many generators ourselves, anyway, to create things like random fields or public keys
* if you strip away the fancier stuff like shrinking failure cases, it's pretty simple. it's all about creating good random values.
* if this is going to be useful outside of mina-signer -- for example, creating transactions that are actually valid on the ledger -- it will need some _very_ custom tooling, which is always simpler to build from scratch than on top of an opinionated lib

### Which issue does this solve right now?

* testing a much greater variety of zkapp transactions was one of the feedback items form the mina-signer audit, and this will make it very simple and nice to maintain