### PR TITLE
Fix events limit checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - this refers to the slot at which the transaction _will be included in a block_.
   - there is only `currentSlot.assertBetween()`; no `currentSlot.get()` (impossible to implement, since the value is determined in the future) and `currentSlot.assertEquals()` (error-prone)
 
+### Fixed
+
+- Incorrect counting of limit on events and actions https://github.com/o1-labs/snarkyjs/issues/757
+
 ## [0.9.1](https://github.com/o1-labs/snarkyjs/compare/71b6132b...9c44b9c2)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Incorrect counting of limit on events and actions https://github.com/o1-labs/snarkyjs/issues/757
+- Incorrect counting of limit on events and actions https://github.com/o1-labs/snarkyjs/pull/758
+- Type error when using `Circuit.array` in on-chain state or events https://github.com/o1-labs/snarkyjs/pull/758
 
 ## [0.9.1](https://github.com/o1-labs/snarkyjs/compare/71b6132b...9c44b9c2)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
   provable,
   provablePure,
   Struct,
+  FlexibleProvable,
+  FlexibleProvablePure,
 } from './lib/circuit_value.js';
 export { UInt32, UInt64, Int64, Sign } from './lib/int.js';
 export { Types } from './provable/types.js';

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -30,11 +30,12 @@ export {
   memoizeWitness,
   getBlindingValue,
   toConstant,
-  InferCircuitValue,
+  InferProvable,
   HashInput,
   FlexibleProvable,
   FlexibleProvablePure,
   InferJson,
+  InferredProvable,
 };
 
 type Constructor<T> = new (...args: any) => T;
@@ -262,11 +263,12 @@ function prop(this: any, target: any, key: string) {
   }
 }
 
