### PR TITLE
add vk hash to account query

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -199,6 +199,7 @@ const accountQuery = (publicKey: string, tokenId: string) => `{
     tokenSymbol
     verificationKey {
       verificationKey
+      hash
     }
   }
 }


### PR DESCRIPTION
We weren't fetching the hash of the vk with `fetchAccount`, resulting in the `parseFetchedAccount` function trying to parse `Field(hash)` unsuccessfully, because hash was undefined https://github.com/o1-labs/snarkyjs/blob/berkeley/src/lib/fetch.ts#L249

Just realized there exists an issue for that https://github.com/o1-labs/snarkyjs/issues/725
this PR is just a quick short term fix so I can get the integration test up and running