### PR TITLE
Update TypeDoc dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^28.0.8",
-        "typedoc": "^0.23.26",
+        "typedoc": "^0.24.6",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -6447,9 +6447,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -7562,14 +7562,14 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.23.26",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
-      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
+      "version": "0.24.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.6.tgz",
+      "integrity": "sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==",
       "dev": true,
       "dependencies": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "bin": {
@@ -7579,7 +7579,7 @@
         "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -7592,15 +7592,15 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.3.0.tgz",
-      "integrity": "sha512-WaMDuhKa7a6zKiwplR1AOz+zGvJba24k5VU1Cy6NhEguavT2YRlHxuINUgTas4wiS6fwBpYq4TcA1XIECSntyw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+      "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12573,9 +12573,9 @@
       }
     },
     "marked": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
-      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "merge-stream": {
@@ -13353,14 +13353,14 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.23.26",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.26.tgz",
-      "integrity": "sha512-5m4KwR5tOLnk0OtMaRn9IdbeRM32uPemN9kur7YK9wFqx8U0CYrvO9aVq6ysdZSV1c824BTm+BuQl2Ze/k1HtA==",
+      "version": "0.24.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.6.tgz",
+      "integrity": "sha512-c3y3h45xJv3qYwKDAwU6Cl+26CjT0ZvblHzfHJ+SjQDM4p1mZxtgHky4lhmG0+nNarRht8kADfZlbspJWdZarQ==",
       "dev": true,
       "requires": {
         "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
         "shiki": "^0.14.1"
       },
       "dependencies": {
@@ -13374,9 +13374,9 @@
           }
         },
         "minimatch": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.3.0.tgz",
-          "integrity": "sha512-WaMDuhKa7a6zKiwplR1AOz+zGvJba24k5VU1Cy6NhEguavT2YRlHxuINUgTas4wiS6fwBpYq4TcA1XIECSntyw==",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+          "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "zk-snark",
     "zero knowledge"
   ],
-    "type": "module",
+  "type": "module",
   "main": "./dist/web/index.js",
   "exports": {
     "types": "./dist/node/index.d.ts",
@@ -89,7 +89,7 @@
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.8",
-    "typedoc": "^0.23.26",
+    "typedoc": "^0.24.6",
     "typescript": "^4.9.5"
   },
   "dependencies": {


### PR DESCRIPTION
# Description
When building the SnarkyJS API Reference docs for the docs website, we install `typedoc-plugin-markdown` to generate markdown from the `typedoc` definitions. `typedoc` is already a dev dependency of SnarkyJs but it's also used by  `typedoc-plugin-markdown`. The problem is that these versions clash and lead to an error while resolving dependencies. 

We fix this by just bumping the version of `typedoc` inside SnarkyJS.