### PR TITLE
Fix Fetch.fetchActions and add new fetchActions method for external use

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -824,6 +824,7 @@ async function fetchActions(
 
       if (isSameAccountUpdate && !isLastAction) {
         currentActionList.push(data);
+        currentAccountUpdateId = accountUpdateId;
         return;
       } else if (isSameAccountUpdate && isLastAction) {
         currentActionList.push(data);

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -749,7 +749,7 @@ async function fetchActions(
 ) {
   if (!graphqlEndpoint)
     throw new Error(
-      'fetchEvents: Specified GraphQL endpoint is undefined. Please specify a valid endpoint.'
+      'fetchActions: Specified GraphQL endpoint is undefined. Please specify a valid endpoint.'
     );
   const { publicKey, actionStates, tokenId } = accountInfo;
   let [response, error] = await makeGraphqlRequest(


### PR DESCRIPTION
- Fix Fetch.fetchActions

When sending actions in the following ways, an error will be reported when using the existing getActions method to get actions data：
```typescript
let tx = await Mina.transaction(
        {
          sender: feePayerAddress,
          fee: txFee,
        },
        () => {
          zkapp.doSomething(); // dispatch 1 action
          zkapp.doSomething(); // dispatch 1 action
        }
);
```
![999](https://user-images.githubusercontent.com/3725514/231054038-906ab30d-6e5c-4c5a-8714-e1d8074050d3.PNG)

This problem only occurs when there are multiple actions corresponding to multiple AccountUpates in the same transaction, which is basically caused by a bug in Fetch.fetchActions that the getActions method depends on.

It can be reproduced using snarkyjs version 0.9.6 under the current Berkeley network:
```typescript
 // This fetchActions method is not exported for external use in current version
 let actions = await fetchActions({
        publicKey: 'B62qqfgrF56mGyqNXsyd6iMqwWDQVC9KKcLVwcToLwfNg5ju2tVwSn5',
        actionStates: {
          fromActionState: Reducer.initialActionsHash.toString(),
        },
      });
 console.log('actions: ', JSON.stringify(actions));
```

- Add two new fetchActions methods for exporting to be used externally

Currently, we don't have any methods that can be called outside the smart contract to get actions from the network.
So it is proposed to add two new asynchronous methods to solve this problem(Compatible with LocalBlockChain and Network):
```typescript
// Mainly returns data in string form
Mina.fetchActions(publicKey, {fromActionState, endActionState}, tokenId)
// Return data as ActionType
SmartContract.reducer.fetchActions({
    fromActionState,
    endActionState,
})
```