### PR TITLE
Fix error on zkapp.state.get()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snarkyjs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snarkyjs",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snarkyjs",
   "description": "JavaScript bindings for SnarkyJS",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/web/index.js",

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -239,7 +239,7 @@ function createState<T>(): InternalStateType<T> {
       });
 
       let state = this._contract.stateType.fromFields(stateAsFields);
-      this._contract.stateType.check?.(state);
+      if (inCheckedComputation()) this._contract.stateType.check?.(state);
       this._contract.wasRead = true;
       this._contract.cachedVariable = state;
       return state;


### PR DESCRIPTION
- avoid 'can only run in checked computation' error
- 0.9.1
