### PR TITLE
Simple manual proof system benchmark

### DIFF
--- a/run-in-browser.js
+++ b/run-in-browser.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import http from 'node:http';
+import minimist from 'minimist';
+import { build } from './src/build/buildExample.js';
+
+let {
+  _: [filePath],
+} = minimist(process.argv.slice(2));
+
+if (!filePath) {
+  console.log(`Usage:
+./run-in-browser [file]`);
+  process.exit(0);
+}
+
+// copy file into /dist/web
+let targetDir = `./dist/web`;
+
+let absPath = await build(filePath, true);
+let fileName = path.basename(absPath);
+
+let newPath = `${targetDir}/${fileName}`;
+await fs.copyFile(absPath, newPath);
+await fs.unlink(absPath);
+console.log(`running in the browser: ${newPath}`);
+
+const indexHtml = `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="data:," />
+    <title>snarkyjs</title>
+    <script type="module" src="./${fileName}">
+    </script>
+  </head>
+  <body>
+    <div>Check out the console (F12)</div>
+  </body>
+</html>
+
+`;
+
+const port = 8000;
+const defaultHeaders = {
+  'content-type': 'text/html',
+  'Cross-Origin-Embedder-Policy': 'require-corp',
+  'Cross-Origin-Opener-Policy': 'same-origin',
+};
+
+const server = http.createServer(async (req, res) => {
+  let file = '.' + req.url;
+  if (file === './') file = './index.html';
+  console.log('serving', file);
+
+  let content;
+  if (file === './index.html') content = indexHtml;
+  else {
+    try {
+      content = await fs.readFile(path.resolve('./dist/web', file), 'utf8');
+    } catch (err) {
+      res.writeHead(404, defaultHeaders);
+      res.write('<html><body>404</body><html>');
+      res.end();
+      return;
+    }
+  }
+
+  const extension = path.basename(file).split('.').pop();
+  const contentType = {
+    html: 'text/html',
+    js: 'application/javascript',
+    map: 'application/json',
+  }[extension];
+  const headers = { ...defaultHeaders, 'content-type': contentType };
+
+  res.writeHead(200, headers);
+  res.write(content);
+  res.end();
+});
+
+server.listen(port, () => {
+  console.log(`Server is running on: http://localhost:${port}`);
+});
+
+server.on('close', () => {});

