### PR TITLE
Mina-signer: Revert legacy tx signature format

### DIFF
--- a/src/lib/testing/random.ts
+++ b/src/lib/testing/random.ts
@@ -107,6 +107,7 @@ const json = {
   uint32: map(UInt32, Bigint.UInt32.toJSON),
   publicKey: map(PublicKey, CurveBigint.PublicKey.toJSON),
   signature: map(Signature, SignatureBigint.Signature.toBase58),
+  signatureJson: map(Signature, SignatureBigint.Signature.toJSON),
 };
 
 const Random = Object.assign(Random_, {

--- a/src/mina-signer/package-lock.json
+++ b/src/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "^1.2.1",

--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",

--- a/src/mina-signer/src/TSTypes.ts
+++ b/src/mina-signer/src/TSTypes.ts
@@ -1,11 +1,12 @@
-import { ZkappCommand as ZkappCommandJson } from '../../provable/gen/transaction-json.js';
+import type { ZkappCommand as ZkappCommandJson } from '../../provable/gen/transaction-json.js';
+import type { SignatureJson } from './signature.js';
 
 export type UInt32 = number | bigint | string;
 export type UInt64 = number | bigint | string;
 
 export type PublicKey = string;
 export type PrivateKey = string;
-export type Signature = string;
+export type Signature = SignatureJson;
 export type Network = 'mainnet' | 'testnet';
 
 export type Keypair = {
@@ -53,6 +54,17 @@ export type ZkappCommand = {
   readonly feePayer: FeePayer;
 };
 
-export type SignableData = string | StakeDelegation | Payment | ZkappCommand;
+export type SignableData = string | StakeDelegation | Payment;
 
-export type Signed<T> = { signature: Signature; publicKey: PublicKey; data: T };
+export type SignedLegacy<T> = {
+  signature: SignatureJson;
+  publicKey: PublicKey;
+  data: T;
+};
+export type Signed<T> = {
+  signature: string; // base58
+  publicKey: PublicKey;
+  data: T;
+};
+
+export type SignedAny = SignedLegacy<SignableData> | Signed<ZkappCommand>;

--- a/src/mina-signer/src/Utils.ts
+++ b/src/mina-signer/src/Utils.ts
@@ -1,11 +1,15 @@
+import { SignatureJson } from './signature.js';
 import type {
   Payment,
   StakeDelegation,
   ZkappCommand,
+  Signed,
+  SignedAny,
+  SignedLegacy,
   SignableData,
 } from './TSTypes.js';
 
-function hasCommonProperties(data: SignableData) {
+function hasCommonProperties(data: SignableData | ZkappCommand) {
   return (
     data.hasOwnProperty('to') &&
     data.hasOwnProperty('from') &&
@@ -14,14 +18,52 @@ function hasCommonProperties(data: SignableData) {
   );
 }
 
-export function isZkappCommand(p: ZkappCommand): p is ZkappCommand {
+export function isZkappCommand(
+  p: SignableData | ZkappCommand
+): p is ZkappCommand {
   return p.hasOwnProperty('zkappCommand') && p.hasOwnProperty('feePayer');
 }
 
-export function isPayment(p: SignableData): p is Payment {
+export function isPayment(p: SignableData | ZkappCommand): p is Payment {
   return hasCommonProperties(p) && p.hasOwnProperty('amount');
 }
 
-export function isStakeDelegation(p: SignableData): p is StakeDelegation {
+export function isStakeDelegation(
+  p: SignableData | ZkappCommand
+): p is StakeDelegation {
   return hasCommonProperties(p) && !p.hasOwnProperty('amount');
+}
+
+function isLegacySignature(s: string | SignatureJson): s is SignatureJson {
+  return typeof s === 'object' && 'field' in s && 'scalar' in s;
+}
+
+export function isSignedZkappCommand(p: SignedAny): p is Signed<ZkappCommand> {
+  return (
+    p.data.hasOwnProperty('zkappCommand') &&
+    p.data.hasOwnProperty('feePayer') &&
+    typeof p.signature === 'string'
+  );
+}
+
+export function isSignedPayment(p: SignedAny): p is SignedLegacy<Payment> {
+  return (
+    hasCommonProperties(p.data) &&
+    isLegacySignature(p.signature) &&
+    p.data.hasOwnProperty('amount')
+  );
+}
+
+export function isSignedDelegation(
+  p: SignedAny
+): p is SignedLegacy<StakeDelegation> {
+  return (
+    hasCommonProperties(p.data) &&
+    isLegacySignature(p.signature) &&
+    !p.data.hasOwnProperty('amount')
+  );
+}
+
+export function isSignedString(p: SignedAny): p is SignedLegacy<string> {
+  return typeof p.data === 'string' && isLegacySignature(p.signature);
 }

--- a/src/mina-signer/src/sign-legacy.ts
+++ b/src/mina-signer/src/sign-legacy.ts
@@ -2,7 +2,13 @@ import { UInt32, UInt64 } from '../../provable/field-bigint.js';
 import { PrivateKey, PublicKey } from '../../provable/curve-bigint.js';
 import { HashInputLegacy } from '../../provable/poseidon-bigint.js';
 import { Memo } from './memo.js';
-import { NetworkId, Signature, signLegacy, verifyLegacy } from './signature.js';
+import {
+  SignatureJson,
+  NetworkId,
+  Signature,
+  signLegacy,
+  verifyLegacy,
+} from './signature.js';
 import { Json } from '../../provable/gen/transaction-bigint.js';
 import { bytesToBits, stringToBytes } from '../../provable/binable.js';
 
@@ -53,12 +59,12 @@ function signUserCommand(
   let input = toInputLegacy(command);
   let privateKey = PrivateKey.fromBase58(privateKeyBase58);
   let signature = signLegacy(input, privateKey, networkId);
-  return Signature.toBase58(signature);
+  return Signature.toJSON(signature);
 }
 
 function verifyPayment(
   payment: PaymentJson,
-  signatureJson: string,
+  signatureJson: SignatureJson,
   publicKeyBase58: string,
   networkId: NetworkId
 ) {
@@ -75,7 +81,7 @@ function verifyPayment(
 }
 function verifyStakeDelegation(
   delegation: DelegationJson,
-  signatureJson: string,
+  signatureJson: SignatureJson,
   publicKeyBase58: string,
   networkId: NetworkId
 ) {
@@ -93,12 +99,12 @@ function verifyStakeDelegation(
 
 function verifyUserCommand(
   command: UserCommand,
-  signatureJson: string,
+  signatureJson: SignatureJson,
   publicKeyBase58: string,
   networkId: NetworkId
 ) {
   let input = toInputLegacy(command);
-  let signature = Signature.fromBase58(signatureJson);
+  let signature = Signature.fromJSON(signatureJson);
   let publicKey = PublicKey.fromBase58(publicKeyBase58);
   return verifyLegacy(signature, input, publicKey, networkId);
 }
@@ -201,17 +207,17 @@ function signString(
   let input = stringToInput(string);
   let privateKey = PrivateKey.fromBase58(privateKeyBase58);
   let signature = signLegacy(input, privateKey, networkId);
-  return Signature.toBase58(signature);
+  return Signature.toJSON(signature);
 }
 function verifyStringSignature(
   string: string,
-  signatureJson: string,
+  signatureJson: SignatureJson,
   publicKeyBase58: string,
   networkId: NetworkId
 ) {
   try {
     let input = stringToInput(string);
-    let signature = Signature.fromBase58(signatureJson);
+    let signature = Signature.fromJSON(signatureJson);
     let publicKey = PublicKey.fromBase58(publicKeyBase58);
     return verifyLegacy(signature, input, publicKey, networkId);
   } catch {

--- a/src/mina-signer/src/sign-legacy.unit-test.ts
+++ b/src/mina-signer/src/sign-legacy.unit-test.ts
@@ -28,7 +28,7 @@ for (let network of networks) {
 
   for (let payment of payments) {
     let signature = signPayment(payment, privateKey, network);
-    let sig = Signature.fromBase58(signature);
+    let sig = Signature.fromJSON(signature);
     let ref = reference[i++];
     expect(sig.r).toEqual(BigInt(ref.field));
     expect(sig.s).toEqual(BigInt(ref.scalar));
@@ -38,7 +38,7 @@ for (let network of networks) {
 
   for (let delegation of delegations) {
     let signature = signStakeDelegation(delegation, privateKey, network);
-    let sig = Signature.fromBase58(signature);
+    let sig = Signature.fromJSON(signature);
     let ref = reference[i++];
     expect(sig.r).toEqual(BigInt(ref.field));
     expect(sig.s).toEqual(BigInt(ref.scalar));
@@ -48,7 +48,7 @@ for (let network of networks) {
 
   for (let string of strings) {
     let signature = signString(string, privateKey, network);
-    let sig = Signature.fromBase58(signature);
+    let sig = Signature.fromJSON(signature);
     let ref = reference[i++];
     expect(sig.r).toEqual(BigInt(ref.field));
     expect(sig.s).toEqual(BigInt(ref.scalar));
@@ -74,7 +74,7 @@ let invalidPublicKey: PaymentJson = {
     source: PublicKey.toBase58({ x: 0n, isOdd: 0n }),
   },
 };
-let signature = Signature.toBase58({ r: Field.random(), s: Scalar.random() });
+let signature = Signature.toJSON({ r: Field.random(), s: Scalar.random() });
 
 expect(() => signPayment(amountTooLarge, privateKey, 'mainnet')).toThrow(
   `inputs larger than ${2n ** 64n - 1n} are not allowed`
@@ -92,12 +92,12 @@ expect(
 
 // negative tests with invalid signatures
 
-let garbageSignature = 'garbage';
-let signatureFieldTooLarge = Signature.toBase58({
+let garbageSignature = { field: 'garbage', scalar: 'garbage' };
+let signatureFieldTooLarge = Signature.toJSON({
   r: Field.modulus,
   s: Scalar.random(),
 });
-let signatureScalarTooLarge = Signature.toBase58({
+let signatureScalarTooLarge = Signature.toJSON({
   r: Field.random(),
   s: Scalar.modulus,
 });

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -34,6 +34,7 @@ export {
   signFieldElement,
   verifyFieldElement,
   Signature,
+  SignatureJson,
   NetworkId,
   signLegacy,
   verifyLegacy,
@@ -44,6 +45,7 @@ const networkIdMainnet = 0x01n;
 const networkIdTestnet = 0x00n;
 type NetworkId = 'mainnet' | 'testnet';
 type Signature = { r: Field; s: Scalar };
+type SignatureJson = { field: string; scalar: string };
 
 const BinableSignature = withVersionNumber(
   record({ r: Field, s: Scalar }, ['r', 's']),
@@ -52,6 +54,17 @@ const BinableSignature = withVersionNumber(
 const Signature = {
   ...BinableSignature,
   ...base58(BinableSignature, versionBytes.signature),
+  toJSON({ r, s }: Signature): SignatureJson {
+    return {
+      field: Field.toJSON(r),
+      scalar: Field.toJSON(s),
+    };
+  },
+  fromJSON({ field, scalar }: SignatureJson) {
+    let r = Field.fromJSON(field);
+    let s = Field.fromJSON(scalar);
+    return { r, s };
+  },
   dummy() {
     return { r: Field(0), s: Scalar(0) };
   },


### PR DESCRIPTION
- closes #745
- fixes signature format for old-style transactions, but keeps the base58 format for zkapp transactions and snarkyjs-compatible arbitrary data signatures; adds helpers to distinguish the two cases in a type-safe way
- releases mina-signer v2.0.1