### PR TITLE
Remove uses of JS classes in OCaml, Part 1

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1764,7 +1764,7 @@ const ZkappCommand = {
     return { feePayer, accountUpdates, memo };
   },
   toJSON({ feePayer, accountUpdates, memo }: ZkappCommand) {
-    memo = Ledger.memoToBase58(memo);
+    memo = Memo.toBase58(memo);
     return Types.ZkappCommand.toJSON({ feePayer, accountUpdates, memo });
   },
 };

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1766,7 +1766,7 @@ const ZkappCommand = {
     return { feePayer, accountUpdates, memo };
   },
   toJSON({ feePayer, accountUpdates, memo }: ZkappCommand) {
-    memo = Memo.toBase58(memo);
+    memo = Memo.toBase58(Memo.fromString(memo));
     return Types.ZkappCommand.toJSON({ feePayer, accountUpdates, memo });
   },
 };

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -26,9 +26,10 @@ import { prefixes } from '../bindings/crypto/constants.js';
 import { Context } from './global-context.js';
 import { assert } from './errors.js';
 import { Ml } from './ml/conversion.js';
-import { FieldConst, MlFieldConstArray } from './field.js';
+import { FieldConst } from './field.js';
 import { MlArray } from './ml/base.js';
 import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
+import { MlFieldConstArray } from './ml/fields.js';
 
 // external API
 export { AccountUpdate, Permissions, ZkappPublicInput };

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -606,7 +606,10 @@ const TokenId = {
     if (tokenOwner.isConstant() && parentTokenId.isConstant()) {
       return Ledger.customTokenId(Ml.fromPublicKey(tokenOwner), parentTokenId);
     } else {
-      return Ledger.customTokenIdChecked(tokenOwner, parentTokenId);
+      return Ledger.customTokenIdChecked(
+        Ml.fromPublicKeyVar(tokenOwner),
+        parentTokenId
+      );
     }
   },
 };

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -604,7 +604,7 @@ const TokenId = {
   },
   derive(tokenOwner: PublicKey, parentTokenId = Field(1)) {
     if (tokenOwner.isConstant() && parentTokenId.isConstant()) {
-      return Ledger.customTokenId(tokenOwner, parentTokenId);
+      return Ledger.customTokenId(Ml.fromPublicKey(tokenOwner), parentTokenId);
     } else {
       return Ledger.customTokenIdChecked(tokenOwner, parentTokenId);
     }

--- a/src/lib/circuit.ts
+++ b/src/lib/circuit.ts
@@ -1,5 +1,5 @@
 import { ProvablePure, Snarky } from '../snarky.js';
-import { Field } from './core.js';
+import { MlFieldArray, MlFieldConstArray } from './field.js';
 import { withThreadPool } from '../bindings/js/wrapper.js';
 import { Provable } from './provable.js';
 import { snarkContext, gatesFromJson } from './provable-context.js';
@@ -48,7 +48,7 @@ class Circuit {
         let proof = Snarky.circuit.prove(
           main,
           publicInputSize,
-          publicInputFields,
+          MlFieldConstArray.to(publicInputFields),
           keypair.value
         );
         return new Proof(proof);
@@ -74,7 +74,7 @@ class Circuit {
     return prettifyStacktracePromise(
       withThreadPool(async () =>
         Snarky.circuit.verify(
-          publicInputFields,
+          MlFieldConstArray.to(publicInputFields),
           proof.value,
           verificationKey.value
         )
@@ -211,11 +211,13 @@ type CircuitData<P, W> = {
 function mainFromCircuitData<P, W>(
   data: CircuitData<P, W>,
   privateInput?: W
-): (publicInput: Field[]) => void {
-  return function main(publicInputFields: Field[]) {
+): Snarky.Main {
+  return function main(publicInputFields: MlFieldArray) {
     let id = snarkContext.enter({ inCheckedComputation: true });
     try {
-      let publicInput = data.publicInputType.fromFields(publicInputFields);
+      let publicInput = data.publicInputType.fromFields(
+        MlFieldArray.from(publicInputFields)
+      );
       let privateInput_ = Provable.witness(
         data.privateInputType,
         () => privateInput as W

--- a/src/lib/circuit.ts
+++ b/src/lib/circuit.ts
@@ -1,5 +1,5 @@
 import { ProvablePure, Snarky } from '../snarky.js';
-import { MlFieldArray, MlFieldConstArray } from './field.js';
+import { MlFieldArray, MlFieldConstArray } from './ml/fields.js';
 import { withThreadPool } from '../bindings/js/wrapper.js';
 import { Provable } from './provable.js';
 import { snarkContext, gatesFromJson } from './provable-context.js';

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -7,9 +7,6 @@ import { Scalar } from './scalar.js';
 
 export { Field, Bool, Scalar, Group };
 
-// internal
-export { withMessage };
-
 /**
  * A {@link Field} is an element of a prime order [finite field](https://en.wikipedia.org/wiki/Finite_field).
  * Every other provable type is built using the {@link Field} type.
@@ -66,12 +63,6 @@ type InferArgs<T> = T extends new (...args: infer Args) => any ? Args : never;
 type InferReturn<T> = T extends new (...args: any) => infer Return
   ? Return
   : never;
-
-function withMessage(error: unknown, message?: string) {
-  if (message === undefined || !(error instanceof Error)) return error;
-  error.message = `${message}\n${error.message}`;
-  return error;
-}
 
 // patching ocaml classes
 

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -4,7 +4,6 @@ import { Bool } from '../snarky.js';
 import { defineBinable } from '../bindings/lib/binable.js';
 import type { NonNegativeInteger } from '../bindings/crypto/non-negative.js';
 import { asProver } from './provable-context.js';
-import { withMessage } from './core.js';
 import { MlArray } from './ml/base.js';
 
 // external API
@@ -19,6 +18,7 @@ export {
   isField,
   MlFieldArray,
   MlFieldConstArray,
+  withMessage,
 };
 
 const SnarkyFieldConstructor = SnarkyField(1).constructor;
@@ -1279,4 +1279,10 @@ function toFp(x: bigint | number | string | Field): Fp {
     return Fp(x as bigint | number | string);
   }
   return (x as Field).toBigInt();
+}
+
+function withMessage(error: unknown, message?: string) {
+  if (message === undefined || !(error instanceof Error)) return error;
+  error.message = `${message}\n${error.message}`;
+  return error;
 }

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -5,8 +5,17 @@ import { defineBinable } from '../bindings/lib/binable.js';
 import type { NonNegativeInteger } from '../bindings/crypto/non-negative.js';
 import { asProver } from './provable-context.js';
 import { withMessage } from './core.js';
+import { MlArray } from './ml/base.js';
 
-export { Field, ConstantField, FieldType, FieldVar, FieldConst, isField };
+export {
+  Field,
+  ConstantField,
+  FieldType,
+  FieldVar,
+  FieldConst,
+  isField,
+  MlFieldArray,
+};
 
 const SnarkyFieldConstructor = SnarkyField(1).constructor;
 
@@ -1218,6 +1227,15 @@ const FieldBinable = defineBinable({
     ];
   },
 });
+
+const MlFieldArray = {
+  to(arr: Field[]): MlArray<FieldVar> {
+    return MlArray.to(arr.map((x) => x.value));
+  },
+  from([, ...arr]: MlArray<FieldVar>) {
+    return arr.map((x) => new Field(x));
+  },
+};
 
 function isField(x: unknown): x is Field {
   return x instanceof Field || (x as any) instanceof SnarkyFieldConstructor;

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -10,16 +10,7 @@ import { MlArray } from './ml/base.js';
 export { Field };
 
 // internal API
-export {
-  ConstantField,
-  FieldType,
-  FieldVar,
-  FieldConst,
-  isField,
-  MlFieldArray,
-  MlFieldConstArray,
-  withMessage,
-};
+export { ConstantField, FieldType, FieldVar, FieldConst, isField, withMessage };
 
 const SnarkyFieldConstructor = SnarkyField(1).constructor;
 
@@ -1238,26 +1229,6 @@ const FieldBinable = defineBinable({
     ];
   },
 });
-
-type MlFieldArray = MlArray<FieldVar>;
-const MlFieldArray = {
-  to(arr: Field[]): MlArray<FieldVar> {
-    return MlArray.to(arr.map((x) => x.value));
-  },
-  from([, ...arr]: MlArray<FieldVar>) {
-    return arr.map((x) => new Field(x));
-  },
-};
-
-type MlFieldConstArray = MlArray<FieldConst>;
-const MlFieldConstArray = {
-  to(arr: Field[]): MlArray<FieldConst> {
-    return MlArray.to(arr.map((x) => x.toConstant().value[1]));
-  },
-  from([, ...arr]: MlArray<FieldConst>): ConstantField[] {
-    return arr.map((x) => new Field(x) as ConstantField);
-  },
-};
 
 function isField(x: unknown): x is Field {
   return x instanceof Field || (x as any) instanceof SnarkyFieldConstructor;

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -7,14 +7,18 @@ import { asProver } from './provable-context.js';
 import { withMessage } from './core.js';
 import { MlArray } from './ml/base.js';
 
+// external API
+export { Field };
+
+// internal API
 export {
-  Field,
   ConstantField,
   FieldType,
   FieldVar,
   FieldConst,
   isField,
   MlFieldArray,
+  MlFieldConstArray,
 };
 
 const SnarkyFieldConstructor = SnarkyField(1).constructor;
@@ -1228,12 +1232,23 @@ const FieldBinable = defineBinable({
   },
 });
 
+type MlFieldArray = MlArray<FieldVar>;
 const MlFieldArray = {
   to(arr: Field[]): MlArray<FieldVar> {
     return MlArray.to(arr.map((x) => x.value));
   },
   from([, ...arr]: MlArray<FieldVar>) {
     return arr.map((x) => new Field(x));
+  },
+};
+
+type MlFieldConstArray = MlArray<FieldConst>;
+const MlFieldConstArray = {
+  to(arr: Field[]): MlArray<FieldConst> {
+    return MlArray.to(arr.map((x) => x.toConstant().value[1]));
+  },
+  from([, ...arr]: MlArray<FieldConst>): ConstantField[] {
+    return arr.map((x) => new Field(FieldVar.constant(x)) as ConstantField);
   },
 };
 

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -1,5 +1,4 @@
-import { withMessage } from './core.js';
-import { Field, FieldVar, isField } from './field.js';
+import { Field, FieldVar, isField, withMessage } from './field.js';
 import { Scalar } from './scalar.js';
 import { Bool, Snarky } from '../snarky.js';
 import { Field as Fp } from '../provable/field-bigint.js';

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,8 +1,9 @@
 import { HashInput, ProvableExtended, Struct } from './circuit_value.js';
-import { Poseidon as Poseidon_ } from '../snarky.js';
+import { MlArray, Poseidon as Poseidon_ } from '../snarky.js';
 import { Field } from './core.js';
 import { createHashHelpers } from './hash-generic.js';
 import { Provable } from './provable.js';
+import { MlFieldArray } from './field.js';
 
 // external API
 export { Poseidon, TokenSymbol };
@@ -17,6 +18,7 @@ export {
   salt,
   packToFields,
   emptyReceiptChainHash,
+  hashConstant,
 };
 
 class Sponge {
@@ -28,11 +30,11 @@ class Sponge {
   }
 
   absorb(x: Field) {
-    Poseidon_.spongeAbsorb(this.sponge, x);
+    Poseidon_.spongeAbsorb(this.sponge, x.value);
   }
 
-  squeeze() {
-    return Poseidon_.spongeSqueeze(this.sponge);
+  squeeze(): Field {
+    return Field(Poseidon_.spongeSqueeze(this.sponge));
   }
 }
 
@@ -41,13 +43,14 @@ const Poseidon = {
     let isChecked = !input.every((x) => x.isConstant());
     // this is the same:
     // return Poseidon_.update(this.initialState, input, isChecked)[0];
-    return Poseidon_.hash(input, isChecked);
+    let digest = Poseidon_.hash(MlFieldArray.to(input), isChecked);
+    return Field(digest);
   },
 
   hashToGroup(input: Field[]) {
     let isChecked = !input.every((x) => x.isConstant());
     // y = sqrt(y^2)
-    let [, xv, yv] = Poseidon_.hashToGroup(input, isChecked);
+    let [, xv, yv] = Poseidon_.hashToGroup(MlFieldArray.to(input), isChecked);
 
     let x = Field(xv);
     let y = Field(yv);
@@ -73,7 +76,12 @@ const Poseidon = {
     let isChecked = !(
       state.every((x) => x.isConstant()) && input.every((x) => x.isConstant())
     );
-    return Poseidon_.update(state, input, isChecked);
+    let newState = Poseidon_.update(
+      MlFieldArray.to(state),
+      MlFieldArray.to(input),
+      isChecked
+    );
+    return MlFieldArray.from(newState) as [Field, Field, Field];
   },
 
   initialState(): [Field, Field, Field] {
@@ -82,6 +90,11 @@ const Poseidon = {
 
   Sponge,
 };
+
+function hashConstant(input: Field[]) {
+  let digest = Poseidon_.hash(MlFieldArray.to(input), false);
+  return Field(digest);
+}
 
 const Hash = createHashHelpers(Field, Poseidon);
 let { salt, emptyHashWithPrefix, hashWithPrefix } = Hash;

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,5 +1,5 @@
 import { HashInput, ProvableExtended, Struct } from './circuit_value.js';
-import { MlArray, Poseidon as Poseidon_ } from '../snarky.js';
+import { Poseidon as Poseidon_ } from '../snarky.js';
 import { Field } from './core.js';
 import { createHashHelpers } from './hash-generic.js';
 import { Provable } from './provable.js';

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -3,7 +3,7 @@ import { Poseidon as Poseidon_ } from '../snarky.js';
 import { Field } from './core.js';
 import { createHashHelpers } from './hash-generic.js';
 import { Provable } from './provable.js';
-import { MlFieldArray } from './field.js';
+import { MlFieldArray } from './ml/fields.js';
 
 // external API
 export { Poseidon, TokenSymbol };

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -29,7 +29,7 @@ import { TransactionCost, TransactionLimits } from './mina/constants.js';
 import { Provable } from './provable.js';
 import { prettifyStacktrace } from './errors.js';
 import { Ml } from './ml/conversion.js';
-import { verifyZkappCommandSignature } from 'src/mina-signer/src/sign-zkapp-command.js';
+import { FieldConst } from './field.js';
 
 export {
   createTransaction,
@@ -423,13 +423,19 @@ function LocalBlockchain({
       );
     },
     hasAccount(publicKey: PublicKey, tokenId: Field = TokenId.default) {
-      return !!ledger.getAccount(Ml.fromPublicKey(publicKey), tokenId);
+      return !!ledger.getAccount(
+        Ml.fromPublicKey(publicKey),
+        Ml.constFromField(tokenId)
+      );
     },
     getAccount(
       publicKey: PublicKey,
       tokenId: Field = TokenId.default
     ): Account {
-      let accountJson = ledger.getAccount(Ml.fromPublicKey(publicKey), tokenId);
+      let accountJson = ledger.getAccount(
+        Ml.fromPublicKey(publicKey),
+        Ml.constFromField(tokenId)
+      );
       if (accountJson === undefined) {
         throw new Error(
           reportGetAccountError(publicKey.toBase58(), TokenId.toBase58(tokenId))
@@ -452,7 +458,7 @@ function LocalBlockchain({
       for (const update of txn.transaction.accountUpdates) {
         let accountJson = ledger.getAccount(
           Ml.fromPublicKey(update.body.publicKey),
-          update.body.tokenId
+          Ml.constFromField(update.body.tokenId)
         );
         if (accountJson) {
           let account = Account.fromJSON(accountJson);
@@ -1229,8 +1235,8 @@ async function verifyAccountUpdate(
   account: Account,
   accountUpdate: AccountUpdate,
   transactionCommitments: {
-    commitment: Field;
-    fullCommitment: Field;
+    commitment: FieldConst;
+    fullCommitment: FieldConst;
   },
   proofsEnabled: boolean
 ): Promise<void> {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -27,6 +27,7 @@ import { Account } from './mina/account.js';
 import { TransactionCost, TransactionLimits } from './mina/constants.js';
 import { Provable } from './provable.js';
 import { prettifyStacktrace } from './errors.js';
+import { Ml } from './ml/conversion.js';
 
 export {
   createTransaction,
@@ -380,8 +381,8 @@ function LocalBlockchain({
 
   let networkState = defaultNetworkState();
 
-  function addAccount(pk: PublicKey, balance: string) {
-    ledger.addAccount(pk, balance);
+  function addAccount(publicKey: PublicKey, balance: string) {
+    ledger.addAccount(Ml.fromPublicKey(publicKey), balance);
   }
 
   let testAccounts: {
@@ -420,13 +421,13 @@ function LocalBlockchain({
       );
     },
     hasAccount(publicKey: PublicKey, tokenId: Field = TokenId.default) {
-      return !!ledger.getAccount(publicKey, tokenId);
+      return !!ledger.getAccount(Ml.fromPublicKey(publicKey), tokenId);
     },
     getAccount(
       publicKey: PublicKey,
       tokenId: Field = TokenId.default
     ): Account {
-      let accountJson = ledger.getAccount(publicKey, tokenId);
+      let accountJson = ledger.getAccount(Ml.fromPublicKey(publicKey), tokenId);
       if (accountJson === undefined) {
         throw new Error(
           reportGetAccountError(publicKey.toBase58(), TokenId.toBase58(tokenId))
@@ -448,7 +449,7 @@ function LocalBlockchain({
 
       for (const update of txn.transaction.accountUpdates) {
         let accountJson = ledger.getAccount(
-          update.body.publicKey,
+          Ml.fromPublicKey(update.body.publicKey),
           update.body.tokenId
         );
         if (accountJson) {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -14,6 +14,7 @@ import {
   Authorization,
   Actions,
   Events,
+  dummySignature,
 } from './account_update.js';
 import * as Fetch from './fetch.js';
 import { assertPreconditionInvariants, NetworkValue } from './precondition.js';
@@ -28,6 +29,7 @@ import { TransactionCost, TransactionLimits } from './mina/constants.js';
 import { Provable } from './provable.js';
 import { prettifyStacktrace } from './errors.js';
 import { Ml } from './ml/conversion.js';
+import { verifyZkappCommandSignature } from 'src/mina-signer/src/sign-zkapp-command.js';
 
 export {
   createTransaction,
@@ -1250,7 +1252,7 @@ async function verifyAccountUpdate(
 
   // check if addMissingSignatures failed to include a signature
   // due to a missing private key
-  if (accountUpdate.authorization === Ledger.dummySignature()) {
+  if (accountUpdate.authorization === dummySignature()) {
     let pk = PublicKey.toBase58(accountUpdate.body.publicKey);
     throw Error(
       `verifyAccountUpdate: Detected a missing signature for (${pk}), private key was missing.`

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -1,13 +1,14 @@
 /**
  * This module contains basic methods for interacting with OCaml
  */
-export { MlArray, MlTuple, MlList, MlOption };
+export { MlArray, MlTuple, MlList, MlOption, MlBool };
 
 // ocaml types
 type MlTuple<X, Y> = [0, X, Y];
 type MlArray<T> = [0, ...T[]];
 type MlList<T> = [0, T, 0 | MlList<T>];
 type MlOption<T> = 0 | [0, T];
+type MlBool = 0 | 1;
 
 const MlArray = {
   to<T>(arr: T[]): MlArray<T> {
@@ -31,6 +32,17 @@ const MlTuple = Object.assign(
     },
     second<Y>(t: MlTuple<unknown, Y>): Y {
       return t[2];
+    },
+  }
+);
+
+const MlBool = Object.assign(
+  function MlBool(b: boolean): MlBool {
+    return b ? 1 : 0;
+  },
+  {
+    from(b: MlBool) {
+      return !!b;
     },
   }
 );

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -1,0 +1,19 @@
+/**
+ * This module contains basic methods for interacting with OCaml
+ */
+export { MlArray, MlTuple, MlList, MlOption };
+
+// ocaml types
+type MlTuple<X, Y> = [0, X, Y];
+type MlArray<T> = [0, ...T[]];
+type MlList<T> = [0, T, 0 | MlList<T>];
+type MlOption<T> = 0 | [0, T];
+
+const MlArray = {
+  to<T>(arr: T[]): MlArray<T> {
+    return [0, ...arr];
+  },
+  from<T>([, ...arr]: MlArray<T>): T[] {
+    return arr;
+  },
+};

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -17,3 +17,20 @@ const MlArray = {
     return arr;
   },
 };
+
+const MlTuple = Object.assign(
+  function MlTuple<X, Y>(x: X, y: Y): MlTuple<X, Y> {
+    return [0, x, y];
+  },
+  {
+    from<X, Y>([, x, y]: MlTuple<X, Y>): [X, Y] {
+      return [x, y];
+    },
+    first<X>(t: MlTuple<X, unknown>): X {
+      return t[1];
+    },
+    second<Y>(t: MlTuple<unknown, Y>): Y {
+      return t[2];
+    },
+  }
+);

--- a/src/lib/ml/consistency.unit-test.ts
+++ b/src/lib/ml/consistency.unit-test.ts
@@ -5,6 +5,8 @@ import { PrivateKey, PublicKey } from '../signature.js';
 import { dummySignature } from '../account_update.js';
 import { Ml } from './conversion.js';
 import { expect } from 'expect';
+import { TokenId } from '../base58-encodings.js';
+import { FieldConst } from '../field.js';
 
 // PrivateKey.toBase58, fromBase58
 
@@ -46,3 +48,16 @@ test(Random.publicKey, (pk0) => {
 let js = dummySignature();
 let ml = Test.signature.dummySignature();
 expect(js).toEqual(ml);
+
+// token id to/from base58
+
+test(Random.field, (x) => {
+  let js = TokenId.toBase58(Field(x));
+  let ml = Test.encoding.tokenIdToBase58(FieldConst.fromBigint(x));
+  expect(js).toEqual(ml);
+
+  expect(TokenId.fromBase58(js).toBigInt()).toEqual(x);
+});
+
+let defaultTokenId = 'wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf';
+expect(TokenId.fromBase58(defaultTokenId).toString()).toEqual('1');

--- a/src/lib/ml/consistency.unit-test.ts
+++ b/src/lib/ml/consistency.unit-test.ts
@@ -1,6 +1,7 @@
 import { Test } from '../../snarky.js';
 import { Random, test } from '../testing/property.js';
-import { PrivateKey } from '../signature.js';
+import { Field, Bool } from '../core.js';
+import { PrivateKey, PublicKey } from '../signature.js';
 import { Ml } from './conversion.js';
 import { expect } from 'expect';
 
@@ -21,4 +22,21 @@ test(Random.privateKey, (s) => {
   // fromBase58 - check consistency with where we started
   expect(PrivateKey.fromBase58(js)).toEqual(sk);
   expect(Test.encoding.privateKeyOfBase58(ml)).toEqual(skMl);
+});
+
+// PublicKey.toBase58, fromBase58
+
+test(Random.publicKey, (pk0) => {
+  // public key from bigint
+  let pk = PublicKey.from({ x: Field(pk0.x), isOdd: Bool(!!pk0.isOdd) });
+  let pkMl = Ml.fromPublicKey(pk);
+
+  // toBase58 - check consistency with ml
+  let ml = Test.encoding.publicKeyToBase58(pkMl);
+  let js = pk.toBase58();
+  expect(js).toEqual(ml);
+
+  // fromBase58 - check consistency with where we started
+  expect(PublicKey.fromBase58(js)).toEqual(pk);
+  expect(Test.encoding.publicKeyOfBase58(ml)).toEqual(pkMl);
 });

--- a/src/lib/ml/consistency.unit-test.ts
+++ b/src/lib/ml/consistency.unit-test.ts
@@ -2,6 +2,7 @@ import { Test } from '../../snarky.js';
 import { Random, test } from '../testing/property.js';
 import { Field, Bool } from '../core.js';
 import { PrivateKey, PublicKey } from '../signature.js';
+import { dummySignature } from '../account_update.js';
 import { Ml } from './conversion.js';
 import { expect } from 'expect';
 
@@ -40,3 +41,8 @@ test(Random.publicKey, (pk0) => {
   expect(PublicKey.fromBase58(js)).toEqual(pk);
   expect(Test.encoding.publicKeyOfBase58(ml)).toEqual(pkMl);
 });
+
+// dummy signature
+let js = dummySignature();
+let ml = Test.signature.dummySignature();
+expect(js).toEqual(ml);

--- a/src/lib/ml/conversion.ts
+++ b/src/lib/ml/conversion.ts
@@ -11,6 +11,7 @@ import { MlTuple, MlBool } from './base.js';
 export { Ml };
 
 const Ml = {
+  toFieldConst,
   fromScalar,
   toScalar,
   fromPrivateKey,
@@ -20,6 +21,10 @@ const Ml = {
   fromPublicKeyVar,
   toPublicKeyVar,
 };
+
+function toFieldConst(x: Field) {
+  return x.toConstant().value[1];
+}
 
 function fromScalar(s: Scalar) {
   return s.toConstant().constantValue;

--- a/src/lib/ml/conversion.ts
+++ b/src/lib/ml/conversion.ts
@@ -4,6 +4,7 @@
 
 import type { MlPublicKey, MlPublicKeyVar } from '../../snarky.js';
 import { Bool, Field } from '../core.js';
+import { FieldConst, FieldVar } from '../field.js';
 import { Scalar, ScalarConst } from '../scalar.js';
 import { PrivateKey, PublicKey } from '../signature.js';
 import { MlTuple, MlBool } from './base.js';
@@ -11,19 +12,35 @@ import { MlTuple, MlBool } from './base.js';
 export { Ml };
 
 const Ml = {
-  toFieldConst,
+  constFromField,
+  constToField,
+  varFromField,
+  varToField,
+
   fromScalar,
   toScalar,
+
   fromPrivateKey,
   toPrivateKey,
+
   fromPublicKey,
   toPublicKey,
+
   fromPublicKeyVar,
   toPublicKeyVar,
 };
 
-function toFieldConst(x: Field) {
+function constFromField(x: Field): FieldConst {
   return x.toConstant().value[1];
+}
+function constToField(x: FieldConst): Field {
+  return Field(x);
+}
+function varFromField(x: Field): FieldVar {
+  return x.value;
+}
+function varToField(x: FieldVar): Field {
+  return Field(x);
 }
 
 function fromScalar(s: Scalar) {

--- a/src/lib/ml/conversion.ts
+++ b/src/lib/ml/conversion.ts
@@ -2,8 +2,11 @@
  * this file contains conversion functions between JS and OCaml
  */
 
+import type { MlPublicKey } from '../../snarky.js';
+import { Bool, Field } from '../core.js';
 import { Scalar, ScalarConst } from '../scalar.js';
-import { PrivateKey } from '../signature.js';
+import { PrivateKey, PublicKey } from '../signature.js';
+import { MlTuple } from './base.js';
 
 export { Ml };
 
@@ -12,6 +15,8 @@ const Ml = {
   toScalar,
   fromPrivateKey,
   toPrivateKey,
+  fromPublicKey,
+  toPublicKey,
 };
 
 function fromScalar(s: Scalar) {
@@ -26,4 +31,15 @@ function fromPrivateKey(sk: PrivateKey) {
 }
 function toPrivateKey(sk: ScalarConst) {
   return new PrivateKey(Scalar.from(sk));
+}
+
+function fromPublicKey(pk: PublicKey): MlPublicKey {
+  return MlTuple(pk.x.value, pk.isOdd.toField().value);
+}
+function toPublicKey([, x, isOdd]: MlPublicKey): PublicKey {
+  return PublicKey.from({
+    x: Field(x),
+    // TODO
+    isOdd: Bool.Unsafe.ofField(Field(isOdd)),
+  });
 }

--- a/src/lib/ml/conversion.ts
+++ b/src/lib/ml/conversion.ts
@@ -2,11 +2,11 @@
  * this file contains conversion functions between JS and OCaml
  */
 
-import type { MlPublicKey } from '../../snarky.js';
+import type { MlPublicKey, MlPublicKeyVar } from '../../snarky.js';
 import { Bool, Field } from '../core.js';
 import { Scalar, ScalarConst } from '../scalar.js';
 import { PrivateKey, PublicKey } from '../signature.js';
-import { MlTuple } from './base.js';
+import { MlTuple, MlBool } from './base.js';
 
 export { Ml };
 
@@ -17,6 +17,8 @@ const Ml = {
   toPrivateKey,
   fromPublicKey,
   toPublicKey,
+  fromPublicKeyVar,
+  toPublicKeyVar,
 };
 
 function fromScalar(s: Scalar) {
@@ -34,9 +36,19 @@ function toPrivateKey(sk: ScalarConst) {
 }
 
 function fromPublicKey(pk: PublicKey): MlPublicKey {
-  return MlTuple(pk.x.value, pk.isOdd.toField().value);
+  return MlTuple(pk.x.toConstant().value[1], MlBool(pk.isOdd.toBoolean()));
 }
 function toPublicKey([, x, isOdd]: MlPublicKey): PublicKey {
+  return PublicKey.from({
+    x: Field(x),
+    isOdd: Bool(MlBool.from(isOdd)),
+  });
+}
+
+function fromPublicKeyVar(pk: PublicKey): MlPublicKeyVar {
+  return MlTuple(pk.x.value, pk.isOdd.toField().value);
+}
+function toPublicKeyVar([, x, isOdd]: MlPublicKeyVar): PublicKey {
   return PublicKey.from({
     x: Field(x),
     // TODO

--- a/src/lib/ml/fields.ts
+++ b/src/lib/ml/fields.ts
@@ -1,0 +1,23 @@
+import { ConstantField, Field, FieldConst, FieldVar } from '../field.js';
+import { MlArray } from './base.js';
+export { MlFieldArray, MlFieldConstArray };
+
+type MlFieldArray = MlArray<FieldVar>;
+const MlFieldArray = {
+  to(arr: Field[]): MlArray<FieldVar> {
+    return MlArray.to(arr.map((x) => x.value));
+  },
+  from([, ...arr]: MlArray<FieldVar>) {
+    return arr.map((x) => new Field(x));
+  },
+};
+
+type MlFieldConstArray = MlArray<FieldConst>;
+const MlFieldConstArray = {
+  to(arr: Field[]): MlArray<FieldConst> {
+    return MlArray.to(arr.map((x) => x.toConstant().value[1]));
+  },
+  from([, ...arr]: MlArray<FieldConst>): ConstantField[] {
+    return arr.map((x) => new Field(x) as ConstantField);
+  },
+};

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -4,7 +4,7 @@ import {
   EmptyVoid,
 } from '../bindings/lib/generic.js';
 import { withThreadPool } from '../bindings/js/wrapper.js';
-import { Bool, ProvablePure, Pickles, Poseidon } from '../snarky.js';
+import { Bool, ProvablePure, Pickles } from '../snarky.js';
 import { Field } from './core.js';
 import {
   FlexibleProvable,
@@ -17,6 +17,7 @@ import {
 import { Provable } from './provable.js';
 import { assert, prettifyStacktracePromise } from './errors.js';
 import { snarkContext } from './provable-context.js';
+import { hashConstant } from './hash.js';
 
 // public API
 export {
@@ -339,9 +340,8 @@ function ZkProgram<
     let methodData = methodIntfs.map((methodEntry, i) =>
       analyzeMethod(publicInputType, methodEntry, methodFunctions[i])
     );
-    let hash = Poseidon.hash(
-      Object.values(methodData).map((d) => Field(BigInt('0x' + d.digest))),
-      false
+    let hash = hashConstant(
+      Object.values(methodData).map((d) => Field(BigInt('0x' + d.digest)))
     );
     return hash.toBigInt().toString(16);
   }

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -19,7 +19,7 @@ import { assert, prettifyStacktracePromise } from './errors.js';
 import { snarkContext } from './provable-context.js';
 import { hashConstant } from './hash.js';
 import { MlArray, MlTuple } from './ml/base.js';
-import { MlFieldArray, MlFieldConstArray } from './field.js';
+import { MlFieldArray, MlFieldConstArray } from './ml/fields.js';
 
 // public API
 export {

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -18,6 +18,8 @@ import { Provable } from './provable.js';
 import { assert, prettifyStacktracePromise } from './errors.js';
 import { snarkContext } from './provable-context.js';
 import { hashConstant } from './hash.js';
+import { MlArray, MlTuple } from './ml/base.js';
+import { MlFieldArray, MlFieldConstArray } from './field.js';
 
 // public API
 export {
@@ -136,25 +138,27 @@ async function verify(
   verificationKey: string
 ) {
   let picklesProof: Pickles.Proof;
-  let statement: Pickles.Statement;
+  let statement: Pickles.StatementConst;
   if (typeof proof.proof === 'string') {
     // json proof
     [, picklesProof] = Pickles.proofOfBase64(
       proof.proof,
       proof.maxProofsVerified
     );
-    statement = {
-      input: (proof as JsonProof).publicInput.map(Field),
-      output: (proof as JsonProof).publicOutput.map(Field),
-    };
+    let input = MlFieldConstArray.to(
+      (proof as JsonProof).publicInput.map(Field)
+    );
+    let output = MlFieldConstArray.to(
+      (proof as JsonProof).publicOutput.map(Field)
+    );
+    statement = MlTuple(input, output);
   } else {
     // proof class
     picklesProof = proof.proof;
     let type = getStatementType(proof.constructor as any);
-    statement = {
-      input: type.input.toFields(proof.publicInput),
-      output: type.output.toFields(proof.publicOutput),
-    };
+    let input = toFieldConsts(type.input, proof.publicInput);
+    let output = toFieldConsts(type.output, proof.publicOutput);
+    statement = MlTuple(input, output);
   }
   return prettifyStacktracePromise(
     withThreadPool(() =>
@@ -250,7 +254,7 @@ function ZkProgram<
     | {
         provers: Pickles.Prover[];
         verify: (
-          statement: Pickles.Statement,
+          statement: Pickles.StatementConst,
           proof: Pickles.Proof
         ) => Promise<boolean>;
       }
@@ -283,8 +287,10 @@ function ZkProgram<
             `Try calling \`await program.compile()\` first, this will cache provers in the background.`
         );
       }
-      let publicInputFields = publicInputType.toFields(publicInput);
-      let previousProofs = getPreviousProofsForProver(args, methodIntfs[i]);
+      let publicInputFields = toFieldConsts(publicInputType, publicInput);
+      let previousProofs = MlArray.to(
+        getPreviousProofsForProver(args, methodIntfs[i])
+      );
 
       let id = snarkContext.enter({ witnesses: args, inProver: true });
       let result: UnwrapPromise<ReturnType<typeof picklesProver>>;
@@ -293,8 +299,8 @@ function ZkProgram<
       } finally {
         snarkContext.leave(id);
       }
-      let { proof } = result;
-      let publicOutput = publicOutputType.fromFields(result.publicOutput);
+      let [publicOutputFields, proof] = MlTuple.from(result);
+      let publicOutput = fromFieldConsts(publicOutputType, publicOutputFields);
       class ProgramProof extends Proof<PublicInput, PublicOutput> {
         static publicInputType = publicInputType;
         static publicOutputType = publicOutputType;
@@ -329,10 +335,10 @@ function ZkProgram<
         `Cannot verify proof, verification key not found. Try calling \`await program.compile()\` first.`
       );
     }
-    let statement = {
-      input: publicInputType.toFields(proof.publicInput),
-      output: publicOutputType.toFields(proof.publicOutput),
-    };
+    let statement = MlTuple(
+      toFieldConsts(publicInputType, proof.publicInput),
+      toFieldConsts(publicOutputType, proof.publicOutput)
+    );
     return compileOutput.verify(statement, proof.proof);
   }
 
@@ -513,25 +519,25 @@ async function compileProgram(
         let result: ReturnType<typeof Pickles.compile>;
         let id = snarkContext.enter({ inCompile: true });
         try {
-          result = Pickles.compile(rules, {
+          result = Pickles.compile(MlArray.to(rules), {
             publicInputSize: publicInputType.sizeInFields(),
             publicOutputSize: publicOutputType.sizeInFields(),
           });
         } finally {
           snarkContext.leave(id);
         }
-        let { getVerificationKeyArtifact, provers, verify, tag } = result;
+        let { getVerificationKey, provers, verify, tag } = result;
         CompiledTag.store(proofSystemTag, tag);
-        let verificationKey = getVerificationKeyArtifact();
-        return { verificationKey, provers, verify, tag };
+        let verificationKey = getVerificationKey();
+        return { verificationKey, provers: MlArray.from(provers), verify, tag };
       })
     );
   // wrap provers
   let wrappedProvers = provers.map(
     (prover): Pickles.Prover =>
       async function picklesProver(
-        publicInput: Field[],
-        previousProofs: Pickles.Proof[]
+        publicInput: MlFieldConstArray,
+        previousProofs: MlArray<Pickles.Proof>
       ) {
         return prettifyStacktracePromise(
           withThreadPool(() => prover(publicInput, previousProofs))
@@ -540,7 +546,7 @@ async function compileProgram(
   );
   // wrap verify
   let wrappedVerify = async function picklesVerify(
-    statement: Pickles.Statement,
+    statement: Pickles.StatementConst,
     proof: Pickles.Proof
   ) {
     return prettifyStacktracePromise(
@@ -570,13 +576,13 @@ function analyzeMethod<T>(
 }
 
 function picklesRuleFromFunction(
-  publicInputType: ProvablePure<any>,
-  publicOutputType: ProvablePure<any>,
+  publicInputType: ProvablePure<unknown>,
+  publicOutputType: ProvablePure<unknown>,
   func: (...args: unknown[]) => any,
   proofSystemTag: { name: string },
   { methodName, witnessArgs, proofArgs, allArgs }: MethodInterface
 ): Pickles.Rule {
-  function main(publicInput: Field[]): ReturnType<Pickles.Rule['main']> {
+  function main(publicInput: MlFieldArray): ReturnType<Pickles.Rule['main']> {
     let { witnesses: argsWithoutPublicInput, inProver } = snarkContext.get();
     assert(!(inProver && argsWithoutPublicInput === undefined));
     let finalArgs = [];
@@ -603,10 +609,9 @@ function picklesRuleFromFunction(
         let proofInstance = new Proof({ publicInput, publicOutput, proof });
         finalArgs[i] = proofInstance;
         proofs.push(proofInstance);
-        previousStatements.push({
-          input: type.input.toFields(publicInput),
-          output: type.output.toFields(publicOutput),
-        });
+        let input = toFieldVars(type.input, publicInput);
+        let output = toFieldVars(type.output, publicOutput);
+        previousStatements.push(MlTuple(input, output));
       } else if (arg.type === 'generic') {
         finalArgs[i] = argsWithoutPublicInput?.[i] ?? emptyGeneric();
       }
@@ -615,15 +620,18 @@ function picklesRuleFromFunction(
     if (publicInputType === Undefined || publicInputType === Void) {
       result = func(...finalArgs);
     } else {
-      result = func(publicInputType.fromFields(publicInput), ...finalArgs);
+      let input = fromFieldVars(publicInputType, publicInput);
+      result = func(input, ...finalArgs);
     }
     // if the public output is empty, we don't evaluate `toFields(result)` to allow the function to return something else in that case
     let hasPublicOutput = publicOutputType.sizeInFields() !== 0;
     let publicOutput = hasPublicOutput ? publicOutputType.toFields(result) : [];
     return {
-      publicOutput,
-      previousStatements,
-      shouldVerify: proofs.map((proof) => proof.shouldVerify),
+      publicOutput: MlFieldArray.to(publicOutput),
+      previousStatements: MlArray.to(previousStatements),
+      shouldVerify: MlArray.to(
+        proofs.map((proof) => proof.shouldVerify.toField().value)
+      ),
     };
   }
 
@@ -647,7 +655,11 @@ function picklesRuleFromFunction(
       return { isSelf: false, tag: compiledTag };
     }
   });
-  return { identifier: methodName, main, proofsToVerify };
+  return {
+    identifier: methodName,
+    main,
+    proofsToVerify: MlArray.to(proofsToVerify),
+  };
 }
 
 function synthesizeMethodArguments(
@@ -757,6 +769,20 @@ function getStatementType<
     input: Proof.publicInputType as any,
     output: Proof.publicOutputType as any,
   };
+}
+
+function fromFieldVars<T>(type: ProvablePure<T>, fields: MlFieldArray) {
+  return type.fromFields(MlFieldArray.from(fields));
+}
+function toFieldVars<T>(type: ProvablePure<T>, value: T) {
+  return MlFieldArray.to(type.toFields(value));
+}
+
+function fromFieldConsts<T>(type: ProvablePure<T>, fields: MlFieldConstArray) {
+  return type.fromFields(MlFieldConstArray.from(fields));
+}
+function toFieldConsts<T>(type: ProvablePure<T>, value: T) {
+  return MlFieldConstArray.to(type.toFields(value));
 }
 
 ZkProgram.Proof = function <

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -528,7 +528,8 @@ async function compileProgram(
         }
         let { getVerificationKey, provers, verify, tag } = result;
         CompiledTag.store(proofSystemTag, tag);
-        let verificationKey = getVerificationKey();
+        let [, data, hash] = getVerificationKey();
+        let verificationKey = { data, hash: Field(hash) };
         return { verificationKey, provers: MlArray.from(provers), verify, tag };
       })
     );

--- a/src/lib/scalar.ts
+++ b/src/lib/scalar.ts
@@ -1,6 +1,7 @@
-import { Snarky, Provable, Bool, MlArray } from '../snarky.js';
+import { Snarky, Provable, Bool } from '../snarky.js';
 import { Scalar as Fq } from '../provable/curve-bigint.js';
 import { Field, FieldConst, FieldVar } from './field.js';
+import { MlArray } from './ml/base.js';
 
 export { Scalar, ScalarConst, unshift, shift };
 

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -1,14 +1,15 @@
-import { Bool, Ledger } from '../snarky.js';
-import { Field, Group, Scalar } from './core.js';
+import { Field, Bool, Group, Scalar } from './core.js';
 import { prop, CircuitValue, AnyConstructor } from './circuit_value.js';
 import { hashWithPrefix } from './hash.js';
 import {
   deriveNonce,
   Signature as SignatureBigint,
 } from '../mina-signer/src/signature.js';
+import { Bool as BoolBigint } from '../provable/field-bigint.js';
 import {
   Scalar as ScalarBigint,
   PrivateKey as PrivateKeyBigint,
+  PublicKey as PublicKeyBigint,
 } from '../provable/curve-bigint.js';
 import { prefixes } from '../bindings/crypto/constants.js';
 
@@ -172,9 +173,10 @@ class PublicKey extends CircuitValue {
    * @returns a {@link PublicKey}
    */
   static fromBase58(publicKeyBase58: string) {
-    let pk = Ledger.publicKeyOfString(publicKeyBase58);
-    return PublicKey.from(pk);
+    let { x, isOdd } = PublicKeyBigint.fromBase58(publicKeyBase58);
+    return PublicKey.from({ x: Field(x), isOdd: Bool(!!isOdd) });
   }
+
   /**
    * Encodes a {@link PublicKey} in base58 format.
    * @returns a base58 encoded {@link PublicKey}
@@ -182,14 +184,18 @@ class PublicKey extends CircuitValue {
   toBase58() {
     return PublicKey.toBase58(this);
   }
-  // static version, to operate on non-class versions of this type
+
   /**
    * Static method to encode a {@link PublicKey} into base58 format.
    * @returns a base58 encoded {@link PublicKey}
    */
-  static toBase58(publicKey: PublicKey) {
-    return Ledger.publicKeyToString(publicKey);
+  static toBase58({ x, isOdd }: PublicKey) {
+    return PublicKeyBigint.toBase58({
+      x: x.toBigInt(),
+      isOdd: BoolBigint(isOdd.toBoolean()),
+    });
   }
+
   /**
    * Serializes a {@link PublicKey} into its JSON representation.
    * @returns a JSON string
@@ -197,6 +203,7 @@ class PublicKey extends CircuitValue {
   static toJSON(publicKey: PublicKey) {
     return publicKey.toBase58();
   }
+
   /**
    * Deserializes a JSON string into a {@link PublicKey}.
    * @returns a JSON string

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -2,7 +2,6 @@ import { Types } from '../bindings/mina-transaction/types.js';
 import {
   Bool,
   Gate,
-  Ledger,
   Pickles,
   Poseidon as Poseidon_,
   ProvablePure,
@@ -36,7 +35,7 @@ import {
 import { Circuit } from './circuit.js';
 import { Provable, getBlindingValue, memoizationContext } from './provable.js';
 import * as Encoding from '../bindings/lib/encoding.js';
-import { Poseidon } from './hash.js';
+import { Poseidon, hashConstant } from './hash.js';
 import { UInt32, UInt64 } from './int.js';
 import * as Mina from './mina.js';
 import {
@@ -431,7 +430,7 @@ function wrapMethod(
           result,
           constantBlindingValue
         );
-        accountUpdate.body.callData = Poseidon_.hash(callDataFields, false);
+        accountUpdate.body.callData = hashConstant(callDataFields);
 
         if (!Authorization.hasAny(accountUpdate)) {
           Authorization.setLazyProof(
@@ -715,9 +714,8 @@ class SmartContract {
   static digest() {
     // TODO: this should use the method digests in a deterministic order!
     let methodData = this.analyzeMethods();
-    let hash = Poseidon_.hash(
-      Object.values(methodData).map((d) => Field(BigInt('0x' + d.digest))),
-      false
+    let hash = hashConstant(
+      Object.values(methodData).map((d) => Field(BigInt('0x' + d.digest)))
     );
     return hash.toBigInt().toString(16);
   }

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'expect';
 import { isReady, Ledger, shutdown } from '../../snarky.js';
-import { Scalar as ScalarSnarky } from '../../lib/core.js';
 import {
   PrivateKey as PrivateKeySnarky,
   PublicKey as PublicKeySnarky,
@@ -284,8 +283,11 @@ function inputFromOcaml({
 function fixVerificationKey(a: AccountUpdate) {
   // ensure verification key is valid
   if (a.body.update.verificationKey.isSome === 1n) {
-    let { data, hash } = Pickles.dummyVerificationKey();
-    a.body.update.verificationKey.value = { data, hash: Field(hash) };
+    let [, data, hash] = Pickles.dummyVerificationKey();
+    a.body.update.verificationKey.value = {
+      data,
+      hash: Field.fromBytes([...hash]),
+    };
   } else {
     a.body.update.verificationKey.value = { data: '', hash: Field(0) };
   }

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -1,13 +1,5 @@
 import { expect } from 'expect';
-import {
-  isReady,
-  Ledger,
-  shutdown,
-  Test,
-  OcamlInput,
-  Pickles,
-} from '../../snarky.js';
-import { Field as FieldSnarky } from '../../lib/core.js';
+import { isReady, Ledger, shutdown, Test, Pickles } from '../../snarky.js';
 import {
   PrivateKey as PrivateKeySnarky,
   PublicKey as PublicKeySnarky,
@@ -49,9 +41,8 @@ import {
 } from './signature.js';
 import { Random, test, withHardCoded } from '../../lib/testing/property.js';
 import { RandomTransaction } from './random-transaction.js';
-import { Ml } from '../../lib/ml/conversion.js';
-import { FieldConst, MlFieldConstArray } from '../../lib/field.js';
-import { MlArray } from '../../lib/ml/base.js';
+import { Ml, MlHashInput } from '../../lib/ml/conversion.js';
+import { FieldConst } from '../../lib/field.js';
 
 // monkey-patch bigint to json
 (BigInt.prototype as any).toJSON = function () {
@@ -79,7 +70,7 @@ expect(AccountUpdate.toJSON(dummy)).toEqual(
 );
 
 let dummyInput = AccountUpdate.toInput(dummy);
-let dummyInputSnarky = inputFromOcaml(
+let dummyInputSnarky = MlHashInput.from(
   Ledger.hashInputFromJson.body(
     JSON.stringify(AccountUpdateSnarky.toJSON(dummySnarky).body)
   )
@@ -200,7 +191,7 @@ test(
     let feePayerJson = AccountUpdate.toJSON(feePayerAccountUpdate);
 
     let feePayerInput = AccountUpdate.toInput(feePayerAccountUpdate);
-    let feePayerInput1 = inputFromOcaml(
+    let feePayerInput1 = MlHashInput.from(
       Ledger.hashInputFromJson.body(JSON.stringify(feePayerJson.body))
     );
     expect(stringify(feePayerInput.fields)).toEqual(
@@ -279,28 +270,6 @@ test(
 
 console.log('to/from json, hashes & signatures are consistent! 🎉');
 shutdown();
-
-// function inputFromOcaml({
-//   fields,
-//   packed,
-// }: {
-//   fields: string[];
-//   packed: { field: string; size: number }[];
-// }) {
-//   return {
-//     fields,
-//     packed: packed.map(({ field, size }) => [field, size] as [string, number]),
-//   };
-// }
-
-function inputFromOcaml([, fields, packed]: OcamlInput) {
-  return {
-    fields: MlFieldConstArray.from(fields),
-    packed: MlArray.from(packed).map(
-      ([, field, size]) => [FieldSnarky(field), size] as [FieldSnarky, number]
-    ),
-  };
-}
 
 function fixVerificationKey(a: AccountUpdate) {
   // ensure verification key is valid

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'expect';
-import { isReady, Ledger, shutdown } from '../../snarky.js';
+import { isReady, Ledger, shutdown, Test } from '../../snarky.js';
 import {
   PrivateKey as PrivateKeySnarky,
   PublicKey as PublicKeySnarky,
@@ -43,6 +43,7 @@ import { Random, test, withHardCoded } from '../../lib/testing/property.js';
 import { RandomTransaction } from './random-transaction.js';
 import { Pickles } from '../../snarky.js';
 import { Ml } from '../../lib/ml/conversion.js';
+import { FieldConst } from '../../lib/field.js';
 
 // monkey-patch bigint to json
 (BigInt.prototype as any).toJSON = function () {
@@ -121,7 +122,7 @@ let memoGenerator = withHardCoded(Random.json.memoString, 'hello world');
 test(memoGenerator, (memoString) => {
   let memo = Memo.fromString(memoString);
   let memoBase58 = Memo.toBase58(memo);
-  let memoBase581 = Ledger.memoToBase58(memoString);
+  let memoBase581 = Test.encoding.memoToBase58(memoString);
   expect(memoBase58).toEqual(memoBase581);
   let memoRecovered = Memo.fromBase58(memoBase58);
   expect(memoRecovered).toEqual(memo);
@@ -184,8 +185,8 @@ test(
 
     let memo = Memo.fromBase58(memoBase58);
     let memoHash = Memo.hash(memo);
-    let memoHashSnarky = Ledger.memoHashBase58(memoBase58);
-    expect(memoHash).toEqual(memoHashSnarky.toBigInt());
+    let memoHashSnarky = Test.encoding.memoHashBase58(memoBase58);
+    expect(memoHash).toEqual(FieldConst.toBigint(memoHashSnarky));
 
     let feePayerAccountUpdate = accountUpdateFromFeePayer(feePayer);
     let feePayerJson = AccountUpdate.toJSON(feePayerAccountUpdate);

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -139,7 +139,7 @@ test(RandomTransaction.zkappCommand, (zkappCommand, assert) => {
   );
   let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
   let commitment = callForestHash(callForest);
-  expect(commitment).toEqual(ocamlCommitments.commitment.toBigInt());
+  expect(commitment).toEqual(FieldConst.toBigint(ocamlCommitments.commitment));
 });
 
 // invalid zkapp transactions
@@ -181,7 +181,9 @@ test(
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
     let commitment = callForestHash(callForest);
-    expect(commitment).toEqual(ocamlCommitments.commitment.toBigInt());
+    expect(commitment).toEqual(
+      FieldConst.toBigint(ocamlCommitments.commitment)
+    );
 
     let memo = Memo.fromBase58(memoBase58);
     let memoHash = Memo.hash(memo);
@@ -203,25 +205,29 @@ test(
     );
 
     let feePayerDigest = feePayerHash(feePayer);
-    expect(feePayerDigest).toEqual(ocamlCommitments.feePayerHash.toBigInt());
+    expect(feePayerDigest).toEqual(
+      FieldConst.toBigint(ocamlCommitments.feePayerHash)
+    );
 
     let fullCommitment = hashWithPrefix(prefixes.accountUpdateCons, [
       memoHash,
       feePayerDigest,
       commitment,
     ]);
-    expect(fullCommitment).toEqual(ocamlCommitments.fullCommitment.toBigInt());
+    expect(fullCommitment).toEqual(
+      FieldConst.toBigint(ocamlCommitments.fullCommitment)
+    );
 
     // signature
     let sigTestnet = signFieldElement(fullCommitment, feePayerKey, 'testnet');
     let sigMainnet = signFieldElement(fullCommitment, feePayerKey, 'mainnet');
     let sigTestnetOcaml = Test.signature.signFieldElement(
-      Ml.toFieldConst(ocamlCommitments.fullCommitment),
+      ocamlCommitments.fullCommitment,
       Ml.fromPrivateKey(feePayerKeySnarky),
       false
     );
     let sigMainnetOcaml = Test.signature.signFieldElement(
-      Ml.toFieldConst(ocamlCommitments.fullCommitment),
+      ocamlCommitments.fullCommitment,
       Ml.fromPrivateKey(feePayerKeySnarky),
       true
     );

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -163,7 +163,7 @@ test(
     let feePayerAddress = PrivateKey.toPublicKey(feePayerKey);
 
     let { feePayer, memo: memoBase58 } = zkappCommand;
-    feePayer.authorization = Ledger.dummySignature();
+    feePayer.authorization = Signature.toBase58(Signature.dummy());
     let zkappCommandJson = ZkappCommand.toJSON(zkappCommand);
 
     // snarkyjs fromJSON -> toJSON roundtrip, + consistency with mina-signer
@@ -215,13 +215,13 @@ test(
     // signature
     let sigTestnet = signFieldElement(fullCommitment, feePayerKey, 'testnet');
     let sigMainnet = signFieldElement(fullCommitment, feePayerKey, 'mainnet');
-    let sigTestnetOcaml = Ledger.signFieldElement(
-      ocamlCommitments.fullCommitment,
+    let sigTestnetOcaml = Test.signature.signFieldElement(
+      Ml.toFieldConst(ocamlCommitments.fullCommitment),
       Ml.fromPrivateKey(feePayerKeySnarky),
       false
     );
-    let sigMainnetOcaml = Ledger.signFieldElement(
-      ocamlCommitments.fullCommitment,
+    let sigMainnetOcaml = Test.signature.signFieldElement(
+      Ml.toFieldConst(ocamlCommitments.fullCommitment),
       Ml.fromPrivateKey(feePayerKeySnarky),
       true
     );

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -66,7 +66,7 @@ const Signature = {
     return { r, s };
   },
   dummy() {
-    return { r: Field(0), s: Scalar(0) };
+    return { r: Field(1), s: Scalar(1) };
   },
 };
 

--- a/src/mina-signer/src/signature.unit-test.ts
+++ b/src/mina-signer/src/signature.unit-test.ts
@@ -7,7 +7,7 @@ import {
   verify,
   verifyFieldElement,
 } from './signature.js';
-import { isReady, Ledger, shutdown } from '../../snarky.js';
+import { isReady, Ledger, shutdown, Test } from '../../snarky.js';
 import { Field as FieldSnarky } from '../../lib/core.js';
 import { Field } from '../../provable/field-bigint.js';
 import { PrivateKey, PublicKey } from '../../provable/curve-bigint.js';
@@ -16,6 +16,7 @@ import { p } from '../../bindings/crypto/finite_field.js';
 import { AccountUpdate } from '../../bindings/mina-transaction/gen/transaction-bigint.js';
 import { HashInput } from '../../bindings/lib/provable-bigint.js';
 import { Ml } from '../../lib/ml/conversion.js';
+import { FieldConst } from '../../lib/field.js';
 
 await isReady;
 
@@ -38,16 +39,10 @@ function checkConsistentSingle(
   expect(okTestnetMainnet).toEqual(false);
   expect(okMainnetMainnet).toEqual(true);
   // consistent with OCaml
-  let actualTest = Ledger.signFieldElement(
-    FieldSnarky(msg),
-    Ml.fromPrivateKey(keySnarky),
-    false
-  );
-  let actualMain = Ledger.signFieldElement(
-    FieldSnarky(msg),
-    Ml.fromPrivateKey(keySnarky),
-    true
-  );
+  let msgMl = FieldConst.fromBigint(msg);
+  let keyMl = Ml.fromPrivateKey(keySnarky);
+  let actualTest = Test.signature.signFieldElement(msgMl, keyMl, false);
+  let actualMain = Test.signature.signFieldElement(msgMl, keyMl, true);
   expect(Signature.toBase58(sigTest)).toEqual(actualTest);
   expect(Signature.toBase58(sigMain)).toEqual(actualMain);
 }

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -17,7 +17,7 @@ export {
 };
 
 // internal
-export { Snarky, Test, JsonGate, MlArray };
+export { Snarky, Test, JsonGate, MlPublicKey, MlPublicKeyVar };
 
 /**
  * `Provable<T>` is the general circuit type interface. Provable interface describes how a type `T` is made up of field elements and auxiliary (non-field element) data.
@@ -1279,8 +1279,9 @@ declare const Poseidon: {
   spongeSqueeze(sponge: unknown): FieldVar;
 };
 
-// these types should be implemented by corresponding snarkyjs classes
-type PublicKey_ = { x: Field; isOdd: Bool };
+type MlBoolean = 0 | 1;
+type MlPublicKey = MlTuple<FieldConst, MlBoolean>;
+type MlPublicKeyVar = MlTuple<FieldVar, BoolVar>;
 
 /**
  * Represents the Mina ledger.
@@ -1290,13 +1291,13 @@ declare class Ledger {
    * Creates a fresh ledger.
    */
   static create(
-    genesisAccounts: Array<{ publicKey: PublicKey_; balance: string }>
+    genesisAccounts: Array<{ publicKey: MlPublicKey; balance: string }>
   ): Ledger;
 
   /**
    * Adds an account and its balance to the ledger.
    */
-  addAccount(publicKey: PublicKey_, balance: string): void;
+  addAccount(publicKey: MlPublicKey, balance: string): void;
 
   /**
    * Applies a JSON transaction to the ledger.
@@ -1310,7 +1311,7 @@ declare class Ledger {
   /**
    * Returns an account.
    */
-  getAccount(publicKey: PublicKey_, tokenId: Field): JsonAccount | undefined;
+  getAccount(publicKey: MlPublicKey, tokenId: Field): JsonAccount | undefined;
 
   /**
    * Returns the commitment of a JSON transaction.
@@ -1343,12 +1344,9 @@ declare class Ledger {
    */
   static dummySignature(): string;
 
-  static customTokenId(publicKey: PublicKey_, tokenId: Field): Field;
-  static customTokenIdChecked(publicKey: PublicKey_, tokenId: Field): Field;
-  static createTokenAccount(publicKey: PublicKey_, tokenId: Field): string;
-
-  static publicKeyToString(publicKey: PublicKey_): string;
-  static publicKeyOfString(publicKeyBase58: string): PublicKey_;
+  static customTokenId(publicKey: MlPublicKey, tokenId: Field): Field;
+  static customTokenIdChecked(publicKey: MlPublicKeyVar, tokenId: Field): Field;
+  static createTokenAccount(publicKey: MlPublicKey, tokenId: Field): string;
 
   static fieldToBase58(field: Field): string;
   static fieldOfBase58(fieldBase58: string): Field;
@@ -1394,6 +1392,8 @@ declare class Ledger {
 
 declare const Test: {
   encoding: {
+    publicKeyToBase58(publicKey: MlPublicKey): string;
+    publicKeyOfBase58(publicKeyBase58: string): MlPublicKey;
     privateKeyToBase58(privateKey: ScalarConst): string;
     privateKeyOfBase58(privateKeyBase58: string): ScalarConst;
   };

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -8,6 +8,7 @@ import type {
   MlOption,
   MlBool,
 } from './lib/ml/base.js';
+import type { MlHashInput } from './lib/ml/conversion.js';
 
 export { SnarkyField };
 export {
@@ -23,7 +24,7 @@ export {
 };
 
 // internal
-export { Snarky, Test, JsonGate, MlPublicKey, MlPublicKeyVar, OcamlInput };
+export { Snarky, Test, JsonGate, MlPublicKey, MlPublicKeyVar };
 
 /**
  * `Provable<T>` is the general circuit type interface. Provable interface describes how a type `T` is made up of field elements and auxiliary (non-field element) data.
@@ -1357,13 +1358,13 @@ declare class Ledger {
   static hashAccountUpdateFromJson(json: string): FieldConst;
 
   static hashInputFromJson: {
-    packInput(input: OcamlInput): MlArray<FieldConst>;
-    timing(json: String): OcamlInput;
-    permissions(json: String): OcamlInput;
-    update(json: String): OcamlInput;
-    accountPrecondition(json: String): OcamlInput;
-    networkPrecondition(json: String): OcamlInput;
-    body(json: String): OcamlInput;
+    packInput(input: MlHashInput): MlArray<FieldConst>;
+    timing(json: String): MlHashInput;
+    permissions(json: String): MlHashInput;
+    update(json: String): MlHashInput;
+    accountPrecondition(json: String): MlHashInput;
+    networkPrecondition(json: String): MlHashInput;
+    body(json: String): MlHashInput;
   };
 
   // low-level encoding helpers
@@ -1423,11 +1424,6 @@ declare const Test: {
  * see https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/mlBytes.js
  */
 type MlBytes = { t: number; c: string; l: number };
-type OcamlInput = [
-  flag: 0,
-  field_elements: MlArray<FieldConst>,
-  packed: MlArray<MlTuple<FieldConst, number>>
-];
 
 /**
  * @deprecated `shutdown()` is no longer needed, and is a no-op. Remove it from your code.

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -48,6 +48,7 @@ declare interface ProvablePure<T> extends Provable<T> {
 }
 
 declare namespace Snarky {
+  type Main = (publicInput: MlArray<FieldVar>) => void;
   type Keypair = unknown;
   type VerificationKey = unknown;
   type Proof = unknown;
@@ -200,18 +201,15 @@ declare const Snarky: {
     /**
      * Generates a proving key and a verification key for the provable function `main`
      */
-    compile(
-      main: (publicInput: Field[]) => void,
-      publicInputSize: number
-    ): Snarky.Keypair;
+    compile(main: Snarky.Main, publicInputSize: number): Snarky.Keypair;
 
     /**
      * Proves a statement using the private input, public input and the keypair of the circuit.
      */
     prove(
-      main: (publicInput: Field[]) => void,
+      main: Snarky.Main,
       publicInputSize: number,
-      publicInput: Field[],
+      publicInput: MlArray<FieldConst>,
       keypair: Snarky.Keypair
     ): Snarky.Proof;
 
@@ -219,7 +217,7 @@ declare const Snarky: {
      * Verifies a proof using the public input, the proof and the verification key of the circuit.
      */
     verify(
-      publicInput: Field[],
+      publicInput: MlArray<FieldConst>,
       proof: Snarky.Proof,
       verificationKey: Snarky.VerificationKey
     ): boolean;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -23,7 +23,7 @@ export {
 };
 
 // internal
-export { Snarky, Test, JsonGate, MlPublicKey, MlPublicKeyVar };
+export { Snarky, Test, JsonGate, MlPublicKey, MlPublicKeyVar, OcamlInput };
 
 /**
  * `Provable<T>` is the general circuit type interface. Provable interface describes how a type `T` is made up of field elements and auxiliary (non-field element) data.
@@ -1316,15 +1316,18 @@ declare class Ledger {
   /**
    * Returns an account.
    */
-  getAccount(publicKey: MlPublicKey, tokenId: Field): JsonAccount | undefined;
+  getAccount(
+    publicKey: MlPublicKey,
+    tokenId: FieldConst
+  ): JsonAccount | undefined;
 
   /**
    * Returns the commitment of a JSON transaction.
    */
   static transactionCommitments(txJson: string): {
-    commitment: Field;
-    fullCommitment: Field;
-    feePayerHash: Field;
+    commitment: FieldConst;
+    fullCommitment: FieldConst;
+    feePayerHash: FieldConst;
   };
 
   /**
@@ -1333,23 +1336,28 @@ declare class Ledger {
   static zkappPublicInput(
     txJson: string,
     accountUpdateIndex: number
-  ): { accountUpdate: Field; calls: Field };
+  ): { accountUpdate: FieldConst; calls: FieldConst };
 
-  static customTokenId(publicKey: MlPublicKey, tokenId: Field): Field;
-  static customTokenIdChecked(publicKey: MlPublicKeyVar, tokenId: Field): Field;
-  static createTokenAccount(publicKey: MlPublicKey, tokenId: Field): string;
+  static customTokenId(publicKey: MlPublicKey, tokenId: FieldConst): FieldConst;
+  static customTokenIdChecked(
+    publicKey: MlPublicKeyVar,
+    tokenId: FieldVar
+  ): FieldVar;
+  static createTokenAccount(
+    publicKey: MlPublicKey,
+    tokenId: FieldConst
+  ): string;
 
   static checkAccountUpdateSignature(
     updateJson: string,
-    commitment: Field
+    commitment: FieldConst
   ): boolean;
 
-  static fieldsOfJson(json: string): Field[];
-  static hashAccountUpdateFromFields(fields: Field[]): Field;
-  static hashAccountUpdateFromJson(json: string): Field;
+  static fieldsOfJson(json: string): MlArray<FieldConst>;
+  static hashAccountUpdateFromJson(json: string): FieldConst;
 
   static hashInputFromJson: {
-    packInput(input: OcamlInput): Field[];
+    packInput(input: OcamlInput): MlArray<FieldConst>;
     timing(json: String): OcamlInput;
     permissions(json: String): OcamlInput;
     update(json: String): OcamlInput;
@@ -1415,7 +1423,11 @@ declare const Test: {
  * see https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/mlBytes.js
  */
 type MlBytes = { t: number; c: string; l: number };
-type OcamlInput = { fields: Field[]; packed: { field: Field; size: number }[] };
+type OcamlInput = [
+  flag: 0,
+  field_elements: MlArray<FieldConst>,
+  packed: MlArray<MlTuple<FieldConst, number>>
+];
 
 /**
  * @deprecated `shutdown()` is no longer needed, and is a no-op. Remove it from your code.

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1,7 +1,8 @@
 import type { Account as JsonAccount } from './bindings/mina-transaction/gen/transaction-json.js';
 import type { Field, FieldConst, FieldVar } from './lib/field.js';
-import type { Scalar, ScalarConst } from './lib/scalar.js';
-// export { Field };
+import type { ScalarConst } from './lib/scalar.js';
+import type { MlArray, MlTuple, MlList, MlOption } from './lib/ml/base.js';
+
 export { SnarkyField };
 export {
   Bool,
@@ -45,12 +46,6 @@ declare interface ProvablePure<T> extends Provable<T> {
   sizeInFields(): number;
   check: (x: T) => void;
 }
-
-// ocaml types
-type MlTuple<X, Y> = [0, X, Y];
-type MlArray<T> = [0, ...T[]];
-type MlList<T> = [0, T, 0 | MlList<T>];
-type MlOption<T> = 0 | [0, T];
 
 declare namespace Snarky {
   type Keypair = unknown;
@@ -1261,13 +1256,16 @@ type Gate = {
 // }
 
 declare const Poseidon: {
-  hash(input: Field[], isChecked: boolean): Field;
+  hash(input: MlArray<FieldVar>, isChecked: boolean): FieldVar;
   update(
-    state: [Field, Field, Field],
-    input: Field[],
+    state: MlArray<FieldVar>,
+    input: MlArray<FieldVar>,
     isChecked: boolean
-  ): [Field, Field, Field];
-  hashToGroup(input: Field[], isChecked: boolean): MlTuple<FieldVar, FieldVar>;
+  ): [0, FieldVar, FieldVar, FieldVar];
+  hashToGroup(
+    input: MlArray<FieldVar>,
+    isChecked: boolean
+  ): MlTuple<FieldVar, FieldVar>;
   prefixes: Record<
     | 'event'
     | 'events'
@@ -1279,8 +1277,8 @@ declare const Poseidon: {
     string
   >;
   spongeCreate(isChecked: boolean): unknown;
-  spongeAbsorb(sponge: unknown, x: Field): void;
-  spongeSqueeze(sponge: unknown): Field;
+  spongeAbsorb(sponge: unknown, x: FieldVar): void;
+  spongeSqueeze(sponge: unknown): FieldVar;
 };
 
 // these types should be implemented by corresponding snarkyjs classes

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1353,12 +1353,6 @@ declare class Ledger {
   static customTokenIdChecked(publicKey: MlPublicKeyVar, tokenId: Field): Field;
   static createTokenAccount(publicKey: MlPublicKey, tokenId: Field): string;
 
-  static fieldToBase58(field: Field): string;
-  static fieldOfBase58(fieldBase58: string): Field;
-
-  static memoToBase58(memoString: string): string;
-  static memoHashBase58(memoBase58: string): Field;
-
   static checkAccountUpdateSignature(
     updateJson: string,
     commitment: Field
@@ -1401,6 +1395,10 @@ declare const Test: {
     publicKeyOfBase58(publicKeyBase58: string): MlPublicKey;
     privateKeyToBase58(privateKey: ScalarConst): string;
     privateKeyOfBase58(privateKeyBase58: string): ScalarConst;
+    tokenIdToBase58(field: FieldConst): string;
+    tokenIdOfBase58(fieldBase58: string): FieldConst;
+    memoToBase58(memoString: string): string;
+    memoHashBase58(memoBase58: string): FieldConst;
   };
   transactionHash: {
     examplePayment(): string;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1335,20 +1335,6 @@ declare class Ledger {
     accountUpdateIndex: number
   ): { accountUpdate: Field; calls: Field };
 
-  /**
-   * Signs a {@link Field} element.
-   */
-  static signFieldElement(
-    messageHash: Field,
-    privateKey: ScalarConst,
-    isMainnet: boolean
-  ): string;
-
-  /**
-   * Returns a dummy signature.
-   */
-  static dummySignature(): string;
-
   static customTokenId(publicKey: MlPublicKey, tokenId: Field): Field;
   static customTokenIdChecked(publicKey: MlPublicKeyVar, tokenId: Field): Field;
   static createTokenAccount(publicKey: MlPublicKey, tokenId: Field): string;
@@ -1399,6 +1385,20 @@ declare const Test: {
     tokenIdOfBase58(fieldBase58: string): FieldConst;
     memoToBase58(memoString: string): string;
     memoHashBase58(memoBase58: string): FieldConst;
+  };
+  signature: {
+    /**
+     * Signs a {@link Field} element.
+     */
+    signFieldElement(
+      messageHash: FieldConst,
+      privateKey: ScalarConst,
+      isMainnet: boolean
+    ): string;
+    /**
+     * Returns a dummy signature.
+     */
+    dummySignature(): string;
   };
   transactionHash: {
     examplePayment(): string;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1476,7 +1476,10 @@ declare const Pickles: {
       proof: Pickles.Proof
     ) => Promise<boolean>;
     tag: unknown;
-    getVerificationKey: () => { data: string; hash: string };
+    /**
+     * @returns (base64 vk, hash)
+     */
+    getVerificationKey: () => MlTuple<string, FieldConst>;
   };
 
   verify(
@@ -1486,7 +1489,10 @@ declare const Pickles: {
   ): Promise<boolean>;
 
   dummyBase64Proof: () => string;
-  dummyVerificationKey: () => { data: string; hash: string };
+  /**
+   * @returns (base64 vk, hash)
+   */
+  dummyVerificationKey: () => MlTuple<string, FieldConst>;
 
   proofToBase64: (proof: [0 | 1 | 2, Pickles.Proof]) => string;
   proofOfBase64: (

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1426,25 +1426,22 @@ declare let isReady: Promise<undefined>;
 
 declare namespace Pickles {
   type Proof = unknown; // opaque to js
-  type Statement = { input: Field[]; output: Field[] };
-  type ProofWithStatement = {
-    publicInput: Field[];
-    publicOutput: Field[];
-    proof: Proof;
-  };
+  type Statement = MlTuple<MlArray<FieldVar>, MlArray<FieldVar>>; // (publicInput, publicOutput)
+  type StatementConst = MlTuple<MlArray<FieldConst>, MlArray<FieldConst>>; // (publicInput, publicOutput)
   type Rule = {
     identifier: string;
-    main: (publicInput: Field[]) => {
-      publicOutput: Field[];
-      previousStatements: Statement[];
-      shouldVerify: Bool[];
+    main: (publicInput: MlArray<FieldVar>) => {
+      publicOutput: MlArray<FieldVar>;
+      previousStatements: MlArray<Statement>;
+      shouldVerify: MlArray<BoolVar>;
     };
-    proofsToVerify: ({ isSelf: true } | { isSelf: false; tag: unknown })[];
+    proofsToVerify: MlArray<{ isSelf: true } | { isSelf: false; tag: unknown }>;
   };
+  // returns (publicOutput, proof)
   type Prover = (
-    publicInput: Field[],
-    previousProofs: Proof[]
-  ) => Promise<{ publicOutput: Field[]; proof: Proof }>;
+    publicInput: MlArray<FieldConst>,
+    previousProofs: MlArray<Proof>
+  ) => Promise<MlTuple<MlArray<FieldConst>, Proof>>;
 }
 
 declare const Pickles: {
@@ -1470,20 +1467,20 @@ declare const Pickles: {
    * 4) let (wrap_pk, wrap_vk) -> log_wrap -> Snarky_log.Constraints.log -> constraint_count (yes, a second time)
    */
   compile: (
-    rules: Pickles.Rule[],
+    rules: MlArray<Pickles.Rule>,
     signature: { publicInputSize: number; publicOutputSize: number }
   ) => {
-    provers: Pickles.Prover[];
+    provers: MlArray<Pickles.Prover>;
     verify: (
-      statement: Pickles.Statement,
+      statement: Pickles.StatementConst,
       proof: Pickles.Proof
     ) => Promise<boolean>;
     tag: unknown;
-    getVerificationKeyArtifact: () => { data: string; hash: string };
+    getVerificationKey: () => { data: string; hash: string };
   };
 
   verify(
-    statement: Pickles.Statement,
+    statement: Pickles.StatementConst,
     proof: Pickles.Proof,
     verificationKey: string
   ): Promise<boolean>;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -1,7 +1,13 @@
 import type { Account as JsonAccount } from './bindings/mina-transaction/gen/transaction-json.js';
 import type { Field, FieldConst, FieldVar } from './lib/field.js';
 import type { ScalarConst } from './lib/scalar.js';
-import type { MlArray, MlTuple, MlList, MlOption } from './lib/ml/base.js';
+import type {
+  MlArray,
+  MlTuple,
+  MlList,
+  MlOption,
+  MlBool,
+} from './lib/ml/base.js';
 
 export { SnarkyField };
 export {
@@ -1279,8 +1285,7 @@ declare const Poseidon: {
   spongeSqueeze(sponge: unknown): FieldVar;
 };
 
-type MlBoolean = 0 | 1;
-type MlPublicKey = MlTuple<FieldConst, MlBoolean>;
+type MlPublicKey = MlTuple<FieldConst, MlBool>;
 type MlPublicKeyVar = MlTuple<FieldVar, BoolVar>;
 
 /**


### PR DESCRIPTION
bindings: https://github.com/o1-labs/snarkyjs-bindings/pull/34

follow up PR to https://github.com/o1-labs/snarkyjs/pull/902, https://github.com/o1-labs/snarkyjs/pull/932, https://github.com/o1-labs/snarkyjs/pull/935

this works towards removing the ocaml Field and Bool classes, by moving to lower level field representations in ALL APIs exposed from ocaml, except Field and Bool themselves. For example, this changes the Poseidon and Pickles APIs, and various helpers. TS to ml conversion logic is moved to TS, to keep the ml side as light as possible. 

We also continue the work of https://github.com/o1-labs/snarkyjs/pull/935 of moving helper functions on `Ledger` to a `Test` module and relegating them to consistency tests (while using TS impls in snarkyjs)

Note: this PR doesn't yet remove old `Field` and `Bool` to keep it independent from the `Bool` refactor https://github.com/o1-labs/snarkyjs/pull/936