### PR TITLE
Update package.json to include ts source files in released package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "files": [
     "src/build",
     "dist",
-    "src/lib",
-    "src/**/*.d.ts"
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "**/*.map"
   ],
   "bin": {
     "snarky-run": "src/build/run.js"


### PR DESCRIPTION
This PR includes ts source files in the released package. Sourcemap warnings occurred previously because only part of the ts source files were bundled in the released package. https://github.com/o1-labs/zkapp-cli/issues/383
 ```
 WARN  Sourcemap for "/node_modules/snarkyjs/dist/node/js_crypto/constants.js" points to missing source files

 WARN  Sourcemap for "/node_modules/snarkyjs/dist/node/snarky/wrapper.js" points to missing source files

 WARN  Sourcemap for "/node_modules/snarkyjs/dist/node/snarky/proxy.js" points to missing source files

 WARN  Sourcemap for "/node_modules/snarkyjs/dist/node/provable/field-bigint.js" points to missing source files
```
