### PR TITLE
Improve Merkle root hashing circuit by 1 constraint / level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,20 +17,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/4573252d...HEAD)
 
+> There are no unreleased changes yet
+
+## [0.9.5](https://github.com/o1-labs/snarkyjs/compare/21de489...4573252d)
+
 ### Breaking changes
 
 - Change type of verification key returned by `SmartContract.compile()` to match `VerificationKey` https://github.com/o1-labs/snarkyjs/pull/812
 
 ### Fixed
 
-- Update the zkApp verification key from within one of its own methods, via proof https://github.com/o1-labs/snarkyjs/pull/812
-
-## [0.9.5](https://github.com/o1-labs/snarkyjs/compare/21de489...4573252d)
-
-### Fixed
-
 - Failing `Mina.transaction` on Berkeley because of unsatisfied constraints caused by dummy data before we fetched account state https://github.com/o1-labs/snarkyjs/pull/807
   - Previously, you could work around this by calling `fetchAccount()` for every account invovled in a transaction. This is not necessary anymore.
+- Update the zkApp verification key from within one of its own methods, via proof https://github.com/o1-labs/snarkyjs/pull/812
 
 ## [0.9.4](https://github.com/o1-labs/snarkyjs/compare/9acec55...21de489)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/4573252d...HEAD)
 
-> There are no unreleased changes yet
+### Breaking changes
+
+- Improve number of constraints needed for Merkle tree hashing https://github.com/o1-labs/snarkyjs/pull/820
+  - This breaks deployed zkApps which use `MerkleWitness.calculateRoot()`, because the circuit is changed
+  - You can make your existing contracts compatible again by switching to `MerkleWitness.calculateRootSlow()`, which has the old circuit
 
 ## [0.9.5](https://github.com/o1-labs/snarkyjs/compare/21de489...4573252d)
 

--- a/src/examples/zkapps/voting/membership.ts
+++ b/src/examples/zkapps/voting/membership.ts
@@ -151,7 +151,7 @@ export class Membership_ extends SmartContract {
     this.committedMembers.assertEquals(committedMembers);
 
     return member.witness
-      .calculateRoot(member.getHash())
+      .calculateRootSlow(member.getHash())
       .equals(committedMembers);
   }
 
@@ -187,7 +187,7 @@ export class Membership_ extends SmartContract {
           // otherwise, we simply return the unmodified state - this is our way of branching
           return Circuit.if(
             isRealMember,
-            action.witness.calculateRoot(action.getHash()),
+            action.witness.calculateRootSlow(action.getHash()),
             state
           );
         },

--- a/src/examples/zkapps/voting/voting.ts
+++ b/src/examples/zkapps/voting/voting.ts
@@ -279,7 +279,7 @@ export class Voting_ extends SmartContract {
           // apply one vote
           action = action.addVote();
           // this is the new root after we added one vote
-          return action.votesWitness.calculateRoot(action.getHash());
+          return action.votesWitness.calculateRootSlow(action.getHash());
         },
         // initial state
         { state: committedVotes, actionsHash: accumulatedVotes }

--- a/src/lib/merkle-tree.unit-test.ts
+++ b/src/lib/merkle-tree.unit-test.ts
@@ -2,7 +2,7 @@ import { Bool, Field } from './core.js';
 import { maybeSwap, maybeSwapBad } from './merkle_tree.js';
 import { Random, test } from './testing/property.js';
 import { expect } from 'expect';
-import { isReady } from '../snarky.js';
+import { isReady, shutdown } from '../snarky.js';
 
 await isReady;
 
@@ -23,3 +23,5 @@ test(Random.bool, Random.field, Random.field, (b, x, y) => {
     expect(y0.toBigInt()).toEqual(x);
   }
 });
+
+shutdown();

--- a/src/lib/merkle-tree.unit-test.ts
+++ b/src/lib/merkle-tree.unit-test.ts
@@ -1,0 +1,25 @@
+import { Bool, Field } from './core.js';
+import { maybeSwap, maybeSwapBad } from './merkle_tree.js';
+import { Random, test } from './testing/property.js';
+import { expect } from 'expect';
+import { isReady } from '../snarky.js';
+
+await isReady;
+
+test(Random.bool, Random.field, Random.field, (b, x, y) => {
+  let [x0, y0] = maybeSwap(Bool(!!b), Field(x), Field(y));
+  let [x1, y1] = maybeSwapBad(Bool(!!b), Field(x), Field(y));
+
+  // both versions of `maybeSwap` should behave the same
+  expect(x0).toEqual(x1);
+  expect(y0).toEqual(y1);
+
+  // if the boolean is true, it shouldn't swap the fields; otherwise, it should
+  if (b) {
+    expect(x0.toBigInt()).toEqual(x);
+    expect(y0.toBigInt()).toEqual(y);
+  } else {
+    expect(x0.toBigInt()).toEqual(y);
+    expect(y0.toBigInt()).toEqual(x);
+  }
+});

--- a/src/lib/merkle_tree.ts
+++ b/src/lib/merkle_tree.ts
@@ -193,6 +193,23 @@ class BaseMerkleWitness extends CircuitValue {
   }
 
   /**
+   * Calculates a root depending on the leaf value.
+   * @deprecated This is a less efficient version of {@link calculateRoot} which was added for compatibility with existing deployed contracts
+   */
+  calculateRootSlow(leaf: Field): Field {
+    let hash = leaf;
+    let n = this.height();
+
+    for (let i = 1; i < n; ++i) {
+      let isLeft = this.isLeft[i - 1];
+      const [left, right] = maybeSwapBad(isLeft, hash, this.path[i - 1]);
+      hash = Poseidon.hash([left, right]);
+    }
+
+    return hash;
+  }
+
+  /**
    * Calculates the index of the leaf node that belongs to this Witness.
    * @returns Index of the leaf.
    */


### PR DESCRIPTION
This improves the constraints needed by `MerkleWitness.calculateRoot()` from $15.5 n$ to $14.5 n$, where $n + 1$ is the tree height. The improvement is achieved by reusing computation done internally by two separate calls to `Circuit.if`.

Unrelated: Fixes the changelog which got messed up by merging