--- a/run-in-browser.js
+++ b/run-in-browser.js
@@ -53,7 +53,7 @@ const defaultHeaders = {
 const server = http.createServer(async (req, res) => {
   let file = '.' + req.url;
   if (file === './') file = './index.html';
-  console.log('serving', file);
+  // console.log('serving', file);
 
   let content;
   if (file === './index.html') content = indexHtml;
@@ -84,5 +84,3 @@ const server = http.createServer(async (req, res) => {
 server.listen(port, () => {
   console.log(`Server is running on: http://localhost:${port}`);
 });
-
-server.on('close', () => {});

--- a/src/build/buildExample.js
+++ b/src/build/buildExample.js
@@ -16,7 +16,7 @@ async function buildAndImport(srcPath, { keepFile = false }) {
   return importedModule;
 }
 
-async function build(srcPath) {
+async function build(srcPath, isWeb = false) {
   let tsConfig = findTsConfig() ?? defaultTsConfig;
 
   let outfile = srcPath.replace('.ts', '.tmp.js');
@@ -30,7 +30,9 @@ async function build(srcPath) {
     target: 'esnext',
     resolveExtensions: ['.node.js', '.ts', '.js'],
     logLevel: 'error',
-    plugins: [typescriptPlugin(tsConfig), makeNodeModulesExternal()],
+    plugins: isWeb
+      ? [typescriptPlugin(tsConfig)]
+      : [typescriptPlugin(tsConfig), makeNodeModulesExternal()],
   });
 
   let absPath = path.resolve('.', outfile);

--- a/src/build/buildExample.js
+++ b/src/build/buildExample.js
@@ -25,7 +25,7 @@ async function build(srcPath, isWeb = false) {
     entryPoints: [srcPath],
     bundle: true,
     format: 'esm',
-    platform: 'node',
+    platform: isWeb ? 'node' : 'browser',
     outfile,
     target: 'esnext',
     resolveExtensions: ['.node.js', '.ts', '.js'],

--- a/src/examples/benchmarks/mul-web.ts
+++ b/src/examples/benchmarks/mul-web.ts
@@ -5,9 +5,9 @@ import { Circuit, Field, Provable, circuitMain, Experimental } from 'snarkyjs';
 let { ZkProgram } = Experimental;
 
 // parameters
-// let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
-let nMuls = 1 << 5;
-let withPickles = false;
+let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
+// let nMuls = 1 << 5;
+let withPickles = true;
 
 // the circuit: multiply a number with itself n times
 let xConst = Field.random();

--- a/src/examples/benchmarks/mul.ts
+++ b/src/examples/benchmarks/mul.ts
@@ -1,0 +1,90 @@
+/**
+ * benchmark a circuit filled with generic gates
+ */
+import { Circuit, Field, Provable, circuitMain, Experimental } from 'snarkyjs';
+import { tic, toc } from '../zkapps/tictoc.js';
+let { ZkProgram } = Experimental;
+
+// parameters
+let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
+let withPickles = true;
+
+// the circuit: multiply a number with itself n times
+let xConst = Field.random();
+
+function main(nMuls: number) {
+  let x = Provable.witness(Field, () => xConst);
+  let z = x;
+  for (let i = 0; i < nMuls; i++) {
+    z = z.mul(x);
+  }
+}
+
+function getRows(nMuls: number) {
+  let { rows } = Provable.constraintSystem(() => main(nMuls));
+  return rows;
+}
+
+function simpleKimchiCircuit(nMuls: number) {
+  class MulChain extends Circuit {
+    @circuitMain
+    static run() {
+      main(nMuls);
+    }
+  }
+  return MulChain;
+}
+
+function picklesCircuit(nMuls: number) {
+  return ZkProgram({
+    methods: {
+      run: {
+        privateInputs: [],
+        method() {
+          main(nMuls);
+        },
+      },
+    },
+  });
+}
+
+console.log('circuit size (without pickles overhead)', getRows(nMuls));
+
+if (withPickles) {
+  let circuit = picklesCircuit(nMuls);
+  tic('compile 1 (includes srs creation)');
+  await circuit.compile();
+  toc();
+
+  tic('compile 2');
+  await circuit.compile();
+  toc();
+
+  tic('prove');
+  let p = await circuit.run();
+  toc();
+
+  tic('verify');
+  let ok = await circuit.verify(p);
+  toc();
+  if (!ok) throw Error('invalid proof');
+} else {
+  let circuit = simpleKimchiCircuit(nMuls);
+
+  tic('compile 1 (includes srs creation)');
+  let kp = await circuit.generateKeypair();
+  toc();
+
+  tic('compile 2');
+  kp = await circuit.generateKeypair();
+  toc();
+
+  tic('prove');
+  let p = await circuit.prove([], [], kp);
+  toc();
+
+  tic('verify');
+  let ok = await circuit.verify([], kp.verificationKey(), p);
+  toc();
+  if (!ok) throw Error('invalid proof');
+}

--- a/src/examples/benchmarks/mul.web.ts
+++ b/src/examples/benchmarks/mul.web.ts
@@ -1,0 +1,107 @@
+/**
+ * benchmark a circuit filled with generic gates
+ */
+import { Circuit, Field, Provable, circuitMain, Experimental } from 'snarkyjs';
+let { ZkProgram } = Experimental;
+
+// parameters
+// let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
+let nMuls = 1 << 5;
+let withPickles = false;
+
+// the circuit: multiply a number with itself n times
+let xConst = Field.random();
+
+function main(nMuls: number) {
+  let x = Provable.witness(Field, () => xConst);
+  let z = x;
+  for (let i = 0; i < nMuls; i++) {
+    z = z.mul(x);
+  }
+}
+
+function getRows(nMuls: number) {
+  let { rows } = Provable.constraintSystem(() => main(nMuls));
+  return rows;
+}
+
+function simpleKimchiCircuit(nMuls: number) {
+  class MulChain extends Circuit {
+    @circuitMain
+    static run() {
+      main(nMuls);
+    }
+  }
+  // circuitMain(MulChain, 'run');
+  return MulChain;
+}
+
+function picklesCircuit(nMuls: number) {
+  return ZkProgram({
+    methods: {
+      run: {
+        privateInputs: [],
+        method() {
+          main(nMuls);
+        },
+      },
+    },
+  });
+}
+
+// timing helpers
+let timingStack: [string, number][] = [];
+let i = 0;
+function tic(label = `Run command ${i++}`) {
+  console.log(`${label}... `);
+  timingStack.push([label, Date.now()]);
+}
+function toc() {
+  let [label, start] = timingStack.pop()!;
+  let time = (Date.now() - start) / 1000;
+  console.log(`\r${label}... ${time.toFixed(3)} sec\n`);
+  return time;
+}
+
+// the script
+
+console.log('circuit size (without pickles overhead)', getRows(nMuls));
+
+if (withPickles) {
+  let circuit = picklesCircuit(nMuls);
+  tic('compile 1 (includes srs creation)');
+  await circuit.compile();
+  toc();
+
+  tic('compile 2');
+  await circuit.compile();
+  toc();
+
+  tic('prove');
+  let p = await circuit.run();
+  toc();
+
+  tic('verify');
+  let ok = await circuit.verify(p);
+  toc();
+  if (!ok) throw Error('invalid proof');
+} else {
+  let circuit = simpleKimchiCircuit(nMuls);
+
+  tic('compile 1 (includes srs creation)');
+  let kp = await circuit.generateKeypair();
+  toc();
+
+  tic('compile 2');
+  kp = await circuit.generateKeypair();
+  toc();
+
+  tic('prove');
+  let p = await circuit.prove([], [], kp);
+  toc();
+
+  tic('verify');
+  let ok = await circuit.verify([], kp.verificationKey(), p);
+  toc();
+  if (!ok) throw Error('invalid proof');
+}


### PR DESCRIPTION
this adds a small benchmark script with the following results:

without pickles:
```
circuit size (without pickles overhead) 49152
compile 1 (includes srs creation)... 54.515 sec
compile 2... 10.954 sec
prove... 28.018 sec
verify... 0.660 sec
```

with pickles:
```
circuit size (without pickles overhead) 49152
compile 1 (includes srs creation)... 68.329 sec
compile 2... 19.319 sec
prove... 41.963 sec
verify... 1.074 sec
```

run the script with:
```bash
./run scr/examples/benchmarks/mul.ts --bundle
```

EDIT: this now also adds a way to serve a TS script for running in the browser. added a version of the benchmark that doesn't use nodejs builtins to be able to use it:

```
./run-in-browser.js src/examples/benchmarks/mul-web.ts
```

this can be helpful to inspect the benchmark in chrome devtools: