### PR TITLE
Add fallback URLs to GraphQL network requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/97e393ed...HEAD)
 
-> No unreleased changes
+### Added
+
+- Support for fallback endpoints when making network requests, allowing users to provide an array of endpoints for GraphQL network requests. https://github.com/o1-labs/snarkyjs/pull/871
+  - Endpoints are checked for validity, and a "waterfall" approach is used to loop through fallback endpoints if needed.
 
 ## [0.9.8](https://github.com/o1-labs/snarkyjs/compare/1a984089...97e393ed)
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -33,8 +33,6 @@ export {
   getCachedActions,
   addCachedAccount,
   networkConfig,
-  // defaultGraphqlEndpoint,
-  // archiveGraphqlEndpoint,
   setGraphqlEndpoint,
   setMinaGraphqlFallbackEndpoints,
   setArchiveGraphqlEndpoint,
@@ -68,15 +66,6 @@ function checkForValidUrl(url: string) {
     return false;
   }
 }
-
-// let defaultGraphqlEndpoint = 'none';
-//let archiveGraphqlEndpoint = 'none';
-/**
- * Specifies the default GraphQL endpoint.
- */
-// function setGraphqlEndpoint(graphqlEndpoint: string) {
-//   defaultGraphqlEndpoint = graphqlEndpoint;
-// }
 
 function setGraphqlEndpoint(graphqlEndpoint: string) {
   if (!checkForValidUrl(graphqlEndpoint)) {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1032,7 +1032,7 @@ async function makeGraphqlRequest(
         errorMessages.push({ endpoint, error: inferError(error) });
       } else {
         clearTimeout(timer);
-        return networkError;
+        return [undefined, networkError] as [undefined, FetchError];
       }
     }
   }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1031,6 +1031,7 @@ async function makeGraphqlRequest(
           console.error(`Request to ${endpoint} failed: ${error.message}`);
         errorMessages.push({ endpoint, error: inferError(error) });
       } else {
+        // If the request failed for some other reason (e.g. SnarkyJS error), return the error
         clearTimeout(timer);
         return [undefined, networkError] as [undefined, FetchError];
       }

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -56,7 +56,7 @@ let networkConfig = {
   minaFallbackEndpoints: [] as string[],
   archiveEndpoint: '',
   archiveFallbackEndpoints: [] as string[],
-};
+} satisfies NetworkConfig;
 
 function checkForValidUrl(url: string) {
   try {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1024,10 +1024,16 @@ async function makeGraphqlRequest(
       });
       return checkResponseStatus(response);
     } catch (error) {
-      if (error instanceof Error) {
-        console.error(`Request to ${endpoint} failed: ${error.message}`);
+      let networkError = inferError(error);
+      // If the request timed out, try the next endpoint
+      if (networkError.statusCode === 408) {
+        if (error instanceof Error)
+          console.error(`Request to ${endpoint} failed: ${error.message}`);
+        errorMessages.push({ endpoint, error: inferError(error) });
+      } else {
+        clearTimeout(timer);
+        return networkError;
       }
-      errorMessages.push({ endpoint, error: inferError(error) });
     }
   }
   clearTimeout(timer);

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -647,20 +647,42 @@ LocalBlockchain satisfies (...args: any) => Mina;
  * Represents the Mina blockchain running on a real network
  */
 function Network(graphqlEndpoint: string): Mina;
