### PR TITLE
add elgamal to community packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a list of changes between versions, see the [CHANGELOG.md](https://github.co
 
 > A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
 
-- [SnarkyJS Elgamal](https://www.npmjs.com/package/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption.
+- [snarkyjs-elgamal](https://github.com/Trivo25/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption. [npm](https://www.npmjs.com/package/snarkyjs-elgamal)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a list of changes between versions, see the [CHANGELOG.md](https://github.co
 
 > A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
 
-- [SnarkyJS Elgamal](https://github.com/Trivo25/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption.
+- [SnarkyJS Elgamal](https://www.npmjs.com/package/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For a list of changes between versions, see the [CHANGELOG.md](https://github.co
 
 > A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
 
+- [SnarkyJS Elgamal](https://github.com/Trivo25/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption.
+
 ## Contributing
 
 We appreciate all community contributions to SnarkyJS! 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ For a list of changes between versions, see the [CHANGELOG.md](https://github.co
 
 ## Community packages
 
-> A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
+Here is a list of community-maintained packages. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
 
-- [snarkyjs-elgamal](https://github.com/Trivo25/snarkyjs-elgamal): A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption. [npm](https://www.npmjs.com/package/snarkyjs-elgamal)
+- **snarkyjs-elgamal** A partially homomorphic encryption library for SnarkyJS based on Elgamal encryption: [GitHub](https://github.com/Trivo25/snarkyjs-elgamal) and [npm](https://www.npmjs.com/package/snarkyjs-elgamal) 
 
 ## Contributing
 


### PR DESCRIPTION
adds snarkyjs-elgamal to community packages, as a first example package

part of https://github.com/o1-labs/proj-management/issues/36