### PR TITLE
Fix silent deploy fail with no verification key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for fallback endpoints when making network requests, allowing users to provide an array of endpoints for GraphQL network requests. https://github.com/o1-labs/snarkyjs/pull/871
   - Endpoints are checked for validity, and a "waterfall" approach is used to loop through fallback endpoints if needed.
 
+### Fixed
+
+- `SmartContract.deploy()` throws an error when no verification key is found https://github.com/o1-labs/snarkyjs/pull/885
+  - The old, confusing behaviour was to silently not update the verification key (but still update some permissions to "proof", breaking the zkApp)
+
 ## [0.9.8](https://github.com/o1-labs/snarkyjs/compare/1a984089...97e393ed)
 
 ### Breaking Changes

--- a/src/lib/precondition.test.ts
+++ b/src/lib/precondition.test.ts
@@ -27,7 +27,7 @@ let feePayerKey: PrivateKey;
 beforeAll(async () => {
   // set up local blockchain, create zkapp keys, deploy the contract
   await isReady;
-  let Local = Mina.LocalBlockchain();
+  let Local = Mina.LocalBlockchain({ proofsEnabled: false });
   Mina.setActiveInstance(Local);
   feePayerKey = Local.testAccounts[0].privateKey;
   feePayer = Local.testAccounts[0].publicKey;

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -728,14 +728,19 @@ class SmartContract {
   } = {}) {
     let accountUpdate = this.newSelf();
     verificationKey ??= (this.constructor as any)._verificationKey;
-    if (verificationKey === undefined && !Mina.getProofsEnabled()) {
-      verificationKey = Pickles.dummyVerificationKey();
+    if (verificationKey === undefined) {
+      if (!Mina.getProofsEnabled()) {
+        verificationKey = Pickles.dummyVerificationKey();
+      } else {
+        throw Error(
+          `\`${this.constructor.name}.deploy()\` was called but no verification key was found.\n` +
+            `Try calling \`await ${this.constructor.name}.compile()\` first, this will cache the verification key in the background.`
+        );
+      }
     }
-    if (verificationKey !== undefined) {
-      let { hash: hash_, data } = verificationKey;
-      let hash = typeof hash_ === 'string' ? Field(hash_) : hash_;
-      accountUpdate.account.verificationKey.set({ hash, data });
-    }
+    let { hash: hash_, data } = verificationKey;
+    let hash = typeof hash_ === 'string' ? Field(hash_) : hash_;
+    accountUpdate.account.verificationKey.set({ hash, data });
     accountUpdate.account.permissions.set(Permissions.default());
     accountUpdate.sign(zkappKey);
     AccountUpdate.attachToTransaction(accountUpdate);


### PR DESCRIPTION
Fixes the behaviour of `deploy()` when no verification key is found (and we have `proofsEnabled: true`)

OLD: `deploy()` silently didn't update the verification key, but still updates some permissions to "proof", breaking the zkApp

NEW: `deploy()` throws an error to remind you to `compile()` before calling `deploy()`