### PR TITLE
Add back timestamp precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/71b6132b...HEAD)
+## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/9c44b9c2...HEAD)
 
-> There are no unreleased changes yet
+### Added
+
+- Add back `this.network.timestamp`, implemented on top of `this.network.globalSlotSinceGenesis` https://github.com/o1-labs/snarkyjs/pull/755
+
+### Changed
+
+- On-chain value `globalSlot` replaced by the clearer `currentSlot` https://github.com/o1-labs/snarkyjs/pull/755
+  - this refers to the slot at which the transaction _will be included in a block_.
+  - there is only `currentSlot.assertBetween()`; no `currentSlot.get()` (impossible to implement, since the value is determined in the future) and `currentSlot.assertEquals()` (error-prone)
+
+## [0.9.1](https://github.com/o1-labs/snarkyjs/compare/71b6132b...9c44b9c2)
+
+### Fixed
+
+- Bug when using `this.<state>.get()` outside a transaction https://github.com/o1-labs/snarkyjs/pull/754
 
 ## [0.9.0](https://github.com/o1-labs/snarkyjs/compare/c5a36207...71b6132b)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@playwright/test": "^1.25.2",
         "@types/isomorphic-fetch": "^0.0.36",
         "@types/jest": "^27.0.0",
-        "@types/node": "^18.7.13",
+        "@types/node": "^18.14.2",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "esbuild": "^0.16.16",
         "eslint": "^8.0.0",
@@ -1992,9 +1992,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -9263,9 +9263,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.13.tgz",
-      "integrity": "sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "@types/prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "howslow": "^0.1.0",
         "jest": "^28.1.3",
         "minimist": "^1.2.5",
-        "prettier": "^2.3.2",
+        "prettier": "^2.8.4",
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^28.0.8",
@@ -6789,15 +6789,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
-      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -12813,9 +12816,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
-      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^28.0.8",
-        "typedoc": "^0.23.11",
-        "typescript": "^4.8.2"
+        "typedoc": "^0.23.26",
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": ">=16.4.0"
@@ -2323,6 +2323,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -6323,9 +6329,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "node_modules/jsonfile": {
@@ -6450,9 +6456,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -7180,14 +7186,15 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
       "dev": true,
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/signal-exit": {
@@ -7564,15 +7571,15 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
-      "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
+      "version": "0.23.26",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
+      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -7581,7 +7588,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -7594,21 +7601,24 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.3.0.tgz",
+      "integrity": "sha512-WaMDuhKa7a6zKiwplR1AOz+zGvJba24k5VU1Cy6NhEguavT2YRlHxuINUgTas4wiS6fwBpYq4TcA1XIECSntyw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7683,15 +7693,15 @@
       }
     },
     "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "node_modules/vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "node_modules/walker": {
@@ -9465,6 +9475,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -12467,9 +12483,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
-      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "jsonfile": {
@@ -12571,9 +12587,9 @@
       }
     },
     "marked": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
-      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true
     },
     "merge-stream": {
@@ -13075,14 +13091,15 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
-      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
       "dev": true,
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "^6.0.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "signal-exit": {
@@ -13350,15 +13367,15 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.11.tgz",
-      "integrity": "sha512-FhZ2HfqlS++53UwHk4txCsTrTlpYR0So/0osMyBeP1E7llRNRqycJGfYK1qx9Wvvv5VO8tGdpwzOwDW5FrTi7A==",
+      "version": "0.23.26",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
+      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.0.19",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.11.1"
+        "marked": "^4.2.12",
+        "minimatch": "^7.1.3",
+        "shiki": "^0.14.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -13371,9 +13388,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.3.0.tgz",
+          "integrity": "sha512-WaMDuhKa7a6zKiwplR1AOz+zGvJba24k5VU1Cy6NhEguavT2YRlHxuINUgTas4wiS6fwBpYq4TcA1XIECSntyw==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -13382,9 +13399,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {
@@ -13430,15 +13447,15 @@
       }
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
       "dev": true
     },
     "vscode-textmate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
-      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.8",
-    "typedoc": "^0.23.11",
-    "typescript": "^4.8.2"
+    "typedoc": "^0.23.26",
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "blakejs": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@playwright/test": "^1.25.2",
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/jest": "^27.0.0",
-    "@types/node": "^18.7.13",
+    "@types/node": "^18.14.2",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "esbuild": "^0.16.16",
     "eslint": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "howslow": "^0.1.0",
     "jest": "^28.1.3",
     "minimist": "^1.2.5",
-    "prettier": "^2.3.2",
+    "prettier": "^2.8.4",
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.8",

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -18,6 +18,8 @@ const doProofs = true;
 
 await isReady;
 
