### PR TITLE
Add analyzeMethods() to ZkProgram

### DIFF
--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -170,6 +170,7 @@ function ZkProgram<
   compile: () => Promise<{ verificationKey: string }>;
   verify: (proof: Proof<InferProvable<PublicInputType>>) => Promise<boolean>;
   digest: () => string;
+  analyzeMethods: () => ReturnType<typeof analyzeMethod>[];
   publicInputType: PublicInputType;
 } & {
   [I in keyof Types]: Prover<InferProvable<PublicInputType>, Types[I]>;
@@ -267,9 +268,15 @@ function ZkProgram<
     return hash.toBigInt().toString(16);
   }
 
+  function analyzeMethods() {
+    return methodIntfs.map((methodEntry, i) =>
+      analyzeMethod(publicInputType, methodEntry, methodFunctions[i])
+    );
+  }
+
   return Object.assign(
     selfTag,
-    { compile, verify, digest, publicInputType },
+    { compile, verify, digest, publicInputType, analyzeMethods },
     provers
   );
 }

--- a/src/lib/proof_system.unit-test.ts
+++ b/src/lib/proof_system.unit-test.ts
@@ -1,0 +1,58 @@
+import { Field, isReady, shutdown } from '../snarky.js';
+import { Struct } from './circuit_value.js';
+import { UInt64 } from './int.js';
+import { ZkProgram } from './proof_system.js';
+import { expect } from 'expect';
+
+await isReady;
+
+const EmptyProgram = ZkProgram({
+  publicInput: Field,
+  methods: {
+    run: {
+      privateInputs: [],
+      method: (publicInput: Field) => {},
+    },
+  },
+});
+
+const emptyMethodsMetadata = EmptyProgram.analyzeMethods();
+emptyMethodsMetadata.forEach((methodMetadata) => {
+  expect(methodMetadata).toEqual({
+    rows: 0,
+    digest: '4f5ddea76d29cfcfd8c595f14e31f21b',
+    result: undefined,
+    gates: [],
+    publicInputSize: 0,
+  });
+});
+
+class CounterPublicInput extends Struct({
+  current: UInt64,
+  updated: UInt64,
+}) {}
+const CounterProgram = ZkProgram({
+  publicInput: CounterPublicInput,
+  methods: {
+    increment: {
+      privateInputs: [UInt64],
+      method: (
+        { current, updated }: CounterPublicInput,
+        incrementBy: UInt64
+      ) => {
+        const newCount = current.add(incrementBy);
+        newCount.assertEquals(updated);
+      },
+    },
+  },
+});
+
+const incrementMethodMetadata = CounterProgram.analyzeMethods()[0];
+expect(incrementMethodMetadata).toEqual(
+  expect.objectContaining({
+    rows: 18,
+    digest: '62d893f727b12d540bdc483427cbd70b',
+  })
+);
+
+shutdown();


### PR DESCRIPTION
This PR implements #827 and adds a simple unit test for the `proof_system.ts` to test it.

I have encountered a few issues when implementing this:
- i couldn't find an appropriate type/interface definition for `analyzeMethod`, so i've used its `ReturnType` instead.
- `run-unit-tests.sh` does not work on Mac due to using features available on bash v4+ (mac runs bash v3). I have installed bash v5 with brew and ran unit tests by hand like this to workaround this issue: `/opt/homebrew/bin/bash ./run-unit-tests.sh`. This could be solved for the long term by replacing `/bin/bash` in the shell scripts to respect the user env, [more information here](https://stackoverflow.com/a/56491222)


~~Question on the side - `.github/workflows/build-action.yml` does not seem to run unit tests. When/where do the unit tests run, assuming they're part of the CI?~~ Answer: `run-ci-tests.sh`