### PR TITLE
docs: fix broken links in readme to contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# SnarkyJS &nbsp; [![npm version](https://img.shields.io/npm/v/snarkyjs.svg?style=flat)](https://www.npmjs.com/package/snarkyjs) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
+# SnarkyJS &nbsp; [![npm version](https://img.shields.io/npm/v/snarkyjs.svg?style=flat)](https://www.npmjs.com/package/snarkyjs) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)]([CONTRIBUTING.md](https://github.com/o1-labs/snarkyjs/blob/main/CONTRIBUTING.md)
 
 To write a zkApp smart contract for the Mina Protocol, we recommend using the [zkApp CLI](https://github.com/o1-labs/zkapp-cli). The zkApp CLI allows you to scaffold, write, test, and deploy zkApps using recommended best practices. zkApps created with the zkApp CLI include SnarkyJS and provide project scaffolding, a test framework, and correct formatting.
 
-To learn more, see the [SnarkyJS reference](https://docs.minaprotocol.com/en/zkapps/snarkyjs-reference) documentation.
+To learn more, see the [SnarkyJS reference](https://docs.minaprotocol.com/en/zkapps/snarkyjs-reference) and [zkApp Developers](https://docs.minaprotocol.com/zkapps) documentation.
 
 For a list of changes between versions, see the [CHANGELOG.md](https://github.com/o1-labs/snarkyjs/blob/main/CHANGELOG.md).
 
 ## Community packages
 
-> A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](./CONTRIBUTING.md#creating-high-quality-community-packages).
+A list of community-maintained packages is being collected. To include your package, see the [Contributing guidelines](https://github.com/o1-labs/snarkyjs/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).
 
 ## Contributing
 
 We appreciate all community contributions to SnarkyJS! 
 
-See the [Contributing guidelines](CONTRIBUTING.md) for ways you can contribute. 
+See the [Contributing guidelines](https://github.com/o1-labs/snarkyjs/blob/main/CONTRIBUTING.md) for ways you can contribute. To learn about ways to participate and interact with community members, see [Online Communities](https://docs.minaprotocol.com/participate/online-communities).


### PR DESCRIPTION
Today I learned that a project readme file is best outfitted with full links. Relative links of course work in the project repository, but after a readme file is out into the wild, the relative links are broken.

For example, links to our contributing guidelines from the [npm trends page for SnarkyJS](https://npmtrends.com/snarkyjs) are broken!

The links to changelog are working because they are absolute links. 

This PR updates the contributing links to absolute links and adds links to a few other docs pages.