### PR TITLE
Add better error checking for fetched GraphQL requests

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1091,6 +1091,14 @@ async function checkResponseStatus(
             .join('\n'),
         } as FetchError,
       ];
+    } else if (jsonResponse.data === undefined) {
+      return [
+        undefined,
+        {
+          statusCode: response.status,
+          statusText: `GraphQL response data is undefined`,
+        } as FetchError,
+      ];
     }
     return [jsonResponse as FetchResponse, undefined];
   } else {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1086,7 +1086,9 @@ async function checkResponseStatus(
         undefined,
         {
           statusCode: response.status,
-          statusText: jsonResponse.errors,
+          statusText: jsonResponse.errors
+            .map((error: any) => error.message)
+            .join('\n'),
         } as FetchError,
       ];
     }


### PR DESCRIPTION
# Description

This PR introduces enhanced error handling for GraphQL network requests within the `Fetch` module. Previously, if a GraphQL request failed, the error output would be presented as `statusText` in an array format. This made error reporting from the user's application less informative, as it logged `[object Object]`. An example of this less descriptive error logging is as follows:

```sh
> npm run build && node build/src/index.js

> test-graphql-errors@0.1.0 build
> tsc
/home/martin/Code/o1/mina/src/lib/snarkyjs/dist/node/_node_bindings/snarky_js_node.bc.cjs:7427
         throw err;
         ^
Error: [object Object]
    at fetchEvents (file:///home/martin/Code/o1/mina/src/lib/snarkyjs/dist/node/lib/fetch.js:475:15)
    at process.processTicksAndRejections (node:internal/process/task_queue:95:5)
    at async main (file:///tmp/test-graphql-errors/build/src/index.js:3:20)
```

With the enhancements made in this PR, the error reporting becomes more informative and user-friendly. The new error messages provide specific details about the issues at hand. An example of the improved error message is:

```sh
> npm run build && node build/src/index.js                         

> test-graphql-errors@0.1.0 build
> tsc
/home/martin/Code/o1/mina/src/lib/snarkyjs/dist/node/_node_bindings/snarky_js_node.bc.cjs:7427
         throw err;
         ^
Error: Cannot query field "events1" on type "Query". Did you mean "events"?
    at fetchEvents (file:///home/martin/Code/o1/mina/src/lib/snarkyjs/dist/node/lib/fetch.js:475:15)
    at process.processTicksAndRejections (node:internal/process/task_queue:95:5)
    at async main (file:///tmp/test-graphql-errors/build/src/index.js:3:20)
```

# Testing
The improvements introduced in this PR have been verified using a local test script.