### PR TITLE
release mina-signer

### DIFF
--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",

--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",


### PR DESCRIPTION
this bumps the mina-signer version and release the newly added `createNullifier` method (which is now also released in SnarkyJS directly, but wasn't accessible because devs couldn't create the nullifier