-function Network(graphqlEndpoints: { mina: string; archive: string }): Mina;
-function Network(input: { mina: string; archive: string } | string): Mina {
+function Network(graphqlEndpoints: {
+  mina: string | string[];
+  archive: string | string[];
+}): Mina;
+function Network(
+  input: { mina: string | string[]; archive: string | string[] } | string
+): Mina {
   let accountCreationFee = UInt64.from(defaultAccountCreationFee);
-  let graphqlEndpoint: string;
+  let minaGraphqlEndpoint: string;
   let archiveEndpoint: string;
 
   if (input && typeof input === 'string') {
-    graphqlEndpoint = input;
-    Fetch.setGraphqlEndpoint(graphqlEndpoint);
+    minaGraphqlEndpoint = input;
+    Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
   } else if (input && typeof input === 'object') {
-    graphqlEndpoint = input.mina;
-    archiveEndpoint = input.archive;
-    Fetch.setGraphqlEndpoint(graphqlEndpoint);
-    Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
+    if (!input.mina || !input.archive)
+      throw new Error(
+        "Network: malformed input. Please provide an object with 'mina' and 'archive' endpoints."
+      );
+    if (Array.isArray(input.mina) && input.mina.length > 1) {
+      minaGraphqlEndpoint = input.mina[0];
+      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
+      Fetch.setMinaGraphqlFallbackEndpoints(input.mina.slice(1));
+    } else if (typeof input.mina === 'string') {
+      minaGraphqlEndpoint = input.mina;
+      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
+    }
+
+    if (Array.isArray(input.archive) && input.archive.length > 1) {
+      archiveEndpoint = input.archive[0];
+      Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
+      Fetch.setArchiveGraphqlFallbackEndpoints(input.archive.slice(1));
+    } else if (typeof input.archive === 'string') {
+      archiveEndpoint = input.archive;
+      Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
+    }
   } else {
     throw new Error(
       "Network: malformed input. Please provide a string or an object with 'mina' and 'archive' endpoints."
@@ -694,17 +716,21 @@ function Network(input: { mina: string; archive: string } | string): Mina {
         !currentTransaction.has() ||
         currentTransaction.get().fetchMode === 'cached'
       ) {
-        return !!Fetch.getCachedAccount(publicKey, tokenId, graphqlEndpoint);
+        return !!Fetch.getCachedAccount(
+          publicKey,
+          tokenId,
+          minaGraphqlEndpoint
+        );
       }
       return false;
     },
     getAccount(publicKey: PublicKey, tokenId: Field = TokenId.default) {
       if (currentTransaction()?.fetchMode === 'test') {
-        Fetch.markAccountToBeFetched(publicKey, tokenId, graphqlEndpoint);
+        Fetch.markAccountToBeFetched(publicKey, tokenId, minaGraphqlEndpoint);
         let account = Fetch.getCachedAccount(
           publicKey,
           tokenId,
-          graphqlEndpoint
+          minaGraphqlEndpoint
         );
         return account ?? dummyAccount(publicKey);
       }
@@ -715,7 +741,7 @@ function Network(input: { mina: string; archive: string } | string): Mina {
         let account = Fetch.getCachedAccount(
           publicKey,
           tokenId,
-          graphqlEndpoint
+          minaGraphqlEndpoint
         );
         if (account !== undefined) return account;
       }
@@ -723,24 +749,24 @@ function Network(input: { mina: string; archive: string } | string): Mina {
         `${reportGetAccountError(
           publicKey.toBase58(),
           TokenId.toBase58(tokenId)
-        )}\nGraphql endpoint: ${graphqlEndpoint}`
+        )}\nGraphql endpoint: ${minaGraphqlEndpoint}`
       );
     },
     getNetworkState() {
       if (currentTransaction()?.fetchMode === 'test') {
-        Fetch.markNetworkToBeFetched(graphqlEndpoint);
-        let network = Fetch.getCachedNetwork(graphqlEndpoint);
+        Fetch.markNetworkToBeFetched(minaGraphqlEndpoint);
+        let network = Fetch.getCachedNetwork(minaGraphqlEndpoint);
         return network ?? defaultNetworkState();
       }
       if (
         !currentTransaction.has() ||
         currentTransaction.get().fetchMode === 'cached'
       ) {
-        let network = Fetch.getCachedNetwork(graphqlEndpoint);
+        let network = Fetch.getCachedNetwork(minaGraphqlEndpoint);
         if (network !== undefined) return network;
       }
       throw Error(
-        `getNetworkState: Could not fetch network state from graphql endpoint ${graphqlEndpoint}`
+        `getNetworkState: Could not fetch network state from graphql endpoint ${minaGraphqlEndpoint}`
       );
     },
     async sendTransaction(txn: Transaction) {
@@ -830,7 +856,7 @@ function Network(input: { mina: string; archive: string } | string): Mina {
         fetchMode: 'test',
         isFinalRunOutsideCircuit: false,
       });
-      await Fetch.fetchMissingData(graphqlEndpoint, archiveEndpoint);
+      await Fetch.fetchMissingData(minaGraphqlEndpoint, archiveEndpoint);
       let hasProofs = tx.transaction.accountUpdates.some(
         Authorization.hasLazyProof
       );
@@ -935,7 +961,7 @@ let activeInstance: Mina = {
       return !!Fetch.getCachedAccount(
         publicKey,
         tokenId,
-        Fetch.defaultGraphqlEndpoint
+        Fetch.networkConfig.minaEndpoint
       );
     }
     return false;
@@ -945,7 +971,7 @@ let activeInstance: Mina = {
       Fetch.markAccountToBeFetched(
         publicKey,
         tokenId,
-        Fetch.defaultGraphqlEndpoint
+        Fetch.networkConfig.minaEndpoint
       );
       return dummyAccount(publicKey);
     }
@@ -956,7 +982,7 @@ let activeInstance: Mina = {
       let account = Fetch.getCachedAccount(
         publicKey,
         tokenId,
-        Fetch.defaultGraphqlEndpoint
+        Fetch.networkConfig.minaEndpoint
       );
       if (account === undefined)
         throw Error(

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -666,7 +666,7 @@ function Network(
       throw new Error(
         "Network: malformed input. Please provide an object with 'mina' and 'archive' endpoints."
       );
-    if (Array.isArray(input.mina) && input.mina.length > 1) {
+    if (Array.isArray(input.mina) && input.mina.length !== 0) {
       minaGraphqlEndpoint = input.mina[0];
       Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
       Fetch.setMinaGraphqlFallbackEndpoints(input.mina.slice(1));
@@ -675,7 +675,7 @@ function Network(
       Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
     }
 
-    if (Array.isArray(input.archive) && input.archive.length > 1) {
+    if (Array.isArray(input.archive) && input.archive.length !== 0) {
       archiveEndpoint = input.archive[0];
       Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
       Fetch.setArchiveGraphqlFallbackEndpoints(input.archive.slice(1));


### PR DESCRIPTION
# Description
This pull request makes several updates to the fetch.ts module, including supporting fallback endpoints and refactoring the code.

Firstly, we now allow users to provide an array of endpoints for GraphQL network requests. The input URLs are checked for validity, and an error is thrown if they're invalid. Instead of issuing multiple requests at once using `Promise.race`, which may lead to unintended spamming, we use a "waterfall" approach to loop through the fallback endpoints. If a request is successful, it returns immediately; otherwise, we collect error messages and display helpful information if all requests fail.

We've also replaced the two standalone string variables with a `NetworkConfig` object, making the network information more organized within the `Fetch` module.