### PR TITLE
Post refactor clean up: Split OCaml libs

### DIFF
--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -55,8 +55,7 @@ const Poseidon = {
 
     let newState = Snarky.poseidon.update(
       MlFieldArray.to(state),
-      MlFieldArray.to(input),
-      true
+      MlFieldArray.to(input)
     );
     return MlFieldArray.from(newState) as [Field, Field, Field];
   },
@@ -73,7 +72,7 @@ const Poseidon = {
     }
 
     // y = sqrt(y^2)
-    let [, xv, yv] = Snarky.poseidon.hashToGroup(MlFieldArray.to(input), true);
+    let [, xv, yv] = Snarky.poseidon.hashToGroup(MlFieldArray.to(input));
 
     let x = Field(xv);
     let y = Field(yv);

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -342,18 +342,12 @@ declare const Snarky: {
   };
 
   poseidon: {
-    hash(input: MlArray<FieldVar>, isChecked: boolean): FieldVar;
-
     update(
       state: MlArray<FieldVar>,
-      input: MlArray<FieldVar>,
-      isChecked: boolean
+      input: MlArray<FieldVar>
     ): [0, FieldVar, FieldVar, FieldVar];
 
-    hashToGroup(
-      input: MlArray<FieldVar>,
-      isChecked: boolean
-    ): MlTuple<FieldVar, FieldVar>;
+    hashToGroup(input: MlArray<FieldVar>): MlTuple<FieldVar, FieldVar>;
 
     sponge: {
       create(isChecked: boolean): unknown;
@@ -439,6 +433,10 @@ declare const Test: {
     // derive custom token ids
     derive(publicKey: MlPublicKey, tokenId: FieldConst): FieldConst;
     deriveChecked(publicKey: MlPublicKeyVar, tokenId: FieldVar): FieldVar;
+  };
+
+  poseidon: {
+    hashToGroup(input: MlArray<FieldConst>): MlTuple<FieldConst, FieldConst>;
   };
 
   signature: {


### PR DESCRIPTION
Some in-between clean up:
- Split OCaml libs into different files
- Use TS poseidon implementations on constant inputs

The main work for this happens in the bindings PR: https://github.com/o1-labs/snarkyjs-bindings/pull/58