### PR TITLE
Improve error when reading variable in provable code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `Group` operations now generate a different set of constraints. This breaks deployed contracts, because the circuit changed. https://github.com/o1-labs/snarkyjs/pull/967
 
+### Changed
+
+- Improve error message `Can't evaluate prover code outside an as_prover block` https://github.com/o1-labs/snarkyjs/pull/998
+
 ## [0.11.0](https://github.com/o1-labs/snarkyjs/compare/a632313a...3fbd9678e)
 
 ### Breaking changes

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -3,11 +3,10 @@ import {
   FlexibleProvable,
   provable,
   provablePure,
-  Struct,
 } from './circuit_value.js';
 import { memoizationContext, memoizeWitness, Provable } from './provable.js';
 import { Field, Bool } from './core.js';
-import { Ledger, Pickles, Test } from '../snarky.js';
+import { Pickles, Test } from '../snarky.js';
 import { jsLayout } from '../bindings/mina-transaction/gen/js-layout.js';
 import {
   Types,
@@ -30,7 +29,6 @@ import { hashWithPrefix, packToFields } from './hash.js';
 import { prefixes } from '../bindings/crypto/constants.js';
 import { Context } from './global-context.js';
 import { assert } from './errors.js';
-import { Ml } from './ml/conversion.js';
 import { MlArray } from './ml/base.js';
 import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
 import { MlFieldConstArray } from './ml/fields.js';

--- a/src/lib/account_update.unit-test.ts
+++ b/src/lib/account_update.unit-test.ts
@@ -1,5 +1,4 @@
 import {
-  Ledger,
   AccountUpdate,
   PrivateKey,
   Field,

--- a/src/lib/bool.ts
+++ b/src/lib/bool.ts
@@ -1,5 +1,11 @@
 import { Snarky } from '../snarky.js';
-import { Field, FieldConst, FieldType, FieldVar } from './field.js';
+import {
+  Field,
+  FieldConst,
+  FieldType,
+  FieldVar,
+  readVarMessage,
+} from './field.js';
 import { Bool as B } from '../provable/field-bigint.js';
 import { defineBinable } from '../bindings/lib/binable.js';
 import { NonNegativeInteger } from 'src/bindings/crypto/non-negative.js';
@@ -179,8 +185,10 @@ class Bool {
     let value: FieldConst;
     if (this.isConstant()) {
       value = this.value[1];
-    } else {
+    } else if (Snarky.run.inProverBlock()) {
       value = Snarky.field.readVar(this.value);
+    } else {
+      throw Error(readVarMessage('toBoolean', 'b', 'Bool'));
     }
     return FieldConst.equal(value, FieldConst[1]);
   }
@@ -368,7 +376,7 @@ function toBoolean(x: boolean | Bool): boolean {
   if (typeof x === 'boolean') {
     return x;
   }
-  return (x as Bool).toBoolean();
+  return x.toBoolean();
 }
 
 // TODO: This is duplicated

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { ProvablePure } from '../snarky.js';
-import { Field, Bool } from './core.js';
+import { Field, Bool, Scalar, Group } from './core.js';
 import {
   provable,
   provablePure,
@@ -451,21 +451,26 @@ function Struct<
   return Struct_ as any;
 }
 
-let primitives = new Set(['Field', 'Bool', 'Scalar', 'Group']);
+let primitives = new Set([Field, Bool, Scalar, Group]);
+function isPrimitive(obj: any) {
+  for (let P of primitives) {
+    if (obj instanceof P) return true;
+  }
+}
 
-// FIXME: the logic in here to check for obj.constructor.name actually doesn't work
-// something that works is Field(1).constructor === obj.constructor etc
 function cloneCircuitValue<T>(obj: T): T {
   // primitive JS types and functions aren't cloned
   if (typeof obj !== 'object' || obj === null) return obj;
 
   // HACK: callbacks, account udpates
   if (
-    ['GenericArgument', 'Callback'].includes((obj as any).constructor?.name)
+    obj.constructor?.name.includes('GenericArgument') ||
+    obj.constructor?.name.includes('Callback')
   ) {
     return obj;
   }
-  if (['AccountUpdate'].includes((obj as any).constructor?.name)) {
+  if (obj.constructor?.name.includes('AccountUpdate')) {
+    console.log('cloning', obj.constructor.name);
     return (obj as any).constructor.clone(obj);
   }
 
@@ -480,7 +485,9 @@ function cloneCircuitValue<T>(obj: T): T {
   if (ArrayBuffer.isView(obj)) return new (obj.constructor as any)(obj);
 
   // snarkyjs primitives aren't cloned
-  if (primitives.has((obj as any).constructor.name)) return obj;
+  if (isPrimitive(obj)) {
+    return obj;
+  }
 
   // cloning strategy that works for plain objects AND classes whose constructor only assigns properties
   let propertyDescriptors: Record<string, PropertyDescriptor> = {};

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -470,7 +470,6 @@ function cloneCircuitValue<T>(obj: T): T {
     return obj;
   }
   if (obj.constructor?.name.includes('AccountUpdate')) {
-    console.log('cloning', obj.constructor.name);
     return (obj as any).constructor.clone(obj);
   }
 

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -456,6 +456,7 @@ function isPrimitive(obj: any) {
   for (let P of primitives) {
     if (obj instanceof P) return true;
   }
+  return false;
 }
 
 function cloneCircuitValue<T>(obj: T): T {

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -1183,7 +1183,7 @@ class Field {
    *
    */
   static toBytes(x: Field) {
-    return [...x.#toConstant('toBytes').value[1]];
+    return FieldBinable.toBytes(x);
   }
 
   /**
@@ -1226,17 +1226,12 @@ class Field {
 
 const FieldBinable = defineBinable({
   toBytes(t: Field) {
-    return Field.toBytes(t);
+    return [...toConstantField(t, 'toBytes').value[1]];
   },
   readBytes(bytes, offset) {
     let uint8array = new Uint8Array(32);
     uint8array.set(bytes.slice(offset, offset + 32));
-    return [
-      Object.assign(Object.create(new Field(1).constructor.prototype), {
-        value: [0, uint8array],
-      }) as Field,
-      offset + 32,
-    ];
+    return [new Field(uint8array), offset + 32];
   },
 });
 
@@ -1271,8 +1266,8 @@ function withMessage(error: unknown, message?: string) {
 function toConstantField(
   x: Field,
   methodName: string,
-  varName: string,
-  varDescription: string
+  varName = 'x',
+  varDescription = 'field element'
 ): ConstantField {
   // if this is a constant, return it
   if (x.isConstant()) return x;

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -1300,7 +1300,7 @@ which only carries actual values during proving, but not during compiling.
 Also, reading out JS values means that whatever you're doing with those values will no longer be
 linked to the original variable in the proof, which makes this pattern prone to security holes.
 
-You can check whether your ${varDescription} is a variable or a constant using ${varName}.isConstant().
+You can check whether your ${varDescription} is a variable or a constant by using ${varName}.isConstant().
 
 To inspect values for debugging, use Provable.log(${varName}). For more advanced use cases,
 there is \`Provable.asProver(() => { ... })\` which allows you to use ${varName}.${methodName}() inside the callback.

--- a/src/lib/hash-input.unit-test.ts
+++ b/src/lib/hash-input.unit-test.ts
@@ -107,11 +107,13 @@ function testInput<T, TJson>(
   // console.log('json', json);
   let input1 = MlHashInput.from(toInputOcaml(JSON.stringify(json)));
   let input2 = Module.toInput(value);
-  // console.log('snarkyjs', JSON.stringify(input2));
+  let input1Json = JSON.stringify(input1);
+  let input2Json = JSON.stringify(input2);
+  // console.log('snarkyjs', input2Json);
   // console.log();
-  // console.log('protocol', JSON.stringify(input1));
-  let ok1 = JSON.stringify(input2) === JSON.stringify(input1);
-  expect(JSON.stringify(input2)).toEqual(JSON.stringify(input1));
+  // console.log('protocol', input1Json);
+  let ok1 = input1Json === input2Json;
+  expect(input2Json).toEqual(input1Json);
   // console.log('ok?', ok1);
   let fields1 = MlFieldConstArray.from(
     hashInputFromJson.packInput(MlHashInput.to(input1))

--- a/src/lib/provable-context.ts
+++ b/src/lib/provable-context.ts
@@ -58,7 +58,7 @@ function inCompileMode() {
 
 function asProver(f: () => void) {
   if (inCheckedComputation()) {
-    Snarky.asProver(f);
+    Snarky.run.asProver(f);
   } else {
     f();
   }
@@ -67,7 +67,7 @@ function asProver(f: () => void) {
 function runAndCheck(f: () => void) {
   let id = snarkContext.enter({ inCheckedComputation: true });
   try {
-    Snarky.runAndCheck(f);
+    Snarky.run.runAndCheck(f);
   } catch (error) {
     throw prettifyStacktrace(error);
   } finally {
@@ -78,7 +78,7 @@ function runAndCheck(f: () => void) {
 function runUnchecked(f: () => void) {
   let id = snarkContext.enter({ inCheckedComputation: true });
   try {
-    Snarky.runUnchecked(f);
+    Snarky.run.runUnchecked(f);
   } catch (error) {
     throw prettifyStacktrace(error);
   } finally {
@@ -90,7 +90,7 @@ function constraintSystem<T>(f: () => T) {
   let id = snarkContext.enter({ inAnalyze: true, inCheckedComputation: true });
   try {
     let result: T;
-    let { rows, digest, json } = Snarky.constraintSystem(() => {
+    let { rows, digest, json } = Snarky.run.constraintSystem(() => {
       result = f();
     });
     let { gates, publicInputSize } = gatesFromJson(json);

--- a/src/lib/scalar.ts
+++ b/src/lib/scalar.ts
@@ -6,6 +6,9 @@ import { Bool } from './bool.js';
 
 export { Scalar, ScalarConst, unshift, shift };
 
+// internal API
+export { constantScalarToBigint };
+
 type BoolVar = FieldVar;
 type ScalarConst = Uint8Array;
 
@@ -106,18 +109,8 @@ class Scalar {
 
   // operations on constant scalars
 
-  // TODO: this is a static method so that it works on ml scalars as well
-  static #assertConstantStatic(x: Scalar, name: string): Fq {
-    if (x.constantValue === undefined)
-      throw Error(
-        `Scalar.${name}() is not available in provable code.
-That means it can't be called in a @method or similar environment, and there's no alternative implemented to achieve that.`
-      );
-    return ScalarConst.toBigint(x.constantValue);
-  }
-
   #assertConstant(name: string) {
-    return Scalar.#assertConstantStatic(this, name);
+    return constantScalarToBigint(this, `Scalar.${name}`);
   }
 
   /**
@@ -138,7 +131,7 @@ That means it can't be called in a @method or similar environment, and there's n
    */
   add(y: Scalar) {
     let x = this.#assertConstant('add');
-    let y0 = Scalar.#assertConstantStatic(y, 'add');
+    let y0 = y.#assertConstant('add');
     let z = Fq.add(x, y0);
     return Scalar.from(z);
   }
@@ -150,7 +143,7 @@ That means it can't be called in a @method or similar environment, and there's n
    */
   sub(y: Scalar) {
     let x = this.#assertConstant('sub');
-    let y0 = Scalar.#assertConstantStatic(y, 'sub');
+    let y0 = y.#assertConstant('sub');
     let z = Fq.sub(x, y0);
     return Scalar.from(z);
   }
@@ -162,7 +155,7 @@ That means it can't be called in a @method or similar environment, and there's n
    */
   mul(y: Scalar) {
     let x = this.#assertConstant('mul');
-    let y0 = Scalar.#assertConstantStatic(y, 'mul');
+    let y0 = y.#assertConstant('mul');
     let z = Fq.mul(x, y0);
     return Scalar.from(z);
   }
@@ -175,7 +168,7 @@ That means it can't be called in a @method or similar environment, and there's n
    */
   div(y: Scalar) {
     let x = this.#assertConstant('div');
-    let y0 = Scalar.#assertConstantStatic(y, 'div');
+    let y0 = y.#assertConstant('div');
     let z = Fq.div(x, y0);
     if (z === undefined) throw Error('Scalar.div(): Division by zero');
     return Scalar.from(z);
@@ -296,7 +289,7 @@ That means it can't be called in a @method or similar environment, and there's n
    * This operation does _not_ affect the circuit and can't be used to prove anything about the string representation of the Scalar.
    */
   static toJSON(x: Scalar) {
-    let s = Scalar.#assertConstantStatic(x, 'toJSON');
+    let s = x.#assertConstant('toJSON');
     return s.toString();
   }
 
@@ -359,4 +352,13 @@ function constToBigint(x: ScalarConst): Fq {
 }
 function constFromBigint(x: Fq) {
   return Uint8Array.from(Fq.toBytes(x));
+}
+
+function constantScalarToBigint(s: Scalar, name: string) {
+  if (s.constantValue === undefined)
+    throw Error(
+      `${name}() is not available in provable code.
+That means it can't be called in a @method or similar environment, and there's no alternative implemented to achieve that.`
+    );
+  return ScalarConst.toBigint(s.constantValue);
 }

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -12,6 +12,8 @@ import {
   PublicKey as PublicKeyBigint,
 } from '../provable/curve-bigint.js';
 import { prefixes } from '../bindings/crypto/constants.js';
+import { constantScalarToBigint } from './scalar.js';
+import { toConstantField } from './field.js';
 
 // external API
 export { PrivateKey, PublicKey, Signature };
@@ -54,7 +56,7 @@ class PrivateKey extends CircuitValue {
    * Convert this {@link PrivateKey} to a bigint
    */
   toBigInt() {
-    return this.s.toBigInt();
+    return constantScalarToBigint(this.s, 'PrivateKey.toBigInt');
   }
 
   /**
@@ -100,7 +102,9 @@ class PrivateKey extends CircuitValue {
    * @returns a base58 encoded string
    */
   static toBase58(privateKey: { s: Scalar }) {
-    return PrivateKeyBigint.toBase58(privateKey.s.toBigInt());
+    return PrivateKeyBigint.toBase58(
+      constantScalarToBigint(privateKey.s, 'PrivateKey.toBase58')
+    );
   }
 }
 
@@ -196,6 +200,7 @@ class PublicKey extends CircuitValue {
    * @returns a base58 encoded {@link PublicKey}
    */
   static toBase58({ x, isOdd }: PublicKey) {
+    x = toConstantField(x, 'toBase58', 'pk', 'public key');
     return PublicKeyBigint.toBase58({
       x: x.toBigInt(),
       isOdd: BoolBigint(isOdd.toBoolean()),

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1,4 +1,3 @@
-import { Types } from '../bindings/mina-transaction/types.js';
 import { Gate, Pickles, ProvablePure } from '../snarky.js';
 import { Field, Bool } from './core.js';
 import {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -163,25 +163,35 @@ declare const Snarky: {
    * witness a single field element variable
    */
   existsVar(compute: () => FieldConst): FieldVar;
+
   /**
-   * Runs code as a prover.
+   * APIs that have to do with running provable code
    */
-  asProver(f: () => void): void;
-  /**
-   * Runs code and checks its correctness.
-   */
-  runAndCheck(f: () => void): void;
-  /**
-   * Runs code in prover mode, without checking correctness.
-   */
-  runUnchecked(f: () => void): void;
-  /**
-   * Returns information about the constraint system in the callback function.
-   */
-  constraintSystem(f: () => void): {
-    rows: number;
-    digest: string;
-    json: JsonConstraintSystem;
+  run: {
+    /**
+     * Runs code as a prover.
+     */
+    asProver(f: () => void): void;
+    /**
+     * Check whether we are inside an asProver or exists block
+     */
+    inProverBlock(): boolean;
+    /**
+     * Runs code and checks its correctness.
+     */
+    runAndCheck(f: () => void): void;
+    /**
+     * Runs code in prover mode, without checking correctness.
+     */
+    runUnchecked(f: () => void): void;
+    /**
+     * Returns information about the constraint system in the callback function.
+     */
+    constraintSystem(f: () => void): {
+      rows: number;
+      digest: string;
+      json: JsonConstraintSystem;
+    };
   };
 
   /**


### PR DESCRIPTION
closes https://github.com/o1-labs/snarkyjs/issues/899
closes https://github.com/o1-labs/snarkyjs/issues/478
closes https://github.com/o1-labs/snarkyjs/issues/489

bindings: https://github.com/o1-labs/snarkyjs-bindings/pull/52

Consider this method which incorrectly tries to extract the JS value of a variable:
```ts
  @method update(y: Field): Field {
    console.log(y.toString());
    // ...
 }
```

We used to get an error that confused people again & again:
```
Error: Can't evaluate prover code outside an as_prover block
```

This frequently caused people to wrap their _entire_ logic in `Provable.asProver(...)` 😬 

With this PR, the error now looks like:

![image](https://github.com/o1-labs/snarkyjs/assets/20989968/b14bd9c0-69e8-4529-8793-b7e40af5186e)

Equivalent error messages happen in methods such as `Bool.toBoolean()`, `Field.toBigInt()` and `PublicKey.toBase58()`. We took care to adapt the error message to refer to a method that a user likely called themselves - e.g., refer to `PublicKey.toBase58()` in the error message even though it causes the error by internally calling `Field.toBigInt()`.