### PR TITLE
fix: mina-signer repo url

### DIFF
--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -18,8 +18,8 @@
   "author": "o1labs",
   "license": "Apache-2.0",
   "homepage": "https://minaprotocol.com/",
-  "repository": "https://github.com/MinaProtocol/mina",
-  "bugs": "https://github.com/MinaProtocol/mina/issues",
+  "repository": "https://github.com/o1-labs/snarkyjs",
+  "bugs": "https://github.com/o1-labs/snarkyjs/issues",
   "main": "dist/node/mina-signer/MinaSigner.js",
   "types": "dist/node/mina-signer/index.d.ts",
   "exports": {


### PR DESCRIPTION
It was difficult to locate the src for this package, hopefully updating these will save others time in the future.