### PR TITLE
Implemented avoid throwing an error if private key is missing unless .send() is executed

### DIFF
--- a/src/lib/account_update.test.ts
+++ b/src/lib/account_update.test.ts
@@ -100,6 +100,22 @@ describe('AccountUpdate', () => {
     expect(TokenId.toBase58(x)).toEqual(Ledger.fieldToBase58(x));
     expect(TokenId.fromBase58(defaultTokenId).toString()).toEqual('1');
   });
+
+  it('does not throw an error if private key is missing unless if .send is executed', async () => {
+    let Local = Mina.LocalBlockchain({ proofsEnabled: false });
+    Mina.setActiveInstance(Local);
+
+    const feePayerKey = Local.testAccounts[0].privateKey;
+    const feePayer = Local.testAccounts[0].publicKey;
+
+    let tx = await Mina.transaction(feePayer, () => {
+      let accountUpdate = AccountUpdate.fundNewAccount(feePayer);
+    });
+    tx.sign();
+    await expect(tx.send()).rejects.toThrow(
+      'Check signature: Invalid signature on fee payer for key'
+    );
+  });
 });
 
 // to check that we got something that looks like a Field

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1881,7 +1881,7 @@ function addMissingSignatures(
         // there is a change signature will be added by the wallet
         // if not, error will be thrown by verifyAccountUpdate
         // while .send() execution
-        return { body, authorization: undefined }
+        return { body, authorization: Ledger.dummySignature() }
       }
       privateKey = additionalKeys[i];
     }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1881,7 +1881,7 @@ function addMissingSignatures(
         // there is a change signature will be added by the wallet
         // if not, error will be thrown by verifyAccountUpdate
         // while .send() execution
-        return { body, authorization: "" }
+        return { body, authorization: undefined }
       }
       privateKey = additionalKeys[i];
     }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1904,7 +1904,8 @@ function addMissingSignatures(
         // there is a change signature will be added by the wallet
         // if not, error will be thrown by verifyAccountUpdate
         // while .send() execution
-        return accountUpdate as AccountUpdate & { lazyAuthorization?: LazyProof };
+        Authorization.setSignature(accountUpdate, Ledger.dummySignature())
+        return accountUpdate as AccountUpdate & { lazyAuthorization: undefined };
       }
       privateKey = additionalKeys[i];
     }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1877,10 +1877,11 @@ function addMissingSignatures(
         pk.equals(accountUpdate.body.publicKey).toBoolean()
       );
       if (i === -1) {
-        let pk = PublicKey.toBase58(accountUpdate.body.publicKey);
-        throw Error(
-          `addMissingSignatures: Cannot add signature for fee payer (${pk}), private key is missing.`
-        );
+        // private key is missing, but we are not throwing an error here
+        // there is a change signature will be added by the wallet
+        // if not, error will be thrown by verifyAccountUpdate
+        // while .send() execution
+        return { body, authorization: "" }
       }
       privateKey = additionalKeys[i];
     }

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1904,7 +1904,7 @@ function addMissingSignatures(
         // there is a change signature will be added by the wallet
         // if not, error will be thrown by verifyAccountUpdate
         // while .send() execution
-        Authorization.setSignature(accountUpdate, Ledger.dummySignature())
+        Authorization.setSignature(accountUpdate, Ledger.dummySignature());
         return accountUpdate as AccountUpdate & { lazyAuthorization: undefined };
       }
       privateKey = additionalKeys[i];

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1899,10 +1899,13 @@ function addMissingSignatures(
       let i = additionalPublicKeys.findIndex((pk) =>
         pk.equals(accountUpdate.body.publicKey).toBoolean()
       );
-      if (i === -1)
-        throw Error(
-          `addMissingSignatures: Cannot add signature for ${accountUpdate.publicKey.toBase58()}, private key is missing.`
-        );
+      if (i === -1) {
+        // private key is missing, but we are not throwing an error here
+        // there is a change signature will be added by the wallet
+        // if not, error will be thrown by verifyAccountUpdate
+        // while .send() execution
+        return accountUpdate as AccountUpdate & { lazyAuthorization?: LazyProof };
+      }
       privateKey = additionalKeys[i];
     }
     let transactionCommitment = accountUpdate.body.useFullCommitment.toBoolean()

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1257,6 +1257,14 @@ async function verifyAccountUpdate(
 
   let { commitment, fullCommitment } = transactionCommitments;
 
+  // check if addMissingSignatures failed to include a signature
+  // due to a missing private key
+  if (accountUpdate.authorization === "") {
+    let pk = PublicKey.toBase58(accountUpdate.body.publicKey);
+    throw Error(
+      `verifyAccountUpdate: Detected a missing signature for (${pk}), private key was missing.`
+    );
+  }
   // we are essentially only checking if the update is empty or an actual update
   function includesChange<T extends {}>(
     val: T | string | null | (string | null)[]

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1259,7 +1259,7 @@ async function verifyAccountUpdate(
 
   // check if addMissingSignatures failed to include a signature
   // due to a missing private key
-  if (accountUpdate.authorization === "") {
+  if (accountUpdate.authorization === undefined) {
     let pk = PublicKey.toBase58(accountUpdate.body.publicKey);
     throw Error(
       `verifyAccountUpdate: Detected a missing signature for (${pk}), private key was missing.`

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1259,7 +1259,7 @@ async function verifyAccountUpdate(
 
   // check if addMissingSignatures failed to include a signature
   // due to a missing private key
-  if (accountUpdate.authorization === undefined) {
+  if (accountUpdate.authorization === Ledger.dummySignature()) {
     let pk = PublicKey.toBase58(accountUpdate.body.publicKey);
     throw Error(
       `verifyAccountUpdate: Detected a missing signature for (${pk}), private key was missing.`


### PR DESCRIPTION
This is a WIP PR for resolving the issue https://github.com/o1-labs/snarkyjs/issues/930

Issue discovered while working on https://github.com/sqrt-xx/mina-ui-deployment

The related discussion thread is: https://discord.com/channels/484437221055922177/1109079490111479848