### PR TITLE
Fix type error when accessing undefined method interface properties

### DIFF
--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -323,7 +323,7 @@ function wrapMethod(
                   this,
                   actualArgs.map((a, i) => {
                     let arg = methodIntf.allArgs[i];
-                    if (arg.type === 'witness') {
+                    if (arg?.type === 'witness') {
                       let type = methodIntf.witnessArgs[arg.index];
                       return Circuit.witness(type, () => a);
                     }


### PR DESCRIPTION
**Description**

Fixes o1-labs/zkapp-cli#406

When deploying the sudoku example contract using the `zkapp-cli` ,  this error occurs: 
```
TypeError: Cannot read properties of undefined (reading 'type')
```
This happens because the `wrappedMethod` function in the `zkapp.ts` file attempts to access the type property on an arg that is undefined.

**Solution**

This PR adds optional chaining when attempting to access the type on the arg property to prevent an error when it is undefined.

**Tested** 

The sudoku example contract was [successfully deployed](https://berkeley.minaexplorer.com/transaction/5Ju1NoedvM6eSJ6Xd4k6oJTSmpJJB3cytYcXVRAxiqjQkvjEJerm) with this change. 