### PR TITLE
Update signMessage to pass private key

### DIFF
--- a/src/mina-signer/README.md
+++ b/src/mina-signer/README.md
@@ -20,7 +20,7 @@ const client = new Client({ network: 'mainnet' });
 let keypair = client.genKeys();
 
 // Sign and verify message
-let signed = client.signMessage('hello', keypair);
+let signed = client.signMessage('hello', keypair.privateKey);
 if (client.verifyMessage(signed)) {
   console.log('Message was verified successfully');
 }


### PR DESCRIPTION
The sample code no longer works as `signMessage` now takes a private key and not a keypair. 