### PR TITLE
Add get actions to network API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a new feature to the library: `fetchEvents` can now be used to fetch events for a specified zkApp from a GraphQL endpoint that implements the schema specified [here](https://github.com/o1-labs/Archive-Node-API/blob/efebc9fd3cfc028f536ae2125e0d2676e2b86cd2/src/schema.ts#L1). `Mina.Network` now accepts an additional endpoint to configure, which points to a GraphQL server running the mentioned schema. Use the `mina` property for normal usage and use `archive` to connect to the mentioned GraphQL server.
+- Added a new feature to the library: `getActions` can now be used to fetch actions for a specified zkApp from a GraphQL endpoint that implements the same schema as `fetchEvents`.
 
 ### Fixed
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -536,7 +536,7 @@ function sendZkappQuery(json: string) {
 }
 `;
 }
-type FetchedEventActionBase = {
+type FetchedEvents = {
   blockInfo: {
     distanceFromMaxBlockHeight: number;
     globalSlotSinceGenesis: number;
@@ -550,18 +550,16 @@ type FetchedEventActionBase = {
     memo: string;
     status: string;
   };
-};
-type FetchedEvents = {
   eventData: {
     data: string[];
   }[];
-} & FetchedEventActionBase;
+};
 type FetchedActions = {
+  actionState: string;
   actionData: {
     data: string[];
   }[];
-  actionState: string;
-} & FetchedEventActionBase;
+};
 
 type EventActionFilterOptions = {
   to?: UInt32;

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,5 +1,5 @@
 import 'isomorphic-fetch';
-import { Field } from '../snarky.js';
+import { Field, Ledger } from '../snarky.js';
 import { UInt32, UInt64 } from './int.js';
 import { TokenId } from './account_update.js';
 import { PublicKey } from './signature.js';
@@ -746,7 +746,7 @@ async function fetchActions(
 
   const actionData = fetchedActions.map((action) => {
     return {
-      hash: action.actionState,
+      hash: Ledger.fieldToBase58(Field(action.actionState)),
       actions: action.actionData.map((actionData) => actionData.data),
     };
   });

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -744,12 +744,14 @@ async function fetchActions(
     };
   }
 
-  const actionData = fetchedActions.map((action) => {
-    return {
-      hash: Ledger.fieldToBase58(Field(action.actionState)),
-      actions: action.actionData.map((actionData) => actionData.data),
-    };
-  });
+  const actionData = fetchedActions
+    .map((action) => {
+      return {
+        hash: Ledger.fieldToBase58(Field(action.actionState)),
+        actions: action.actionData.map((actionData) => actionData.data),
+      };
+    })
+    .reverse(); // Reverse the order of actions since the API returns in descending order of block height while Localblockchain pushes new actions to end of array.
   addCachedActionsInternal(
     {
       publicKey: PublicKey.fromBase58(publicKey),

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -225,7 +225,7 @@ async function fetchMissingData(
         { publicKey, tokenId },
         archiveEndpoint
       );
-      if ('error' in response && response.error === undefined)
+      if (!('error' in response) || response.error === undefined)
         delete actionsToFetch[key];
     }
   );

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -739,7 +739,7 @@ async function fetchActions(
     return {
       error: {
         statusCode: 404,
-        statusText: `fetchActions: Account with public key ${publicKey} does not exist.`,
+        statusText: `fetchActions: Account with public key ${publicKey} with tokenId ${tokenId} does not exist.`,
       },
     };
   }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -617,19 +617,6 @@ const getActionsQuery = (
   }
   return `{
   actions(input: { ${input} }) {
-    blockInfo {
-      distanceFromMaxBlockHeight
-      height
-      globalSlotSinceGenesis
-      stateHash
-      parentHash
-      chainStatus
-    }
-    transactionInfo {
-      hash
-      memo
-      status
-    }
     actionState
     actionData {
       data

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -226,7 +226,7 @@ async function fetchMissingData(
         archiveEndpoint
       );
       if ('error' in response && response.error === undefined)
-        delete accountsToFetch[key];
+        delete actionsToFetch[key];
     }
   );
   promises.push(...actionPromises);

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -488,7 +488,6 @@ type FetchedEventActionBase = {
 };
 type FetchedEvents = {
   eventData: {
-    index: string;
     data: string[];
   }[];
 } & FetchedEventActionBase;

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -811,7 +811,7 @@ function Network(input: { mina: string; archive: string } | string): Mina {
         if (actions !== undefined) return actions;
       }
       throw Error(
-        `getActions: Could not find actions for the for public key ${publicKey}`
+        `getActions: Could not find actions for the public key ${publicKey}`
       );
     },
     proofsEnabled: true,


### PR DESCRIPTION
## Description
Adds `getActions` to the network API. Uses a GraphQL server implements the [following schema](https://github.com/o1-labs/Archive-Node-API/blob/main/schema.graphql)

`getActions` is used in `methods,` so it cannot be asynchronous. Instead, we use the caching system already wired up to fetch account and network data. We create a new action cache and add it to the promises executed in `fetchMissingData`. When `fetchMissingData` is called, `fetchActions` queries the GraphQL schema and then caches the results, which can then be used by `method`s of a smart contract in a non-asynchronous way.

## Tested
Manual Testing at these addresses:
https://berkeley.minaexplorer.com/wallet/B62qnL4b3wuAPwFb5E7ChYgDJFdxZgmud2kkx2N8RzNaq4ykagfzumy
https://berkeley.minaexplorer.com/wallet/B62qp7bmbYVpuhqRFmmMDGWcZQBavf9T5Lo1Jfj7yjSaPx2awYcTTvF
https://berkeley.minaexplorer.com/wallet/B62qp2SfYeLBo3p1ZwMS33qtqn6qCnAjAMXzTy6ZAYzYG8DLTr8xqhS

## Discussion
Do we want to change the return types for actions to include the extra data returned from the GraphQL server? I left the data inside the query, but if it's not essential, I will remove it to save on network traffic.