+const beforeGenesis = UInt64.from(Date.now());
+
 class SimpleZkapp extends SmartContract {
   @state(Field) x = State<Field>();
 
@@ -30,6 +32,7 @@ class SimpleZkapp extends SmartContract {
 
   @method update(y: Field): Field {
     this.account.provedState.assertEquals(Bool(true));
+    this.network.timestamp.assertBetween(beforeGenesis, UInt64.MAXINT());
     this.emitEvent('update', y);
     let x = this.x.get();
     this.x.assertEquals(x);

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -87,16 +87,13 @@ function createDex({
          * supply liquidity again (or, create another account to supply liquidity from).
          */
         let amountLocked = dl;
-        userUpdate.update.timing = {
-          isSome: Bool(true),
-          value: {
-            initialMinimumBalance: amountLocked,
-            cliffAmount: amountLocked,
-            cliffTime: UInt32.from(lockedLiquiditySlots),
-            vestingIncrement: UInt64.zero,
-            vestingPeriod: UInt32.one,
-          },
-        };
+        userUpdate.account.timing.set({
+          initialMinimumBalance: amountLocked,
+          cliffAmount: amountLocked,
+          cliffTime: UInt32.from(lockedLiquiditySlots),
+          vestingIncrement: UInt64.zero,
+          vestingPeriod: UInt32.one,
+        });
         userUpdate.requireSignature();
       }
 

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -632,7 +632,7 @@ class AccountUpdate implements Types.AccountUpdate {
     undefined;
   account: Precondition.Account;
   network: Precondition.Network;
-  globalSlot: Precondition.GlobalSlot;
+  currentSlot: Precondition.CurrentSlot;
   children: {
     callsType:
       | { type: 'None' }
@@ -654,13 +654,13 @@ class AccountUpdate implements Types.AccountUpdate {
     this.id = Math.random();
     this.body = body;
     this.authorization = authorization;
-    let { account, network, globalSlot } = Precondition.preconditions(
+    let { account, network, currentSlot } = Precondition.preconditions(
       this,
       isSelf
     );
     this.account = account;
     this.network = network;
-    this.globalSlot = globalSlot;
+    this.currentSlot = currentSlot;
     this.isSelf = isSelf;
   }
 

--- a/src/lib/int.ts
+++ b/src/lib/int.ts
@@ -40,6 +40,15 @@ class UInt64 extends CircuitValue {
     return this.value.toBigInt();
   }
 
+  /**
+   * Turns the {@link UInt64} into a {@link UInt32}, asserting that it fits in 32 bits.
+   */
+  toUInt32() {
+    let uint32 = new UInt32(this.value);
+    UInt32.check(uint32);
+    return uint32;
+  }
+
   static check(x: UInt64) {
     let actual = x.value.rangeCheckHelper(64);
     actual.assertEquals(x.value);

--- a/src/lib/int.ts
+++ b/src/lib/int.ts
@@ -49,6 +49,21 @@ class UInt64 extends CircuitValue {
     return uint32;
   }
 
+  /**
+   * Turns the {@link UInt64} into a {@link UInt32}, clamping to the 32 bits range if it's too large.
+   * ```ts
+   * UInt64.from(4294967296).toUInt32Clamped().toString(); // "4294967295"
+   * ```
+   */
+  toUInt32Clamped() {
+    let max = (1n << 32n) - 1n;
+    return Circuit.if(
+      this.greaterThan(UInt64.from(max)),
+      UInt32.from(max),
+      new UInt32(this.value)
+    );
+  }
+
   static check(x: UInt64) {
     let actual = x.value.rangeCheckHelper(64);
     actual.assertEquals(x.value);

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -368,7 +368,7 @@ function LocalBlockchain({
     getNetworkConstants() {
       return {
         genesisTimestamp,
-        accountCreationFee,
+        accountCreationFee: UInt64.from(accountCreationFee),
       };
     },
     currentSlot() {
@@ -575,6 +575,8 @@ function LocalBlockchain({
     },
   };
 }
+// assert type compatibility without preventing LocalBlockchain to return additional properties / methods
+LocalBlockchain satisfies (...args: any) => Mina;
 
 /**
  * Represents the Mina blockchain running on a real network

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -33,6 +33,7 @@ export {
   currentTransaction,
   CurrentTransaction,
   Transaction,
+  activeInstance,
   setActiveInstance,
   transaction,
   sender,
@@ -333,7 +334,8 @@ function LocalBlockchain({
   enforceTransactionLimits = true,
 } = {}) {
   const msPerSlot = 3 * 60 * 1000;
-  const startTime = new Date().valueOf();
+  const startTime = Date.now();
+  const genesisTimestamp = UInt64.from(startTime);
 
   const ledger = Ledger.create([]);
 
@@ -359,8 +361,6 @@ function LocalBlockchain({
 
   const events: Record<string, any> = {};
   const actions: Record<string, any> = {};
-
-  const genesisTimestamp = UInt64.from(Date.now());
 
   return {
     proofsEnabled,
@@ -585,6 +585,7 @@ function Network(graphqlEndpoint: string): Mina {
   let accountCreationFee = UInt64.from(defaultAccountCreationFee);
   Fetch.setGraphqlEndpoint(graphqlEndpoint);
 
+  // copied from mina/genesis_ledgers/berkeley.json
   // TODO fetch from graphql instead of hardcoding
   const genesisTimestampString = '2023-02-23T20:00:01Z';
   const genesisTimestamp = UInt64.from(

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -311,6 +311,10 @@ interface Mina {
   getNetworkState(): NetworkValue;
   getNetworkConstants(): {
     genesisTimestamp: UInt64;
+    /**
+     * Duration of 1 slot in millisecondw
+     */
+    slotTime: UInt64;
     accountCreationFee: UInt64;
   };
   accountCreationFee(): UInt64;
@@ -333,7 +337,7 @@ function LocalBlockchain({
   proofsEnabled = true,
   enforceTransactionLimits = true,
 } = {}) {
-  const msPerSlot = 3 * 60 * 1000;
+  const slotTime = 3 * 60 * 1000;
   const startTime = Date.now();
   const genesisTimestamp = UInt64.from(startTime);
 
@@ -369,11 +373,12 @@ function LocalBlockchain({
       return {
         genesisTimestamp,
         accountCreationFee: UInt64.from(accountCreationFee),
+        slotTime: UInt64.from(slotTime),
       };
     },
     currentSlot() {
       return UInt32.from(
-        Math.ceil((new Date().valueOf() - startTime) / msPerSlot)
+        Math.ceil((new Date().valueOf() - startTime) / slotTime)
       );
     },
     hasAccount(publicKey: PublicKey, tokenId: Field = TokenId.default) {
@@ -591,11 +596,14 @@ function Network(graphqlEndpoint: string): Mina {
   const genesisTimestamp = UInt64.from(
     Date.parse(genesisTimestampString.slice(0, -1) + '+00:00')
   );
+  // TODO also fetch from graphql
+  const slotTime = UInt64.from(3 * 60 * 1000);
   return {
     accountCreationFee: () => accountCreationFee,
     getNetworkConstants() {
       return {
         genesisTimestamp,
+        slotTime,
         accountCreationFee,
       };
     },

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -13,7 +13,6 @@ import {
   CallForest,
   Authorization,
   SequenceEvents,
-  Permissions,
 } from './account_update.js';
 
 import * as Fetch from './fetch.js';

--- a/src/lib/precondition.test.ts
+++ b/src/lib/precondition.test.ts
@@ -150,15 +150,14 @@ describe('preconditions', () => {
 
   it('unsatisfied assertEquals should be rejected (numbers)', async () => {
     for (let precondition of implementedNumber) {
-      let tx = await Mina.transaction(feePayer, () => {
-        let p = precondition().get();
-        precondition().assertEquals(p.add(1) as any);
-        AccountUpdate.attachToTransaction(zkapp.self);
-      });
-
-      await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
-        /unsatisfied/
-      );
+      await expect(async () => {
+        let tx = await Mina.transaction(feePayer, () => {
+          let p = precondition().get();
+          precondition().assertEquals(p.add(1) as any);
+          AccountUpdate.attachToTransaction(zkapp.self);
+        });
+        await tx.sign([feePayerKey]).send();
+      }).rejects.toThrow(/unsatisfied/);
     }
   });
 
@@ -216,6 +215,7 @@ let implementedNumber = [
   () => zkapp.account.receiptChainHash,
   () => zkapp.network.blockchainLength,
   () => zkapp.network.globalSlotSinceGenesis,
+  () => zkapp.network.timestamp,
   () => zkapp.network.minWindowDensity,
   () => zkapp.network.totalCurrency,
   () => zkapp.network.stakingEpochData.epochLength,
@@ -247,6 +247,7 @@ let implementedWithRange = [
   () => zkapp.account.nonce,
   () => zkapp.network.blockchainLength,
   () => zkapp.network.globalSlotSinceGenesis,
+  () => zkapp.network.timestamp,
   () => zkapp.network.minWindowDensity,
   () => zkapp.network.totalCurrency,
   () => zkapp.network.stakingEpochData.epochLength,

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -53,9 +53,11 @@ function Network(accountUpdate: AccountUpdate): Network {
       return globalSlotToTimestamp(slot);
     },
     assertEquals(value: UInt64) {
+      let { genesisTimestamp } = Mina.activeInstance.getNetworkConstants();
       let slot = timestampToGlobalSlot(
         value,
-        `Timestamp precondition unsatisfied: the timestamp must be divisible by ${slotMs} (the milliseconds per slot).`
+        `Timestamp precondition unsatisfied: the timestamp can only equal numbers of the form ${genesisTimestamp} + k*${slotMs},\n` +
+          `i.e., the genesis timestamp plus an integer number of slots. Received: ${value}.`
       );
       return network.globalSlotSinceGenesis.assertEquals(slot);
     },

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -54,7 +54,10 @@ function Network(accountUpdate: AccountUpdate): Network {
       return globalSlotToTimestamp(slot);
     },
     assertEquals(value: UInt64) {
-      let slot = timestampToGlobalSlot(value);
+      let slot = timestampToGlobalSlot(
+        value,
+        `Timestamp precondition unsatisfied: the timestamp must be divisible by ${slotMs} (the milliseconds per slot).`
+      );
       return network.globalSlotSinceGenesis.assertEquals(slot);
     },
     assertBetween(lower: UInt64, upper: UInt64) {
@@ -286,12 +289,9 @@ const slotMs = 3 * 60 * 1000; // 3 minutes
 function globalSlotToTimestamp(slot: UInt32) {
   return UInt64.from(slot).mul(slotMs).add(genesisTimestamp);
 }
-function timestampToGlobalSlot(timestamp: UInt64) {
+function timestampToGlobalSlot(timestamp: UInt64, message: string) {
   let { quotient: slot, rest } = timestamp.sub(genesisTimestamp).divMod(slotMs);
-  rest.value.assertEquals(
-    Field(0),
-    `timestamp must be divisible by ${slotMs} (the milliseconds per slot)`
-  );
+  rest.value.assertEquals(Field(0), message);
   return slot.toUInt32();
 }
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -926,10 +926,12 @@ super.init();
     return this.self.network;
   }
   /**
-   * Current global slot on the network.
+   * Current global slot on the network. This is the slot at which this transaction is included in a block. Since we cannot know this value
+   * at the time of transaction construction, this only has the `assertBetween()` method but no `get()` (impossible to implement)
+   * or `assertEquals()` (confusing, because the developer can't know the exact slot at which this will be included either)
    */
-  get globalSlot() {
-    return this.self.globalSlot;
+  get currentSlot() {
+    return this.self.currentSlot;
   }
   /**
    * Token of the {@link SmartContract}.


### PR DESCRIPTION
- closes #579 
- adds `network.timestamp`
- changes `globalSlot` -> `currentSlot` following internal discussion with @jasongitmail 
- moves to TypeScript v4.9 to use the new `satisfies` operator

## Timestamp precondition RFC

`network.timestamp` is implemented as a wrapper for `network.globalSlotSinceGenesis`, which means:
  - when using `network.timestamp.get()`, the global slot is fetched under the hood and converted to a timestamp
  - when using `timestamp.assertEquals()` or `timestamp.assertBetween()`, a precondition for `globalSlotSinceGenesis` is added  under the hood
  
 ### Implementation details
 
- conversion between timestamps and global slots requires the knowledge of the timestamp which corresponds to slot 0. This is called the "genesis timestamp" and is a hardcoded property of each deployed network. We expose this by adding a new method `.getNetworkConstants()` on the `Mina` interface, which returns constants such as the genesis timestamp. This way, we can also use a reasonable mock value for local blockchain: the timestamp at which `LocalBlockchain` is instantiated.
- However, for remote networks, currently there is no way to obtain the genesis timestamp. This needs to be added to the GraphQL interface: https://github.com/MinaProtocol/mina/issues/12728 . Since the GraphQL interface will only change upon upgrade of the current testnet, as an intermediate solution until that upgrade we hardcode the genesis timestamp of the current testnet as a constant.
- Added some primitives for in-snark conversion of a `UInt64` to a `UInt32` with two possible semantics: either assert that the `UInt64` fits in 32 bits already, or clamp the `UInt64` to the uint32 range, so that larger values just become the max uint32. For our conversion of timestamp ranges to slot ranges, clamping is appropriate: this enables users to specify a "definitely large enough" timestamp value as the upper bound and have it converted to the max uint32 which is a definitely large enough slot.

### Potential caveats

The fact that we implement one precondition on top of another means that the network doesn't know that `timestamp` was used and can't return an appropriate error. This is currently not an issue because the protocol returns `Protocol_state_precondition_unsatisfied` for _all_ failing network preconditions, so it doesn't distinguish the exact case anyway.
