### PR TITLE
Update transaction hash version byte

### DIFF
--- a/src/js_crypto/constants.ts
+++ b/src/js_crypto/constants.ts
@@ -23,7 +23,7 @@ let versionBytes = {
   "userCommandMemo": 20,
   "privateKey": 90,
   "signature": 154,
-  "transactionHash": 18,
+  "transactionHash": 29,
   "signedCommandV1": 19
 };
 let poseidonParamsKimchiFp = {
@@ -855,4 +855,3 @@ let poseidonParamsLegacyFp = {
   "rate": 2,
   "power": 5
 };
-


### PR DESCRIPTION
The new transaction hash version in OCaml is `\x1D`, which is 29 decimal.

Link: https://github.com/MinaProtocol/mina/blob/develop/src/lib/base58_check/version_bytes.ml#L60

The SnarkyJS unit test is failing in CI because of the incorrect value: https://buildkite.com/o-1-labs-2/mina/builds/27147#01865677-acee-4cfe-ba63-c5bbffc0cc34