### PR TITLE
Clean up SnarkyJS-OCaml, part 3

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1804,6 +1804,7 @@ const Authorization = {
     signature ??= {};
     accountUpdate.body.authorizationKind.isSigned = Bool(true);
     accountUpdate.body.authorizationKind.isProved = Bool(false);
+    accountUpdate.body.authorizationKind.verificationKeyHash = Field(0);
     accountUpdate.authorization = {};
     accountUpdate.lazyAuthorization = { ...signature, kind: 'lazy-signature' };
   },
@@ -1861,6 +1862,7 @@ const Authorization = {
   setLazyNone(accountUpdate: AccountUpdate) {
     accountUpdate.body.authorizationKind.isSigned = Bool(false);
     accountUpdate.body.authorizationKind.isProved = Bool(false);
+    accountUpdate.body.authorizationKind.verificationKeyHash = Field(0);
     accountUpdate.authorization = {};
     accountUpdate.lazyAuthorization = { kind: 'lazy-none' };
   },

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -8,7 +8,11 @@ import { memoizationContext, memoizeWitness, Provable } from './provable.js';
 import { Field, Bool } from './core.js';
 import { Ledger, Pickles, Test } from '../snarky.js';
 import { jsLayout } from '../bindings/mina-transaction/gen/js-layout.js';
-import { Types, toJSONEssential } from '../bindings/mina-transaction/types.js';
+import {
+  Types,
+  TypesBigint,
+  toJSONEssential,
+} from '../bindings/mina-transaction/types.js';
 import { PrivateKey, PublicKey } from './signature.js';
 import { UInt64, UInt32, Int64, Sign } from './int.js';
 import * as Mina from './mina.js';
@@ -26,10 +30,10 @@ import { prefixes } from '../bindings/crypto/constants.js';
 import { Context } from './global-context.js';
 import { assert } from './errors.js';
 import { Ml } from './ml/conversion.js';
-import { FieldConst } from './field.js';
 import { MlArray } from './ml/base.js';
 import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
 import { MlFieldConstArray } from './ml/fields.js';
+import { transactionCommitments } from '../mina-signer/src/sign-zkapp-command.js';
 
 // external API
 export { AccountUpdate, Permissions, ZkappPublicInput };
@@ -1874,11 +1878,9 @@ function addMissingSignatures(
   additionalKeys = [] as PrivateKey[]
 ): ZkappCommandSigned {
   let additionalPublicKeys = additionalKeys.map((sk) => sk.toPublicKey());
-  let commitments = Ledger.transactionCommitments(
-    JSON.stringify(ZkappCommand.toJSON(zkappCommand))
+  let { commitment, fullCommitment } = transactionCommitments(
+    TypesBigint.ZkappCommand.fromJSON(ZkappCommand.toJSON(zkappCommand))
   );
-  let commitment = FieldConst.toBigint(commitments.commitment);
-  let fullCommitment = FieldConst.toBigint(commitments.fullCommitment);
 
   function addFeePayerSignature(accountUpdate: FeePayerUnsigned): FeePayer {
     let { body, authorization, lazyAuthorization } =

--- a/src/lib/precondition.test.ts
+++ b/src/lib/precondition.test.ts
@@ -10,6 +10,7 @@ import {
   method,
   PublicKey,
   Bool,
+  Field,
 } from 'snarkyjs';
 
 class MyContract extends SmartContract {
@@ -185,8 +186,9 @@ describe('preconditions', () => {
   });
 
   it('unsatisfied assertEquals should be rejected (public key)', async () => {
+    let publicKey = PublicKey.from({ x: Field(-1), isOdd: Bool(false) });
     let tx = await Mina.transaction(feePayer, () => {
-      zkapp.account.delegate.assertEquals(PublicKey.empty());
+      zkapp.account.delegate.assertEquals(publicKey);
       AccountUpdate.attachToTransaction(zkapp.self);
     });
     await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(/unsatisfied/);

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -97,12 +97,11 @@ function verifyAccountUpdateSignature(
 ) {
   if (update.authorization.signature === undefined) return false;
 
-  let publicKey = update.body.publicKey;
-  let { useFullCommitment } = update.body;
+  let { publicKey, useFullCommitment } = update.body;
   let { commitment, fullCommitment } = transactionCommitments;
   let usedCommitment = useFullCommitment === 1n ? fullCommitment : commitment;
-
   let signature = Signature.fromBase58(update.authorization.signature);
+
   return verifyFieldElement(signature, usedCommitment, publicKey, networkId);
 }
 

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -142,6 +142,7 @@ function accountUpdatesToCallForest(updates: AccountUpdate[], callDepth = 0) {
 }
 
 function accountUpdateHash(update: AccountUpdate) {
+  assertAuthorizationKindValid(update);
   let input = AccountUpdate.toInput(update);
   let fields = packToFields(input);
   return hashWithPrefix(prefixes.body, fields);
@@ -210,4 +211,17 @@ function isCallDepthValid(zkappCommand: ZkappCommand) {
     current = callDepth;
   }
   return true;
+}
+
+function assertAuthorizationKindValid(accountUpdate: AccountUpdate) {
+  let { isSigned, isProved, verificationKeyHash } =
+    accountUpdate.body.authorizationKind;
+  if (isProved && isSigned)
+    throw Error(
+      'Invalid authorization kind: Only one of `isProved` and `isSigned` may be true.'
+    );
+  if (!isProved && verificationKeyHash !== 0n)
+    throw Error(
+      `Invalid authorization kind: If \`isProved\` is false, verification key hash must be 0, got ${verificationKeyHash}`
+    );
 }

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -23,6 +23,8 @@ export { signZkappCommand, verifyZkappCommandSignature };
 
 // internal API
 export {
+  transactionCommitments,
+  verifyAccountUpdateSignature,
   accountUpdatesToCallForest,
   callForestHash,
   accountUpdateHash,
@@ -86,6 +88,22 @@ function verifyZkappCommandSignature(
     if (!ok) return false;
   }
   return ok;
+}
+
+function verifyAccountUpdateSignature(
+  update: AccountUpdate,
+  transactionCommitments: { commitment: bigint; fullCommitment: bigint },
+  networkId: NetworkId
+) {
+  if (update.authorization.signature === undefined) return false;
+
+  let publicKey = update.body.publicKey;
+  let { useFullCommitment } = update.body;
+  let { commitment, fullCommitment } = transactionCommitments;
+  let usedCommitment = useFullCommitment === 1n ? fullCommitment : commitment;
+
+  let signature = Signature.fromBase58(update.authorization.signature);
+  return verifyFieldElement(signature, usedCommitment, publicKey, networkId);
 }
 
 function transactionCommitments(zkappCommand: ZkappCommand) {

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -129,7 +129,7 @@ test(RandomTransaction.zkappCommand, (zkappCommand, assert) => {
 
   assert(isCallDepthValid(zkappCommand));
   let zkappCommandJson = ZkappCommand.toJSON(zkappCommand);
-  let ocamlCommitments = Ledger.transactionCommitments(
+  let ocamlCommitments = Test.hashFromJson.transactionCommitments(
     JSON.stringify(zkappCommandJson)
   );
   let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
@@ -171,7 +171,7 @@ test(
     expect(recoveredZkappCommand).toEqual(zkappCommand);
 
     // tx commitment
-    let ocamlCommitments = Ledger.transactionCommitments(
+    let ocamlCommitments = Test.hashFromJson.transactionCommitments(
       JSON.stringify(zkappCommandJson)
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -320,15 +320,6 @@ declare class Ledger {
     tokenId: FieldConst
   ): JsonAccount | undefined;
 
-  /**
-   * Returns the commitment of a JSON transaction.
-   */
-  static transactionCommitments(txJson: string): {
-    commitment: FieldConst;
-    fullCommitment: FieldConst;
-    feePayerHash: FieldConst;
-  };
-
   static customTokenId(publicKey: MlPublicKey, tokenId: FieldConst): FieldConst;
   static customTokenIdChecked(
     publicKey: MlPublicKeyVar,
@@ -377,6 +368,14 @@ declare const Test: {
   };
   hashFromJson: {
     accountUpdate(json: string): FieldConst;
+    /**
+     * Returns the commitment of a JSON transaction.
+     */
+    transactionCommitments(txJson: string): {
+      commitment: FieldConst;
+      fullCommitment: FieldConst;
+      feePayerHash: FieldConst;
+    };
     /**
      * Returns the public input of a zkApp transaction.
      */

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -338,11 +338,6 @@ declare class Ledger {
     publicKey: MlPublicKey,
     tokenId: FieldConst
   ): string;
-
-  static checkAccountUpdateSignature(
-    updateJson: string,
-    commitment: FieldConst
-  ): boolean;
 }
 
 declare const Test: {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -325,10 +325,6 @@ declare class Ledger {
     publicKey: MlPublicKeyVar,
     tokenId: FieldVar
   ): FieldVar;
-  static createTokenAccount(
-    publicKey: MlPublicKey,
-    tokenId: FieldConst
-  ): string;
 }
 
 declare const Test: {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -319,12 +319,6 @@ declare class Ledger {
     publicKey: MlPublicKey,
     tokenId: FieldConst
   ): JsonAccount | undefined;
-
-  static customTokenId(publicKey: MlPublicKey, tokenId: FieldConst): FieldConst;
-  static customTokenIdChecked(
-    publicKey: MlPublicKeyVar,
-    tokenId: FieldVar
-  ): FieldVar;
 }
 
 declare const Test: {
@@ -342,6 +336,12 @@ declare const Test: {
     tokenIdOfBase58(fieldBase58: string): FieldConst;
     memoToBase58(memoString: string): string;
     memoHashBase58(memoBase58: string): FieldConst;
+  };
+
+  tokenId: {
+    // derive custom token ids
+    derive(publicKey: MlPublicKey, tokenId: FieldConst): FieldConst;
+    deriveChecked(publicKey: MlPublicKeyVar, tokenId: FieldVar): FieldVar;
   };
 
   signature: {


### PR DESCRIPTION
bindings: https://github.com/o1-labs/snarkyjs-bindings/pull/39

Follow-up to https://github.com/o1-labs/snarkyjs/pull/956, https://github.com/o1-labs/snarkyjs/pull/974

This further cleans up the OCaml interface by removing all remaining static helper methods away from the `Ledger` class.

* deriving custom token ids is now implemented in TS; OCaml impl is moved to `Test`, and a new test for consistency is added
* verifying account update signature is moved to TS. the code is a subset of the existing mina-signer implementation of verifying zkapp command signatures. OCaml impl is removed (the consistency of these signatures is checked in great detail in existing tests)
* for `transactionCommitments()`, we use the existing mina-signer impl and move the OCaml one to `Test` (consistency covered by existing tests)