-function circuitArray<
-  A extends FlexibleProvable<any>,
-  T = InferCircuitValue<A>,
-  TJson = InferJson<A>
->(elementType: A, length: number): ProvableExtended<T[], TJson[]> {
+function circuitArray<A extends FlexibleProvable<any>>(
+  elementType: A,
+  length: number
+): InferredProvable<A[]> {
+  type T = InferProvable<A>;
+  type TJson = InferJson<A>;
   let type = elementType as ProvableExtended<T>;
   return {
     /**
@@ -343,7 +345,7 @@ function circuitArray<
         HashInput.empty
       );
     },
-  };
+  } satisfies ProvableExtended<T[], TJson[]> as any;
 }
 
 function arrayProp<T>(elementType: FlexibleProvable<T>, length: number) {
@@ -472,12 +474,14 @@ type ProvableExtension<T, TJson = any> = {
 };
 type ProvableExtended<T, TJson = any> = Provable<T> &
   ProvableExtension<T, TJson>;
+type ProvableExtendedPure<T, TJson = any> = ProvablePure<T> &
+  ProvableExtension<T, TJson>;
 
 function provable<A>(
   typeObj: A,
   options?: { customObjectKeys?: string[]; isPure?: boolean }
-): ProvableExtended<InferCircuitValue<A>, InferJson<A>> {
-  type T = InferCircuitValue<A>;
+): ProvableExtended<InferProvable<A>, InferJson<A>> {
+  type T = InferProvable<A>;
   type J = InferJson<A>;
   let objectKeys =
     typeof typeObj === 'object' && typeObj !== null
@@ -653,8 +657,8 @@ function provable<A>(
 function provablePure<A>(
   typeObj: A,
   options: { customObjectKeys?: string[] } = {}
-): ProvablePure<InferCircuitValue<A>> &
-  ProvableExtension<InferCircuitValue<A>, InferJson<A>> {
+): ProvablePure<InferProvable<A>> &
+  ProvableExtension<InferProvable<A>, InferJson<A>> {
   return provable(typeObj, { ...options, isPure: true }) as any;
 }
 
@@ -730,7 +734,7 @@ function provablePure<A>(
  */
 function Struct<
   A,
-  T extends InferCircuitValue<A> = InferCircuitValue<A>,
+  T extends InferProvable<A> = InferProvable<A>,
   J extends InferJson<A> = InferJson<A>,
   Pure extends boolean = IsPure<A>
 >(
@@ -1162,27 +1166,27 @@ type InferPrimitiveJson<P extends Primitive> = P extends typeof String
   ? null
   : any;
 
-type InferCircuitValue<A> = A extends Constructor<infer U>
+type InferProvable<A> = A extends Constructor<infer U>
   ? A extends Provable<U>
     ? U
     : A extends Struct<U>
     ? U
-    : InferCircuitValueBase<A>
-  : InferCircuitValueBase<A>;
+    : InferProvableBase<A>
+  : InferProvableBase<A>;
 
-type InferCircuitValueBase<A> = A extends Provable<infer U>
+type InferProvableBase<A> = A extends Provable<infer U>
   ? U
   : A extends Primitive
   ? InferPrimitive<A>
   : A extends Tuple<any>
   ? {
-      [I in keyof A]: InferCircuitValue<A[I]>;
+      [I in keyof A]: InferProvable<A[I]>;
     }
   : A extends (infer U)[]
-  ? InferCircuitValue<U>[]
+  ? InferProvable<U>[]
   : A extends Record<any, any>
   ? {
-      [K in keyof A]: InferCircuitValue<A[K]>;
+      [K in keyof A]: InferProvable<A[K]>;
     }
   : never;
 
@@ -1219,3 +1223,7 @@ type IsPureBase<A> = A extends ProvablePure<any>
       [K in keyof A]: IsPure<A[K]>;
     }[keyof A]
   : false;
+
+type InferredProvable<A> = IsPure<A> extends true
+  ? ProvableExtendedPure<InferProvable<A>, InferJson<A>>
+  : ProvableExtended<InferProvable<A>, InferJson<A>>;

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -18,6 +18,8 @@ export {
   provable,
   provablePure,
   Struct,
+  FlexibleProvable,
+  FlexibleProvablePure,
 };
 
 // internal API
@@ -32,8 +34,6 @@ export {
   toConstant,
   InferProvable,
   HashInput,
-  FlexibleProvable,
-  FlexibleProvablePure,
   InferJson,
   InferredProvable,
 };

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1244,11 +1244,11 @@ ${JSON.stringify(authTypes)}
   }
 
   if (!isWithinEventsLimit) {
-    error += `Error: The AccountUpdates in your transaction are trying to emit too many events. The maximum allowed amount of events is ${maxEventElements}, but you tried to emit ${eventElements['events']}.\n\n`;
+    error += `Error: The account updates in your transaction are trying to emit too much event data. The maximum allowed number of field elements in events is ${maxEventElements}, but you tried to emit ${eventElements.events}.\n\n`;
   }
 
   if (!isWithinActionsLimit) {
-    error += `Error: The AccountUpdates in your transaction are trying to emit too many actions. The maximum allowed amount of actions is ${maxActionElements}, but you tried to emit ${eventElements['actions']}.\n\n`;
+    error += `Error: The account updates in your transaction are trying to emit too much action data. The maximum allowed number of field elements in actions is ${maxActionElements}, but you tried to emit ${eventElements.actions}.\n\n`;
   }
 
   if (error) throw Error('Error during transaction sending:\n\n' + error);

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -13,6 +13,7 @@ import {
   CallForest,
   Authorization,
   SequenceEvents,
+  Events,
 } from './account_update.js';
 
 import * as Fetch from './fetch.js';
@@ -1198,19 +1199,16 @@ function verifyTransactionLimits(accountUpdates: AccountUpdate[]) {
   const costLimit = 69.45;
 
   // constants that define the maximum number of events in one transaction
-  const maxSequenceEventElements = 16;
+  const maxActionElements = 16;
   const maxEventElements = 16;
 
-  let eventElements = {
-    events: 0,
-    sequence: 0,
-  };
+  let eventElements = { events: 0, actions: 0 };
 
   let authTypes = filterGroups(
     accountUpdates.map((update) => {
       let json = update.toJSON();
-      eventElements.events += update.body.events.data.length;
-      eventElements.sequence += update.body.actions.data.length;
+      eventElements.events += countEventElements(update.body.events);
+      eventElements.actions += countEventElements(update.body.actions);
       return json.body.authorizationKind;
     })
   );
@@ -1230,9 +1228,8 @@ function verifyTransactionLimits(accountUpdates: AccountUpdate[]) {
 
   let isWithinCostLimit = totalTimeRequired < costLimit;
 
-  let isWithinEventsLimit = eventElements['events'] <= maxEventElements;
-  let isWithinSequenceEventsLimit =
-    eventElements['sequence'] <= maxSequenceEventElements;
+  let isWithinEventsLimit = eventElements.events <= maxEventElements;
+  let isWithinActionsLimit = eventElements.actions <= maxActionElements;
 
   let error = '';
 
@@ -1250,11 +1247,15 @@ ${JSON.stringify(authTypes)}
     error += `Error: The AccountUpdates in your transaction are trying to emit too many events. The maximum allowed amount of events is ${maxEventElements}, but you tried to emit ${eventElements['events']}.\n\n`;
   }
 
-  if (!isWithinSequenceEventsLimit) {
-    error += `Error: The AccountUpdates in your transaction are trying to emit too many actions. The maximum allowed amount of actions is ${maxSequenceEventElements}, but you tried to emit ${eventElements['sequence']}.\n\n`;
+  if (!isWithinActionsLimit) {
+    error += `Error: The AccountUpdates in your transaction are trying to emit too many actions. The maximum allowed amount of actions is ${maxActionElements}, but you tried to emit ${eventElements['actions']}.\n\n`;
   }
 
   if (error) throw Error('Error during transaction sending:\n\n' + error);
+}
+
+function countEventElements({ data }: Events) {
+  return data.reduce((acc, ev) => acc + ev.length, 0);
 }
 
 type AuthorizationKind = { isProved: boolean; isSigned: boolean };

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -34,7 +34,7 @@ import {
   cloneCircuitValue,
   FlexibleProvablePure,
   getBlindingValue,
-  InferCircuitValue,
+  InferProvable,
   memoizationContext,
   provable,
   Struct,
@@ -1464,7 +1464,7 @@ function declareMethods<T extends typeof SmartContract>(
 
 const Reducer: (<
   T extends FlexibleProvablePure<any>,
-  A extends InferCircuitValue<T> = InferCircuitValue<T>
+  A extends InferProvable<T> = InferProvable<T>
 >(reducer: {
   actionType: T;
 }) => ReducerReturn<A>) & {

--- a/src/provable/provable-generic.ts
+++ b/src/provable/provable-generic.ts
@@ -10,7 +10,7 @@ export { createProvable, createHashInput, ProvableConstructor };
 type ProvableConstructor<Field> = <A>(
   typeObj: A,
   options?: { customObjectKeys?: string[]; isPure?: boolean }
-) => GenericProvableExtended<InferCircuitValue<A, Field>, InferJson<A>, Field>;
+) => GenericProvableExtended<InferProvable<A, Field>, InferJson<A>, Field>;
 
 function createProvable<Field>(): ProvableConstructor<Field> {
   type ProvableExtended<T, TJson = JSONValue> = GenericProvableExtended<
@@ -26,8 +26,8 @@ function createProvable<Field>(): ProvableConstructor<Field> {
   function provable<A>(
     typeObj: A,
     options?: { customObjectKeys?: string[]; isPure?: boolean }
-  ): ProvableExtended<InferCircuitValue<A, Field>, InferJson<A>> {
-    type T = InferCircuitValue<A, Field>;
+  ): ProvableExtended<InferProvable<A, Field>, InferJson<A>> {
+    type T = InferProvable<A, Field>;
     type J = InferJson<A>;
     let objectKeys =
       typeof typeObj === 'object' && typeObj !== null
@@ -278,25 +278,25 @@ type InferPrimitiveJson<P extends Primitive> = P extends typeof String
   ? null
   : JSONValue;
 
-type InferCircuitValue<A, Field> = A extends Constructor<infer U>
+type InferProvable<A, Field> = A extends Constructor<infer U>
   ? A extends GenericProvable<U, Field>
     ? U
-    : InferCircuitValueBase<A, Field>
-  : InferCircuitValueBase<A, Field>;
+    : InferProvableBase<A, Field>
+  : InferProvableBase<A, Field>;
 
-type InferCircuitValueBase<A, Field> = A extends GenericProvable<infer U, Field>
+type InferProvableBase<A, Field> = A extends GenericProvable<infer U, Field>
   ? U
   : A extends Primitive
   ? InferPrimitive<A>
   : A extends Tuple<any>
   ? {
-      [I in keyof A]: InferCircuitValue<A[I], Field>;
+      [I in keyof A]: InferProvable<A[I], Field>;
     }
   : A extends (infer U)[]
-  ? InferCircuitValue<U, Field>[]
+  ? InferProvable<U, Field>[]
   : A extends Record<any, any>
   ? {
-      [K in keyof A]: InferCircuitValue<A[K], Field>;
+      [K in keyof A]: InferProvable<A[K], Field>;
     }
   : never;
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1,8 +1,6 @@
 import type {
   FlexibleProvable,
-  InferCircuitValue,
-  InferJson,
-  ProvableExtended,
+  InferredProvable,
 } from './lib/circuit_value.js';
 import type { Account as JsonAccount } from './provable/gen/transaction-json.js';
 export {
@@ -818,7 +816,7 @@ declare class Circuit {
   static array<A extends FlexibleProvable<any>>(
     elementType: A,
     length: number
-  ): ProvableExtended<InferCircuitValue<A>[], InferJson<A>[]>;
+  ): InferredProvable<A[]>;
 
   /**
    * Asserts that two values are equal.


### PR DESCRIPTION
- closes https://github.com/o1-labs/snarkyjs/issues/757
  - makes event limit checks conform to the protocol: check max # of field elements, not events
- closes https://github.com/o1-labs/snarkyjs/issues/625
  - make `Circuit.array` infer whether it's pure
  - change some type names (circuit value -> provable)
- exports `FlexibleProvable` and `FlexibleProvablePure`
  - fixes pain point mentioned here and elsewhere: https://github.com/o1-labs/snarkyjs/pull/567#issuecomment-1330440318
