### PR TITLE
[WIP] Fix `isSuccess` always returning true, even if transaction fails

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -134,7 +134,7 @@ async function fetchAccountInternal(
 }
 
 type FetchConfig = { timeout?: number };
-type FetchResponse = { data: any };
+type FetchResponse = { data: any; errors?: any };
 type FetchError = {
   statusCode: number;
   statusText: string;
@@ -855,7 +855,17 @@ async function checkResponseStatus(
   response: Response
 ): Promise<[FetchResponse, undefined] | [undefined, FetchError]> {
   if (response.ok) {
-    return [(await response.json()) as FetchResponse, undefined];
+    let jsonResponse = await response.json();
+    if (jsonResponse.errors && jsonResponse.errors.length > 0) {
+      return [
+        undefined,
+        {
+          statusCode: response.status,
+          statusText: jsonResponse.errors,
+        } as FetchError,
+      ];
+    }
+    return [jsonResponse as FetchResponse, undefined];
   } else {
     return [
       undefined,

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -715,18 +715,17 @@ function Network(input: { mina: string; archive: string } | string): Mina {
 
       let [response, error] = await Fetch.sendZkapp(txn.toJSON());
       let errors: any[] | undefined;
-      if (error === undefined) {
-        if (response!.data === null && (response as any).errors?.length > 0) {
-          console.log(
-            'got graphql errors',
-            JSON.stringify((response as any).errors, null, 2)
-          );
-          errors = (response as any).errors;
-        }
-      } else {
+      if (response === undefined && error !== undefined) {
         console.log('got fetch error', error);
         errors = [error];
+      } else if (response && response.errors && response.errors.length > 0) {
+        console.log(
+          'got graphql errors',
+          JSON.stringify(response.errors, null, 2)
+        );
+        errors = response.errors;
       }
+
       let isSuccess = errors === undefined;
 
       let maxAttempts: number;


### PR DESCRIPTION
## Description
:link: Related Issue: https://github.com/o1-labs/snarkyjs/issues/819

Refactors some of the response and error checking logic when sending GraphQL requests. 

At the time of this PR, the Berkeley network is not including transactions in blocks due to a SNARK issue, so this has not been tested yet. This will be tested when Berkeley is accepting transactions again.