### PR TITLE
Fix: window not supported in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Improve error message `Can't evaluate prover code outside an as_prover block` https://github.com/o1-labs/snarkyjs/pull/998
 
+### Fixed
+
+- Fix unsupported use of `window` when running SnarkyJS in workers https://github.com/o1-labs/snarkyjs/pull/1002
+
 ## [0.11.0](https://github.com/o1-labs/snarkyjs/compare/a632313a...3fbd9678e)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `Group` operations now generate a different set of constraints. This breaks deployed contracts, because the circuit changed. https://github.com/o1-labs/snarkyjs/pull/967
 
+### Added
+
+- Implemented `Nullifier` as a new primitive https://github.com/o1-labs/snarkyjs/pull/882
+  - mina-signer can now be used to generate a Nullifier, which can be consumed by zkApps using the newly added Nullifier Struct
+
 ### Changed
 
 - Improve error message `Can't evaluate prover code outside an as_prover block` https://github.com/o1-labs/snarkyjs/pull/998
@@ -40,8 +45,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - More efficient than `field.equals(x).assertFalse()`
 - Add `scalar.toConstant()`, `scalar.toBigInt()`, `Scalar.from()`, `privateKey.toBigInt()`, `PrivateKey.fromBigInt()` https://github.com/o1-labs/snarkyjs/pull/935
 - `Poseidon.hashToGroup` enables hashing to a group https://github.com/o1-labs/snarkyjs/pull/887
-- Implemented `Nullifier` as a new primitive https://github.com/o1-labs/snarkyjs/pull/882
-  - mina-signer can now be used to generate a Nullifier, which can be consumed by zkApps using the newly added Nullifier Struct
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/3fbd9678e...HEAD)
+## [Unreleased](https://github.com/o1-labs/snarkyjs/compare/c549e02fa...HEAD)
+
+> No unreleased changes yet
+
+## [0.11.1](https://github.com/o1-labs/snarkyjs/compare/3fbd9678e...c549e02fa)
 
 ### Breaking changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snarkyjs",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "snarkyjs",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snarkyjs",
   "description": "TypeScript framework for zk-SNARKs and zkApps",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "Apache-2.0",
   "homepage": "https://github.com/o1-labs/snarkyjs/",
   "keywords": [


### PR DESCRIPTION
* fixes running SnarkyJS in web workers, which failed because of our use of `window`
* releases version 0.11.1 with the fix **and nullifiers**!

bindings: https://github.com/o1-labs/snarkyjs-bindings/pull/57