### PR TITLE
Change fetchEvents to return transactionInfo inside events type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - This breaks deployed zkApps which use `MerkleWitness.calculateRoot()`, because the circuit is changed
   - You can make your existing contracts compatible again by switching to `MerkleWitness.calculateRootSlow()`, which has the old circuit
 
+### Fixed
+
+- Improved Event Handling in SnarkyJS https://github.com/o1-labs/snarkyjs/pull/825
+  - Updated the internal event type to better handle events emitted in different zkApp transactions and when multiple zkApp transactions are present within a block.
+  - The internal event type now includes event data and transaction information as separate objects, allowing for more accurate information about each event and its associated transaction.
+
 ## [0.9.5](https://github.com/o1-labs/snarkyjs/compare/21de489...4573252d)
 
 ### Breaking changes

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -545,12 +545,12 @@ type FetchedEvents = {
     parentHash: string;
     chainStatus: string;
   };
-  transactionInfo: {
-    hash: string;
-    memo: string;
-    status: string;
-  };
   eventData: {
+    transactionInfo: {
+      hash: string;
+      memo: string;
+      status: string;
+    };
     data: string[];
   }[];
 };
@@ -590,12 +590,12 @@ const getEventsQuery = (
       parentHash
       chainStatus
     }
-    transactionInfo {
-      hash
-      memo
-      status
-    }
     eventData {
+      transactionInfo {
+        hash
+        memo
+        status
+      }
       data
     }
   }
@@ -686,7 +686,12 @@ async function fetchEvents(
   }
 
   return fetchedEvents.map((event) => {
-    let events = event.eventData.map((eventData) => eventData.data);
+    let events = event.eventData.map((eventData) => {
+      return {
+        data: eventData.data,
+        transactionInfo: eventData.transactionInfo,
+      };
+    });
 
     return {
       events,
@@ -695,9 +700,6 @@ async function fetchEvents(
       parentBlockHash: event.blockInfo.parentHash,
       globalSlot: UInt32.from(event.blockInfo.globalSlotSinceGenesis),
       chainStatus: event.blockInfo.chainStatus,
-      transactionHash: event.transactionInfo.hash,
-      transactionStatus: event.transactionInfo.status,
-      transactionMemo: event.transactionInfo.memo,
     };
   });
 }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -686,10 +686,10 @@ async function fetchEvents(
   }
 
   return fetchedEvents.map((event) => {
-    let events = event.eventData.map((eventData) => {
+    let events = event.eventData.map(({ data, transactionInfo }) => {
       return {
-        data: eventData.data,
-        transactionInfo: eventData.transactionInfo,
+        data,
+        transactionInfo,
       };
     });
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -475,8 +475,18 @@ function LocalBlockchain({
           if (events[addr][tokenId] === undefined) {
             events[addr][tokenId] = [];
           }
+          let updatedEvents = p.body.events.map((data) => {
+            return {
+              data,
+              transactionInfo: {
+                transactionHash: '',
+                transactionStatus: '',
+                transactionMemo: '',
+              },
+            };
+          });
           events[addr][tokenId].push({
-            events: p.body.events,
+            events: updatedEvents,
             blockHeight: networkState.blockchainLength,
             globalSlot: networkState.globalSlotSinceGenesis,
             // The following fields are fetched from the Mina network. For now, we mock these values out
@@ -484,9 +494,6 @@ function LocalBlockchain({
             blockHash: '',
             parentBlockHash: '',
             chainStatus: '',
-            transactionHash: '',
-            transactionStatus: '',
-            transactionMemo: '',
           });
         }
 

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1069,15 +1069,19 @@ super.init();
   ): Promise<
     {
       type: string;
-      event: ProvablePure<any>;
+      event: {
+        data: ProvablePure<any>;
+        transactionInfo: {
+          transactionHash: string;
+          transactionStatus: string;
+          transactionMemo: string;
+        };
+      };
       blockHeight: UInt32;
       blockHash: string;
       parentBlockHash: string;
       globalSlot: UInt32;
       chainStatus: string;
-      transactionHash: string;
-      transactionStatus: string;
-      transactionMemo: string;
     }[]
   > {
     // filters all elements so that they are within the given range
@@ -1114,26 +1118,40 @@ super.init();
       if (sortedEventTypes.length === 1) {
         let type = sortedEventTypes[0];
         let event = this.events[type].fromFields(
-          eventData.event.map((f: string) => Field(f))
+          eventData.event.data.map((f: string) => Field(f))
         );
         return {
           ...eventData,
           type,
-          event,
+          event: {
+            data: event,
+            transactionInfo: {
+              transactionHash: eventData.event.transactionInfo.hash,
+              transactionStatus: eventData.event.transactionInfo.status,
+              transactionMemo: eventData.event.transactionInfo.memo,
+            },
+          },
         };
       } else {
         // if there are multiple events we have to use the index event[0] to find the exact event type
-        let eventObjectIndex = Number(eventData.event[0]);
+        let eventObjectIndex = Number(eventData.event.data[0]);
         let type = sortedEventTypes[eventObjectIndex];
         // all other elements of the array are values used to construct the original object, we can drop the first value since its just an index
-        let eventProps = eventData.event.slice(1);
+        let eventProps = eventData.event.data.slice(1);
         let event = this.events[type].fromFields(
           eventProps.map((f: string) => Field(f))
         );
         return {
           ...eventData,
           type,
-          event,
+          event: {
+            data: event,
+            transactionInfo: {
+              transactionHash: eventData.event.transactionInfo.hash,
+              transactionStatus: eventData.event.transactionInfo.status,
+              transactionMemo: eventData.event.transactionInfo.memo,
+            },
+          },
         };
       }
     });


### PR DESCRIPTION
# Description
🔗 Related Issue: https://github.com/o1-labs/snarkyjs/issues/806

This PR addresses an issue with the internal event type in SnarkyJS. Previously, the event handling assumed that all events were contained within the same zkApp transaction, which isn't always true. Events can be emitted in different zkApp transactions, and multiple zkApp transactions can be present within a block.

To resolve this, we have updated the internal event type to include event data and transaction information as separate objects. This allows us to provide accurate information about each event, taking into account the specific transaction it belongs to.

Please note that there is a related PR for the Archive Node API, which can be found here: https://github.com/o1-labs/Archive-Node-API/pull/68

Both PRs should be merged simultaneously to ensure proper coordination and integration. 