### PR TITLE
Fixup deserialization of proof-systems JSON format

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - berkeley
+      - develop
   pull_request:
     branches:
       - main
       - berkeley
+      - develop
   workflow_dispatch: {}
 
 jobs:

--- a/src/lib/provable-context.ts
+++ b/src/lib/provable-context.ts
@@ -1,6 +1,6 @@
 import { Context } from './global-context.js';
 import { Gate, JsonGate, Snarky } from '../snarky.js';
-import { bytesToBigInt } from '../bindings/crypto/bigint-helpers.js';
+import { parseHexString } from '../bindings/crypto/bigint-helpers.js';
 import { prettifyStacktrace } from './errors.js';
 
 // internal API
@@ -105,12 +105,8 @@ function constraintSystem<T>(f: () => T) {
 // helpers
 
 function gatesFromJson(cs: { gates: JsonGate[]; public_input_size: number }) {
-  let gates: Gate[] = cs.gates.map(({ typ, wires, coeffs: byteCoeffs }) => {
-    let coeffs = [];
-    for (let coefficient of byteCoeffs) {
-      let arr = new Uint8Array(coefficient);
-      coeffs.push(bytesToBigInt(arr).toString());
-    }
+  let gates: Gate[] = cs.gates.map(({ typ, wires, coeffs: hexCoeffs }) => {
+    let coeffs = hexCoeffs.map(hex => parseHexString(hex).toString());
     return { type: typ, wires, coeffs };
   });
   return { publicInputSize: cs.public_input_size, gates };

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -222,7 +222,7 @@ declare const Snarky: {
 type JsonGate = {
   typ: string;
   wires: { row: number; col: number }[];
-  coeffs: number[][];
+  coeffs: string[];
 };
 type JsonConstraintSystem = { gates: JsonGate[]; public_input_size: number };
 


### PR DESCRIPTION
This PR is associated with the bindings changes in https://github.com/o1-labs/snarkyjs-bindings/pull/37.

As well as updating the bindings, this PR fixes the `gatesFromJson` helper: the JSON format emitted from the rust side now represents the coefficients as hex strings. This fix uses the helper function introduced in https://github.com/o1-labs/snarkyjs-bindings/pull/37, which handles the endianness mismatch between the rust `Field` serialization and the JS `Bigint`'s.