### PR TITLE
Add endActionState and fromActionState to fetchActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Improve number of constraints needed for Merkle tree hashing https://github.com/o1-labs/snarkyjs/pull/820
   - This breaks deployed zkApps which use `MerkleWitness.calculateRoot()`, because the circuit is changed
   - You can make your existing contracts compatible again by switching to `MerkleWitness.calculateRootSlow()`, which has the old circuit
+- Renamed Function Parameters: The `getAction` function now accepts a new object structure for its parameters. https://github.com/o1-labs/snarkyjs/pull/828
+  - The previous object keys, `fromActionHash` and `endActionHash`, have been replaced by `fromActionState` and `endActionState`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - The internal event type now includes event data and transaction information as separate objects, allowing for more accurate information about each event and its associated transaction.
 - Removed multiple best tip blocks when fetching action data https://github.com/o1-labs/snarkyjs/pull/817
   - Implemented a temporary fix that filters out multiple best tip blocks, if they exist, while fetching actions. This fix will be removed once the related issue in the Archive-Node-API repository (https://github.com/o1-labs/Archive-Node-API/issues/7) is resolved.
-- New `fromActionHash` and `endActionHash` parameters for fetchActions function in SnarkyJS https://github.com/o1-labs/snarkyjs/pull/828
-  - Allows fetching only necessary actions to compute the latest actions hash
+- New `fromActionState` and `endActionState` parameters for fetchActions function in SnarkyJS https://github.com/o1-labs/snarkyjs/pull/828
+  - Allows fetching only necessary actions to compute the latest actions state
   - Eliminates the need to retrieve the entire actions history of a zkApp
   - Utilizes `actionStateTwo` field returned by Archive Node API as a safe starting point for deriving the most recent action hash
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - The internal event type now includes event data and transaction information as separate objects, allowing for more accurate information about each event and its associated transaction.
 - Removed multiple best tip blocks when fetching action data https://github.com/o1-labs/snarkyjs/pull/817
   - Implemented a temporary fix that filters out multiple best tip blocks, if they exist, while fetching actions. This fix will be removed once the related issue in the Archive-Node-API repository (https://github.com/o1-labs/Archive-Node-API/issues/7) is resolved.
+- New `fromActionHash` and `endActionHash` parameters for fetchActions function in SnarkyJS https://github.com/o1-labs/snarkyjs/pull/828
+  - Allows fetching only necessary actions to compute the latest actions hash
+  - Eliminates the need to retrieve the entire actions history of a zkApp
+  - Utilizes `actionStateTwo` field returned by Archive Node API as a safe starting point for deriving the most recent action hash
 
 ## [0.9.5](https://github.com/o1-labs/snarkyjs/compare/21de489...4573252d)
 

--- a/src/examples/zkapps/reducer/reducer.ts
+++ b/src/examples/zkapps/reducer/reducer.ts
@@ -39,7 +39,7 @@ class CounterZkapp extends SmartContract {
 
     // compute the new counter and hash from pending actions
     let pendingActions = this.reducer.getActions({
-      fromActionHash: actionsHash,
+      fromActionState: actionsHash,
     });
 
     let { state: newCounter, actionsHash: newActionsHash } =

--- a/src/examples/zkapps/reducer/reducer_composite.ts
+++ b/src/examples/zkapps/reducer/reducer_composite.ts
@@ -50,7 +50,7 @@ class CounterZkapp extends SmartContract {
 
     // compute the new counter and hash from pending actions
     let pendingActions = this.reducer.getActions({
-      fromActionHash: actionsHash,
+      fromActionState: actionsHash,
     });
 
     let { state: newCounter, actionsHash: newActionsHash } =

--- a/src/examples/zkapps/voting/membership.ts
+++ b/src/examples/zkapps/voting/membership.ts
@@ -115,7 +115,7 @@ export class Membership_ extends SmartContract {
     // checking if the member already exists within the accumulator
     let { state: exists } = this.reducer.reduce(
       this.reducer.getActions({
-        fromActionHash: accumulatedMembers,
+        fromActionState: accumulatedMembers,
       }),
       Bool,
       (state: Bool, action: Member) => {
@@ -168,7 +168,7 @@ export class Membership_ extends SmartContract {
     this.committedMembers.assertEquals(committedMembers);
 
     let pendingActions = this.reducer.getActions({
-      fromActionHash: accumulatedMembers,
+      fromActionState: accumulatedMembers,
     });
 
     let { state: newCommittedMembers, actionsHash: newAccumulatedMembers } =

--- a/src/examples/zkapps/voting/voting.ts
+++ b/src/examples/zkapps/voting/voting.ts
@@ -273,7 +273,7 @@ export class Voting_ extends SmartContract {
 
     let { state: newCommittedVotes, actionsHash: newAccumulatedVotes } =
       this.reducer.reduce(
-        this.reducer.getActions({ fromActionHash: accumulatedVotes }),
+        this.reducer.getActions({ fromActionState: accumulatedVotes }),
         Field,
         (state: Field, action: Member) => {
           // apply one vote

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -641,7 +641,7 @@ const getActionsQuery = (
     input += `, fromActionState: "${fromActionState}"`;
   }
   if (endActionState !== undefined) {
-    input += `, endActionHash: "${endActionState}"`;
+    input += `, endActionState: "${endActionState}"`;
   }
   return `{
   actions(input: { ${input} }) {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -591,48 +591,37 @@ function LocalBlockchain({
       actionStates?: ActionStates,
       tokenId: Field = TokenId.default
     ): { hash: string; actions: string[][] }[] {
+      let currentActions: { hash: string; actions: string[][] }[] =
+        actions?.[publicKey.toBase58()]?.[Ledger.fieldToBase58(tokenId)] ?? [];
       let { fromActionState, endActionState } = actionStates ?? {};
-      let actionsForAccount: { hash: string; actions: string[][] }[] = [];
 
-      Circuit.asProver(() => {
-        // if the fromActionState is the empty state, we fetch all events
-        fromActionState = fromActionState
-          ?.equals(SequenceEvents.emptySequenceState())
-          .toBoolean()
-          ? undefined
-          : fromActionState;
+      fromActionState = fromActionState
+        ?.equals(SequenceEvents.emptySequenceState())
+        .toBoolean()
+        ? undefined
+        : fromActionState;
 
-        // used to determine start and end values in string
-        let start: string | undefined = fromActionState
-          ? Ledger.fieldToBase58(fromActionState)
-          : undefined;
-        let end: string | undefined = endActionState
-          ? Ledger.fieldToBase58(endActionState)
-          : undefined;
+      // used to determine start and end values in string
+      let start: string | undefined = fromActionState
+        ? Ledger.fieldToBase58(fromActionState)
+        : undefined;
+      let end: string | undefined = endActionState
+        ? Ledger.fieldToBase58(endActionState)
+        : undefined;
 
-        let currentActions =
-          actions?.[publicKey.toBase58()]?.[Ledger.fieldToBase58(tokenId)] ??
-          [];
+      let startIndex = start
+        ? currentActions.findIndex((e) => e.hash === start) + 1
+        : 0;
+      let endIndex = end
+        ? currentActions.findIndex((e) => e.hash === end) + 1
+        : undefined;
 
-        // gets the start/end indices of our array slice
-        let startIndex = start
-          ? currentActions.findIndex(
-              (e: { hash: string; actions: string[] }) => e.hash === start
-            ) + 1
-          : 0;
-
-        let endIndex = end
-          ? currentActions.findIndex(
-              (e: { hash: string; actions: string[] }) => e.hash === end
-            ) + 1
-          : undefined;
-
-        actionsForAccount = actions.slice(
+      return (
+        currentActions?.slice(
           startIndex,
           endIndex === 0 ? undefined : endIndex
-        );
-      });
-      return actionsForAccount;
+        ) ?? []
+      );
     },
     addAccount,
     /**

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1262,7 +1262,7 @@ type ReducerReturn<Action> = {
    *
    * ```ts
    *  let pendingActions = this.reducer.getActions({
-   *    fromActionHash: actionsHash,
+   *    fromActionState: actionsHash,
    *  });
    *
    *  let { state: newState, actionsHash: newActionsHash } =
@@ -1288,16 +1288,16 @@ type ReducerReturn<Action> = {
    * Fetches the list of previously emitted {@link Action}s by this {@link SmartContract}.
    * ```ts
    * let pendingActions = this.reducer.getActions({
-   *    fromActionHash: actionsHash,
+   *    fromActionState: actionsHash,
    * });
    * ```
    */
   getActions({
-    fromActionHash,
-    endActionHash,
+    fromActionState,
+    endActionState,
   }: {
-    fromActionHash?: Field;
-    endActionHash?: Field;
+    fromActionState?: Field;
+    endActionState?: Field;
   }): Action[][];
 };
 
@@ -1391,19 +1391,19 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
       return { state, actionsHash };
     },
     getActions({
-      fromActionHash,
-      endActionHash,
+      fromActionState,
+      endActionState,
     }: {
-      fromActionHash?: Field;
-      endActionHash?: Field;
+      fromActionState?: Field;
+      endActionState?: Field;
     }): A[][] {
       let actionsForAccount: A[][] = [];
       Circuit.asProver(() => {
         let actions = Mina.getActions(
           contract.address,
           {
-            fromActionState: fromActionHash,
-            endActionState: endActionHash,
+            fromActionState,
+            endActionState,
           },
           contract.self.tokenId
         );

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1408,9 +1408,9 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
           contract.self.tokenId
         );
 
-        // putting our string-Fields back into the original action type
         actionsForAccount = actions.map(
           (event: { hash: string; actions: string[][] }) =>
+            // putting our string-Fields back into the original action type
             event.actions.map((action: string[]) =>
               (reducer.actionType as ProvablePure<A>).fromFields(
                 action.map((fieldAsString: string) => Field(fieldAsString))

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1396,7 +1396,14 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
           ? Ledger.fieldToBase58(endActionHash)
           : undefined;
 
-        let actions = Mina.getActions(contract.address, contract.self.tokenId);
+        let actions = Mina.getActions(
+          contract.address,
+          {
+            fromActionHash,
+            endActionHash,
+          },
+          contract.self.tokenId
+        );
 
         // gets the start/end indices of our array slice
         let startIndex = start

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1399,49 +1399,24 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
     }): A[][] {
       let actionsForAccount: A[][] = [];
       Circuit.asProver(() => {
-        // if the fromActionHash is the empty state, we fetch all events
-        fromActionHash = fromActionHash
-          ?.equals(SequenceEvents.emptySequenceState())
-          .toBoolean()
-          ? undefined
-          : fromActionHash;
-
-        // used to determine start and end values in string
-        let start: string | undefined = fromActionHash
-          ? Ledger.fieldToBase58(fromActionHash)
-          : undefined;
-        let end: string | undefined = endActionHash
-          ? Ledger.fieldToBase58(endActionHash)
-          : undefined;
-
         let actions = Mina.getActions(
           contract.address,
           {
-            fromActionHash,
-            endActionHash,
+            fromActionState: fromActionHash,
+            endActionState: endActionHash,
           },
           contract.self.tokenId
         );
 
-        // gets the start/end indices of our array slice
-        let startIndex = start
-          ? actions.findIndex((e) => e.hash === start) + 1
-          : 0;
-        let endIndex = end
-          ? actions.findIndex((e) => e.hash === end) + 1
-          : undefined;
-
-        // slices the array so we only get the wanted range between fromActionHash and endActionHash
-        actionsForAccount = actions
-          .slice(startIndex, endIndex === 0 ? undefined : endIndex)
-          .map((event: { hash: string; actions: string[][] }) =>
-            // putting our string-Fields back into the original action type
+        // putting our string-Fields back into the original action type
+        actionsForAccount = actions.map(
+          (event: { hash: string; actions: string[][] }) =>
             event.actions.map((action: string[]) =>
               (reducer.actionType as ProvablePure<A>).fromFields(
                 action.map((fieldAsString: string) => Field(fieldAsString))
               )
             )
-          );
+        );
       });
 
       return actionsForAccount;


### PR DESCRIPTION
# Description
:link: Resolves https://github.com/o1-labs/snarkyjs/issues/802

This PR introduces `fromActionState` and `endActionState` parameters to the `fetchActions` function in SnarkyJS. This enhancement allows us to fetch only the necessary actions to compute the latest actions state, instead of retrieving the entire actions history of a zkApp as done previously.

With these improvements, we no longer need to start from an empty action state and apply hashes to derive the current action state by analyzing each block from the beginning of a zkApp's history. Instead, we can utilize the new `actionStateTwo` field returned by the Archive Node API. As `actionStateTwo` represents the second latest action state calculated, it serves as a safe starting point for deriving the most recent action state. We can now apply AccountUpdates to the `actionStateTwo` value to compute the current action state.

Furthermore, users can now provide a `fromActionState` parameter to the Archive Node API, which will return actions only after the specified action state. This feature offers a filtering option in SnarkyJS that was previously unavailable.

Please note that this PR relies on https://github.com/o1-labs/Archive-Node-API/pull/71.