### PR TITLE
Fix fetchActions, part 2

### DIFF
--- a/src/examples/zkapps/voting/test.ts
+++ b/src/examples/zkapps/voting/test.ts
@@ -79,16 +79,12 @@ export async function testSet(
     );
     console.log('checking that the tx is valid using default verification key');
 
+    let m = Member.from(PrivateKey.random().toPublicKey(), UInt64.from(15));
+    verificationKeySet.Local.addAccount(m.publicKey, m.balance.toString());
+
     await assertValidTx(
       true,
       () => {
-        let m = Member.from(
-          PrivateKey.random().toPublicKey(),
-
-          UInt64.from(15)
-        );
-        verificationKeySet.Local.addAccount(m.publicKey, m.balance.toString());
-
         verificationKeySet.voting.voterRegistration(m);
       },
       verificationKeySet.feePayer
@@ -109,16 +105,12 @@ export async function testSet(
       verificationKeySet.feePayer
     );
 
+    m = Member.from(PrivateKey.random().toPublicKey(), UInt64.from(15));
+    verificationKeySet.Local.addAccount(m.publicKey, m.balance.toString());
+
     await assertValidTx(
       false,
       () => {
-        let m = Member.from(
-          PrivateKey.random().toPublicKey(),
-
-          UInt64.from(15)
-        );
-        verificationKeySet.Local.addAccount(m.publicKey, m.balance.toString());
-
         verificationKeySet.voting.voterRegistration(m);
       },
       verificationKeySet.feePayer,
@@ -159,16 +151,12 @@ export async function testSet(
     );
     console.log('checking that the tx is valid using default permissions');
 
+    let m = Member.from(PrivateKey.random().toPublicKey(), UInt64.from(15));
+    permissionedSet.Local.addAccount(m.publicKey, m.balance.toString());
+
     await assertValidTx(
       true,
       () => {
-        let m = Member.from(
-          PrivateKey.random().toPublicKey(),
-
-          UInt64.from(15)
-        );
-        permissionedSet.Local.addAccount(m.publicKey, m.balance.toString());
-
         permissionedSet.voting.voterRegistration(m);
       },
       permissionedSet.feePayer
@@ -192,16 +180,12 @@ export async function testSet(
 
     console.log('trying to invoke method with invalid permissions...');
 
+    m = Member.from(PrivateKey.random().toPublicKey(), UInt64.from(15));
+    permissionedSet.Local.addAccount(m.publicKey, m.balance.toString());
+
     await assertValidTx(
       false,
       () => {
-        let m = Member.from(
-          PrivateKey.random().toPublicKey(),
-
-          UInt64.from(15)
-        );
-        permissionedSet.Local.addAccount(m.publicKey, m.balance.toString());
-
         permissionedSet.voting.voterRegistration(m);
       },
       permissionedSet.feePayer,
@@ -240,24 +224,19 @@ export async function testSet(
 
     console.log('trying to invoke invalid contract method...');
 
+    let m = Member.from(PrivateKey.random().toPublicKey(), UInt64.from(15));
+    invalidSet.Local.addAccount(m.publicKey, m.balance.toString());
+
     try {
       let tx = await Mina.transaction(invalidSet.feePayer.toPublicKey(), () => {
-        let m = Member.from(
-          PrivateKey.random().toPublicKey(),
-
-          UInt64.from(15)
-        );
-        invalidSet.Local.addAccount(m.publicKey, m.balance.toString());
-
         invalidSet.voting.voterRegistration(m);
       });
-
       await tx.prove();
       await tx.sign([invalidSet.feePayer]).send();
     } catch (err: any) {
-      if (!err.toString().includes('precondition_unsatisfied')) {
+      if (!err.toString().includes('fromActionState not found')) {
         throw Error(
-          `Transaction should have failed but went through! Error: ${err}`
+          `Transaction should have failed, but failed with an unexpected error! ${err}`
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   TransactionStatus,
   addCachedAccount,
   setGraphqlEndpoint,
+  setArchiveGraphqlEndpoint,
   sendZkapp,
 } from './lib/fetch.js';
 export * as Encryption from './lib/encryption.js';

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -791,13 +791,22 @@ async function fetchActions(
   fetchedActions.reverse();
   let actionsList: { actions: string[][]; hash: string }[] = [];
 
+  // correct for archive node sending one block too many
+  if (
+    fetchedActions.length !== 0 &&
+    fetchedActions[0].actionState.actionStateOne ===
+      actionStates.fromActionState
+  ) {
+    fetchedActions = fetchedActions.slice(1);
+  }
+
   fetchedActions.forEach((actionBlock) => {
     let { actionData } = actionBlock;
     let latestActionState = Field(actionBlock.actionState.actionStateTwo);
     let actionState = actionBlock.actionState.actionStateOne;
 
     if (actionData.length === 0)
-      throw new Error(
+      throw Error(
         `No action data was found for the account ${publicKey} with the latest action state ${actionState}`
       );
 


### PR DESCRIPTION
* fixes #852
  * if `fromActionState` is used, the archive node returns one block too many (namely, the one that ended in `fromActionState`). we check for this in snarkyjs and correct if necessary
* refactored `fetchActions` / `getActions` functions throughout to improve readability and do less back and forth conversion.
  * don't store action states with base58 tokenId encoding. Instead, store them as decimal strings which is cheaper to convert to and more consistent with other APIs like graphql
  * fixes #795
  * throw an error in `LocalBlockchain.getActions` when `fromActionState` or `endActionState` aren't found; filed issue for archive node to do the same: https://github.com/o1-labs/Archive-Node-API/issues/77
* reverts https://github.com/o1-labs/snarkyjs/pull/844 which fixed the order that actions are processed inside reduce, but broke hashing which rely on the reversed order; instead, reverse back inside reduce and otherwise keep the reversed order that is consistent with how actions have to be stored on the account update